### PR TITLE
in task.py write_taskinfo function, the parameter order is wrong, and…

### DIFF
--- a/qpandalite/task/quafu/task.py
+++ b/qpandalite/task/quafu/task.py
@@ -194,7 +194,8 @@ def query_by_taskid(taskid):
     elif res_dict["status"] in [3,4]:
         return 'Failed'
         
-    results = json.loads(res_dict['raw'])
+    # results = json.loads(res_dict['raw'])
+    results = res_dict
     return results
 
 def query_all_task(savepath = None): 
@@ -209,6 +210,8 @@ def query_all_task(savepath = None):
             if ret is None:
                 continue
             elif ret == 'Failed':
-                write_taskinfo(savepath, taskid, {})
+                # write_taskinfo(savepath, taskid, {})
+                write_taskinfo(taskid, taskinfo={}, savepath=savepath)
             else:                
-                write_taskinfo(savepath, taskid, ret)
+                # write_taskinfo(savepath, taskid, ret)
+                write_taskinfo(taskid, taskinfo=ret, savepath=savepath)

--- a/test/quafu/verify_real_chip_bitsequence_quafu/step2_view_results.py
+++ b/test/quafu/verify_real_chip_bitsequence_quafu/step2_view_results.py
@@ -33,15 +33,16 @@ if __name__ == '__main__':
             with open(savepath / f'{taskid}.txt') as fp:            
                 taskinfo = json.load(fp)
 
-            if taskinfo['status'] == 'failed':
+            # if taskinfo['status'] == 'failed':
+            if taskinfo['status'] in [3, 4]:
                 continue
             
-            result_list = taskinfo["result"]
+            result_list = taskinfo["res"]
 
-            for result in result_list:
-                keys = result['key']
-                values = result['value']
-                result_dict = {keys[i]:values[i] for i in range(len(keys))}                
-                print(f'Task Result: {result_dict}')
-
+            # for result in result_list:
+                # keys = result['key']
+                # values = result['value']
+                # result_dict = {keys[i]:values[i] for i in range(len(keys))}
+                # print(f'Task Result: {result_dict}')
+            print(f'Task Result: {result_list}')
             


### PR DESCRIPTION
在step2_view_results里，12行调用task/quafu/task.py的query_all_task函数，在其中调用write_taskinfo(savepath, taskid, ret)。在这里write_taskinfo的几个参数顺序似乎写反了，应该是write_taskinfo(taskid, taskinfo, savepath = None)才对。这样就会导致savepath变成测量结果的dict，从而导致
    with open(savepath / '{}.txt'.format(taskid), 'w') as fp:
TypeError: unsupported operand type(s) for /: 'dict' and 'str'错误。此外，在query_by_taskid时，应该返回完整结果，而非仅测量结果，因此，在step2_view_results里，也不需要重新将key和value组合成result dict，而可以直接使用result_dict = taskinfo["res"]