### PR TITLE
OpenQASM to OriginIR & analyze_circuit

### DIFF
--- a/QPandaLiteCpp/src/noisy_simulator.cpp
+++ b/QPandaLiteCpp/src/noisy_simulator.cpp
@@ -20,7 +20,7 @@ namespace qpandalite {
 	{
 		double r = rand();
 		if (r > p)
-			return
+			return;
 		else
 			x(qn);
 	}
@@ -29,7 +29,7 @@ namespace qpandalite {
 	{
 		double r = rand();
 		if (r > p)
-			return
+			return;
 		else
 			z(qn);
 	}

--- a/QPandaLiteCpp/src/rng.h
+++ b/QPandaLiteCpp/src/rng.h
@@ -16,7 +16,7 @@ namespace qpandalite
 
 		inline void seed(unsigned int seed_)
 		{
-			eng.seed(seed_)
+			eng.seed(seed_);
 		}
 
 		inline double rand()

--- a/qpandalite/circuit_builder/qcircuit.py
+++ b/qpandalite/circuit_builder/qcircuit.py
@@ -1,6 +1,22 @@
 '''
 Definition of quantum circuit (Circuit)
 
+Class Circuit is essentially the OriginIR generator and analysis tool suppported by origin_line_parser and origin_base_parser.
+Each function inside the class is the ingredients that help us to construct quantum circuits.
+Each line after parsing will be transferred to either our OriginIR_Simulator/ OriginIR_Parser/ OpenQASM2_Parser or actual quantum machines.\n
+
+With that being said, for each function that modifies the circuit added to the class, we need to consider,
+1. How does it looks like in the quantum circuit?
+2. How does the origin/qasm_parser need to change in order to deal with this new feature?
+
+Circuit 类本质上是由 origin_line_parser 和 origin_base_parser 支持的 OriginIR 生成器和分析工具。
+类内的每个函数都是帮助我们构建量子电路的成分。
+解析后的每一行都会被传输到我们的 OriginIR_Simulator/ OriginIR_Parser/ OpenQASM2_Parser 或实际的量子机器。
+
+有鉴于此，对于每个添加到类中并修改电路的函数，我们需要考虑：
+1. 它在量子电路中是什么样子的？
+2. 为了处理这个新特性，origin/qasm_parser 需要怎样的变化？
+
 Author: Agony5757
 '''
 
@@ -262,6 +278,11 @@ class Circuit:
         self.circuit_str += 'CZ q[{}], q[{}]\n'.format(q1, q2)
         self.record_qubit(q1, q2)
 
+    def barrier(self, *qubits) -> None:
+        placeholders = ', '.join(['q[{}]'] * len(qubits))
+        self.circuit_str += ('BARRIER ' + placeholders + '\n').format(*qubits)
+        self.record_qubit(*qubits)
+
     def measure(self, *qubits):
         self.record_qubit(*qubits)
         self.measure_list = list(qubits)
@@ -356,6 +377,7 @@ class Circuit:
         # (operation, qubits, cbit, parameter, dagger_flag, deepcopy(control_qubits_set)).
 
         self.circuit_info['qubits'] = parser.n_qubit
+        # Just in case we have more ancillary_operations
         ancillary_operation = ['MEASURE']
         
         for single_command in parser.program_body:
@@ -380,27 +402,6 @@ class Circuit:
         
         print(self.circuit_info)
         # return parser.to_extended_originir()
-
-# def transform_line(line, circuit):
-#     # Match the cx operation
-#     match_cx = re.match(r'cx q\[(\d+)\],q\[(\d+)\];', line)
-#     if match_cx:
-#         qubit1, qubit2 = map(int, match_cx.groups())
-#         circuit.cnot(qubit1, qubit2)
-    
-#     # Match other operations, for example, h gate
-#     match_h = re.match(r'h q\[(\d+)\];', line)
-#     if match_h:
-#         qubit = int(match_h.group(1))
-#         circuit.h(qubit)
-    
-#     # Handling measure operation
-#     match_measure = re.match(r'measure q\[(\d+)\] -> c\[\d+\];', line)
-#     if match_measure:
-#         qubit = int(match_measure.group(1))
-#         circuit.measure_list.append(qubit)
-        # return None 
-
 
 if __name__ == '__main__':
     import qpandalite

--- a/qpandalite/originir/originir_line_parser.py
+++ b/qpandalite/originir/originir_line_parser.py
@@ -36,7 +36,9 @@ class OriginIR_Parser:
                         comma + blank + 
                         cid + 
                         '$')
-        
+    regexp_barrier_str = (r'^BARRIER' +
+                          f'(({blank}{qid}{blank}{comma})*{blank}{qid}{blank})' + 
+                          '$')    
     regexp_control_str = (r'^(CONTROL|ENDCONTROL)' +
                           f'(({blank}{qid}{blank}{comma})*{blank}{qid}{blank})' + 
                           '$')
@@ -46,6 +48,7 @@ class OriginIR_Parser:
     regexp_1q1p = re.compile(regexp_1q1p_str)
     regexp_1q2p = re.compile(regexp_1q2p_str)
     regexp_meas = re.compile(regexp_measure_str)
+    regexp_barrier = re.compile(regexp_barrier_str)
     regexp_control = re.compile(regexp_control_str)
     regexp_qid = re.compile(qid)
 
@@ -93,8 +96,12 @@ class OriginIR_Parser:
     
     @staticmethod
     def handle_barrier(line):
-        matches = OriginIR_Parser.regexp_barrier.findall(line)
-        return matches
+        matches = OriginIR_Parser.regexp_barrier.match(line)
+        # Extract individual qubit patterns
+        qubits = OriginIR_Parser.regexp_qid.findall(line)
+        # Extract only the numeric part of each qubit pattern
+        qubit_indices = [int(q[0]) for q in qubits]
+        return "BARRIER", qubit_indices
     
     @staticmethod
     def handle_control(line):
@@ -176,6 +183,9 @@ class OriginIR_Parser:
                 operation, q, parameter = OriginIR_Parser.handle_1q1p(line)
             elif line.startswith('RPhi'):
                 operation, q, parameter = OriginIR_Parser.handle_1q2p(line)
+            elif line.startswith('BARRIER'):
+                operation = 'BARRIER'
+                operation, q = OriginIR_Parser.handle_barrier(line)
             elif line.startswith('MEASURE'):
                 operation = 'MEASURE'
                 q, c = OriginIR_Parser.handle_measure(line)

--- a/qpandalite/originir/originir_line_parser.py
+++ b/qpandalite/originir/originir_line_parser.py
@@ -95,6 +95,7 @@ class OriginIR_Parser:
     def handle_barrier(line):
         matches = OriginIR_Parser.regexp_barrier.findall(line)
         return matches
+    
     @staticmethod
     def handle_control(line):
         """
@@ -113,7 +114,6 @@ class OriginIR_Parser:
         operation_type = matches.group(1)
         qubits = OriginIR_Parser.regexp_qid.findall(matches.group(2))
         controls = [int(ctrl) for ctrl in qubits]
-        
         return operation_type, controls
 
     @staticmethod

--- a/qpandalite/qasm_origin/__init__.py
+++ b/qpandalite/qasm_origin/__init__.py
@@ -1,0 +1,1 @@
+from .qasm_line_parser import OpenQASM2_Parser

--- a/qpandalite/qasm_origin/qasm_line_parser.py
+++ b/qpandalite/qasm_origin/qasm_line_parser.py
@@ -137,7 +137,7 @@ class OpenQASM2_Parser:
             elif line.startswith('ENDDAGGER'):
                 pass
             else:
-                raise NotImplementedError(f'A invalid line: {line}.')      
+                raise NotImplementedError(f'This line of OpenQASM 2 has not been supported yet: {line}.')      
             
             return None
         except AttributeError as e:

--- a/qpandalite/qasm_origin/qasm_line_parser.py
+++ b/qpandalite/qasm_origin/qasm_line_parser.py
@@ -1,0 +1,52 @@
+import re
+
+class OpenQASM2_Parser:
+	opname = r'([A-Za-z]+)'
+    blank = r' *'
+    qid = r'q *\[ *(\d+) *\]'
+    cid = r'c *\[ *(\d+) *\]'
+    comma = r','
+    lbracket = r'\('
+    rbracket = r'\)'
+    parameter = r'(-?\d+(\.\d*)?([eE][-+]?\d+)?)'
+    regexp_1q_str = '^' + opname + blank + qid + '$'
+    regexp_2q_str = '^' + opname + blank + qid + blank + comma + blank + qid + '$'
+    regexp_1q1p_str = ('^' + 
+                        opname + blank + 
+                        qid + blank +  
+                        comma + blank + 
+                        lbracket + blank + 
+                        parameter + blank + 
+                        rbracket + 
+                        '$')
+    regexp_1q2p_str = ('^' + 
+                        opname + blank + 
+                        qid + blank +  
+                        comma + blank + 
+                        lbracket + blank + 
+                        parameter + blank + 
+                        comma + blank + 
+                        parameter + blank + 
+                        rbracket +
+                        '$')
+    regexp_measure_str = ('^' + 
+                        r'MEASURE' + blank + 
+                        qid + blank + 
+                        comma + blank + 
+                        cid + 
+                        '$')
+        
+    regexp_control_str = (r'^(CONTROL|ENDCONTROL)' +
+                          f'(({blank}{qid}{blank}{comma})*{blank}{qid}{blank})' + 
+                          '$')
+    
+    regexp_1q = re.compile(regexp_1q_str)
+    regexp_2q = re.compile(regexp_2q_str)
+    regexp_1q1p = re.compile(regexp_1q1p_str)
+    regexp_1q2p = re.compile(regexp_1q2p_str)
+    regexp_meas = re.compile(regexp_measure_str)
+    regexp_control = re.compile(regexp_control_str)
+    regexp_qid = re.compile(qid)
+
+    def __init__(self):
+        pass

--- a/qpandalite/qasm_origin/qasm_line_parser.py
+++ b/qpandalite/qasm_origin/qasm_line_parser.py
@@ -1,52 +1,172 @@
 import re
+import math
+from qpandalite.circuit_builder.qcircuit import Circuit
 
 class OpenQASM2_Parser:
-	opname = r'([A-Za-z]+)'
-    blank = r' *'
-    qid = r'q *\[ *(\d+) *\]'
-    cid = r'c *\[ *(\d+) *\]'
-    comma = r','
-    lbracket = r'\('
-    rbracket = r'\)'
-    parameter = r'(-?\d+(\.\d*)?([eE][-+]?\d+)?)'
-    regexp_1q_str = '^' + opname + blank + qid + '$'
-    regexp_2q_str = '^' + opname + blank + qid + blank + comma + blank + qid + '$'
-    regexp_1q1p_str = ('^' + 
-                        opname + blank + 
-                        qid + blank +  
-                        comma + blank + 
-                        lbracket + blank + 
-                        parameter + blank + 
-                        rbracket + 
-                        '$')
-    regexp_1q2p_str = ('^' + 
-                        opname + blank + 
-                        qid + blank +  
-                        comma + blank + 
-                        lbracket + blank + 
-                        parameter + blank + 
-                        comma + blank + 
-                        parameter + blank + 
-                        rbracket +
-                        '$')
-    regexp_measure_str = ('^' + 
-                        r'MEASURE' + blank + 
-                        qid + blank + 
-                        comma + blank + 
-                        cid + 
-                        '$')
-        
-    regexp_control_str = (r'^(CONTROL|ENDCONTROL)' +
-                          f'(({blank}{qid}{blank}{comma})*{blank}{qid}{blank})' + 
-                          '$')
-    
-    regexp_1q = re.compile(regexp_1q_str)
-    regexp_2q = re.compile(regexp_2q_str)
-    regexp_1q1p = re.compile(regexp_1q1p_str)
-    regexp_1q2p = re.compile(regexp_1q2p_str)
-    regexp_meas = re.compile(regexp_measure_str)
-    regexp_control = re.compile(regexp_control_str)
-    regexp_qid = re.compile(qid)
+    """
+        The module transforms circuits written in OpenQASM 2.0 into an intermediate representation known as OriginIR.
 
+        This representation can then be further transformed to be compatible with our quantum machines.
+        
+        Essentially, with OpenQASM2_Parser, any quantum circuit penned in OpenQASM 2.0 can be seamlessly executed on the OriginQC platform.
+        
+        Example:
+            # [Assume you have a circuit written in OpenQASM 2.0]
+            # [And the type of it is string, e.g. circ.qasm() in qiskit]
+            
+            qasm_string = circ.qasm()
+            
+            # The quantum circuit(OriginIR) object
+            circuit_origin = OpenQASM2_Parser.build_from_qasm_str(qasm_string)
+            
+            # Converting back to original quantum circuit(OpenQASM 2.0) using qasm in the Circuit(OriginIR) class
+            qc_init = QuantumCircuit.from_qasm_str(circuit_origin.qasm)
+
+        Notice:
+            This module now only sucessfully converting QASM file with h, x, y, z, rx, ry, rz, cx, cz.
+            More will be supported soon. :^)
+    """
     def __init__(self):
         pass
+    
+    @staticmethod
+    def string_to_float(s):
+        # Define a safe dictionary that only contains the math module's attributes
+        safe_dict = {k: getattr(math, k) for k in dir(math)}
+        
+        try:
+            return eval(s, {"__builtins__": None}, safe_dict)
+        except:
+            raise ValueError(f"Failed to convert '{s}' to float")
+
+    @staticmethod
+    def parse_line(line, QASM_Origin_circuit):
+        try:
+            if not line:
+                pass 
+            elif line.startswith('qreg'):
+                pass
+            elif line.startswith('creg'):
+                pass
+            elif line.startswith('h'):
+                match_h = re.match(r'h q\[(\d+)\];', line) 
+                qubit = int(match_h.group(1))
+                QASM_Origin_circuit.h(qubit)
+
+            elif line.startswith('x'):
+                match_x = re.match(r'x q\[(\d+)\];', line) 
+                qubit = int(match_x.group(1))
+                QASM_Origin_circuit.x(qubit)
+
+            elif line.startswith('SX'):
+                pass
+            elif line.startswith('y'):
+                match_y = re.match(r'y q\[(\d+)\];', line) 
+                qubit = int(match_y.group(1))
+                QASM_Origin_circuit.y(qubit)
+
+            elif line.startswith('z'):
+                match_z = re.match(r'z q\[(\d+)\];', line) 
+                qubit = int(match_z.group(1))
+                QASM_Origin_circuit.z(qubit)
+
+            elif line.startswith('cz'):
+                match_cz = re.match(r'cz q\[(\d+)\],q\[(\d+)\];', line)
+                qubit1, qubit2 = map(int, match_cz.groups())
+                QASM_Origin_circuit.cz(qubit1, qubit2)
+
+            elif line.startswith('ISWAP'):
+                pass
+            elif line.startswith('XY'):
+                pass
+            elif line.startswith('cx'):
+                # Match the cx operation
+                match_cx = re.match(r'cx q\[(\d+)\],q\[(\d+)\];', line)
+                qubit1, qubit2 = map(int, match_cx.groups())
+                QASM_Origin_circuit.cnot(qubit1, qubit2)
+
+            elif line.startswith('rx'):
+                pattern = r'rx\(([^)]+)\) q\[(\d+)\];'
+
+                match = re.match(pattern, line)
+                
+                param_str = match.group(1)
+                qubit = int(match.group(2))
+
+                param = OpenQASM2_Parser.string_to_float(param_str)
+
+                QASM_Origin_circuit.rx(qubit, param)
+
+            elif line.startswith('ry'):
+                pattern = r'ry\(([^)]+)\) q\[(\d+)\];'
+
+                match = re.match(pattern, line)
+                
+                param_str = match.group(1)
+                qubit = int(match.group(2))
+
+                param = OpenQASM2_Parser.string_to_float(param_str)
+
+                QASM_Origin_circuit.ry(qubit, param)
+            
+            elif line.startswith('rz'):
+                pattern = r'rz\(([^)]+)\) q\[(\d+)\];'
+
+                match = re.match(pattern, line)
+                
+                param_str = match.group(1)
+                qubit = int(match.group(2))
+
+                param = OpenQASM2_Parser.string_to_float(param_str)
+
+                QASM_Origin_circuit.rz(qubit, param)
+
+            elif line.startswith('u3'):
+                pass
+
+            elif line.startswith('measure'):
+                match_measure = re.match(r'measure q\[(\d+)\] -> c\[\d+\];', line)
+                qubit = int(match_measure.group(1))
+                QASM_Origin_circuit.measure_list.append(qubit)
+            elif line.startswith('CONTROL'):
+                pass
+            elif line.startswith('ENDCONTROL'):
+                pass
+            elif line.startswith('DAGGER'):
+                pass
+            elif line.startswith('ENDDAGGER'):
+                pass
+            else:
+                raise NotImplementedError(f'A invalid line: {line}.')      
+            
+            return None
+        except AttributeError as e:
+            raise RuntimeError(f'Error when parsing the line: {line}')
+
+    @staticmethod
+    def build_from_qasm_str(qasm_str):
+        """
+        The function coverts OpenQASM string into OriginIR circuit. It will create the
+        quantum circuit object given the qasm_str.
+
+        In the initilization phase, we need to notice that OriginIR-based quantum circuit
+        doe not need to specify how many qregs and cregs used. 
+        
+        Parameters:
+        - qasm_str: The quantum circuit of intersts in the OpenQASM format.
+
+        Returns:
+        - origin_qcirc: The quantum circuit of intersts in the OriginIR format. 
+        """
+        # Create an empty Circuit object
+        origincircuit = Circuit()
+        # parser = OpenQASM2_Parser()
+
+        lines_to_remove = ["OPENQASM 2.0;", "include \"qelib1.inc\";"]
+
+        # Split the QASM string into lines and parse each line
+        for line in qasm_str.split("\n"):
+            if line not in lines_to_remove:
+                OpenQASM2_Parser.parse_line(line, origincircuit)
+
+        return origincircuit

--- a/qpandalite/qasm_origin/qasm_line_parser.py
+++ b/qpandalite/qasm_origin/qasm_line_parser.py
@@ -124,6 +124,14 @@ class OpenQASM2_Parser:
             elif line.startswith('u3'):
                 pass
 
+            elif line.startswith('barrier'):
+                pattern = r'q\[(\d+)\]'
+                matches = re.findall(pattern, line)
+                # Convert matched strings to integers
+                qubit_indices = [int(index) for index in matches]
+                print(qubit_indices)
+                QASM_Origin_circuit.barrier(*qubit_indices)
+            
             elif line.startswith('measure'):
                 match_measure = re.match(r'measure q\[(\d+)\] -> c\[\d+\];', line)
                 qubit = int(match_measure.group(1))

--- a/qpandalite/qasm_origin/qasm_line_parser.py
+++ b/qpandalite/qasm_origin/qasm_line_parser.py
@@ -129,12 +129,12 @@ class OpenQASM2_Parser:
                 matches = re.findall(pattern, line)
                 # Convert matched strings to integers
                 qubit_indices = [int(index) for index in matches]
-                print(qubit_indices)
+                # print(qubit_indices)
                 QASM_Origin_circuit.barrier(*qubit_indices)
             
             elif line.startswith('measure'):
-                match_measure = re.match(r'measure q\[(\d+)\] -> c\[\d+\];', line)
-                qubit = int(match_measure.group(1))
+                match_measure = re.match(r'measure (\w+)\[(\d+)\] -> (\w+)\[\d+\];', line)
+                qubit = int(match_measure.group(2))
                 QASM_Origin_circuit.measure_list.append(qubit)
             elif line.startswith('CONTROL'):
                 pass

--- a/qpandalite/task/ibm/task.py
+++ b/qpandalite/task/ibm/task.py
@@ -330,34 +330,34 @@ def query_all_task(savepath=None):
 if __name__ == '__main__':
     import numpy as np
     from qiskit import QuantumCircuit
-    # circ = QuantumCircuit(3)
+    circ = QuantumCircuit(3)
     
-    # circ.h(0)
-    # circ.rx(0.4, 0)
-    # circ.x(0)
-    # circ.ry(0.39269908169872414, 1)
-    # circ.y(0)
-    # circ.rz(np.pi/8, 1)
-    # circ.z(0)
-    # circ.cz(0, 1)
-    # circ.cx(0, 2) 
+    circ.h(0)
+    circ.rx(0.4, 0)
+    circ.x(0)
+    circ.ry(0.39269908169872414, 1)
+    circ.y(0)
+    circ.rz(np.pi/8, 1)
+    circ.z(0)
+    circ.cz(0, 1)
+    circ.cx(0, 2) 
 
-    # circ.sx(0)
-    # circ.iswap(0, 1)
-    # circ.cz(0, 2)
-    # circ.ccx(0, 1, 2)
-    # x_circuit = QuantumCircuit(2, name='Xs')
-    # x_circuit.x(range(2))
-    # xs_gate = x_circuit.to_gate()
-    # cxs_gate = xs_gate.control()
-    # circ.append(cxs_gate, [0, 1, 2])
+    circ.sx(0)
+    circ.iswap(0, 1)
+    circ.cz(0, 2)
+    circ.ccx(0, 1, 2)
+    x_circuit = QuantumCircuit(2, name='Xs')
+    x_circuit.x(range(2))
+    xs_gate = x_circuit.to_gate()
+    cxs_gate = xs_gate.control()
+    circ.append(cxs_gate, [0, 1, 2])
     
-    # # Create a Quantum Circuit
-    # meas = QuantumCircuit(3, 3)
-    # meas.measure(range(3), range(3))
-    # qc = meas.compose(circ, range(3), front=True)
-    # QASM_string = qc.qasm()
-    # print(QASM_string)
+    # Create a Quantum Circuit
+    meas = QuantumCircuit(3, 3)
+    meas.measure(range(3), range(3))
+    qc = meas.compose(circ, range(3), front=True)
+    QASM_string = qc.qasm()
+    print(QASM_string)
 
     # The quantum circuit in OriginIR
     import qpandalite

--- a/qpandalite/task/ibm/task.py
+++ b/qpandalite/task/ibm/task.py
@@ -210,7 +210,7 @@ def _submit_task_group(circuits=None,
     return job
 
 
-=======
+# =======
 import qiskit
 # import qiskit_ibm_provider
 from qpandalite.task.task_utils import write_taskinfo
@@ -331,7 +331,7 @@ if __name__ == '__main__':
     import numpy as np
     from qiskit import QuantumCircuit
     
-    The quantum circuit in qiskit
+    # The quantum circuit in qiskit
     # circ = QuantumCircuit(3)
     
     # circ.h(0)

--- a/test/qpandalite/circuit_builder/test_barrier.py
+++ b/test/qpandalite/circuit_builder/test_barrier.py
@@ -1,0 +1,40 @@
+import numpy as np
+import math
+from qiskit import QuantumCircuit, transpile
+from qiskit.circuit.library import TdgGate, RXGate
+from qiskit import BasicAer
+import qpandalite.simulator as sim
+from qpandalite.qasm_origin import OpenQASM2_Parser
+from qpandalite.circuit_builder import Circuit
+
+
+circ = QuantumCircuit(3)
+circ.h(0)
+circ.barrier(0)
+circ.rx(-0.4, 0)
+circ.barrier(1)
+circ.x(0)
+circ.barrier(2)
+circ.ry(0.4, 0)
+circ.barrier(0, 1)
+circ.y(0)
+circ.barrier(1, 2)
+circ.rz(math.pi/3, 1)
+circ.barrier(0, 1, 2)
+circ.z(0)
+circ.cz(0, 1)
+circ.cx(0, 2)
+meas = QuantumCircuit(3, 3)
+meas.measure(range(3), range(3))
+circ = meas.compose(circ, range(3), front=True)
+qasm_string = circ.qasm()
+print("---Circuit created using Qiskit(QASM)---")
+print(qasm_string)
+# Create a Circuit instance from the QASM string
+circuit_origin = OpenQASM2_Parser.build_from_qasm_str(qasm_string)
+print("---OriginIR Circuit coverted from QASM---")
+print(circuit_origin.circuit)
+
+origin_qc = QuantumCircuit.from_qasm_str(circuit_origin.qasm)
+print("---Back?---")
+print(origin_qc.qasm())

--- a/test/qpandalite/circuit_builder/test_qasm.py
+++ b/test/qpandalite/circuit_builder/test_qasm.py
@@ -1,0 +1,34 @@
+import numpy as np
+import math
+from qiskit import QuantumCircuit, transpile
+from qiskit.circuit.library import TdgGate, RXGate
+from qiskit import BasicAer
+import qpandalite.simulator as sim
+from qpandalite.qasm_origin import OpenQASM2_Parser
+from qpandalite.circuit_builder import Circuit
+
+
+circ = QuantumCircuit(3)
+circ.h(0)
+circ.rx(-0.4, 0)
+circ.x(0)
+circ.ry(0.4, 0)
+circ.y(0)
+circ.rz(math.pi/3, 1)
+circ.z(0)
+circ.cz(0, 1)
+circ.cx(0, 2)
+meas = QuantumCircuit(3, 3)
+meas.measure(range(3), range(3))
+circ = meas.compose(circ, range(3), front=True)
+qasm_string = circ.qasm()
+print("---Circuit created using Qiskit(QASM)---")
+print(qasm_string)
+# Create a Circuit instance from the QASM string
+circuit_origin = OpenQASM2_Parser.build_from_qasm_str(qasm_string)
+print("---OriginIR Circuit coverted from QASM---")
+print(circuit_origin.circuit)
+
+origin_qc = QuantumCircuit.from_qasm_str(circuit_origin.qasm)
+print("---Back?---")
+print(origin_qc.qasm())

--- a/test/qpandalite/circuit_builder/test_unwrap.py
+++ b/test/qpandalite/circuit_builder/test_unwrap.py
@@ -1,0 +1,57 @@
+import numpy as np
+import math
+from qiskit import QuantumCircuit, transpile
+from qiskit.circuit.library import TdgGate, RXGate
+from qiskit import BasicAer
+import qpandalite.simulator as sim
+from qpandalite.qasm_origin import OpenQASM2_Parser
+from qpandalite.circuit_builder import Circuit
+
+my_circ = Circuit()
+my_circ.h(0)
+my_circ.cnot(1, 0)
+my_circ.cnot(0, 2)  
+# # Single control(Correct)
+with my_circ.control(0, 1, 2):
+    my_circ.x(4)
+
+# Single dagger(Correct)
+with my_circ.dagger():
+    my_circ.z(5)
+    my_circ.x(10)
+
+# Nested-dagger
+with my_circ.dagger():
+    my_circ.z(2)
+    with my_circ.dagger():
+        my_circ.z(5)
+        my_circ.x(10)
+
+# Nested-control(Correct)
+with my_circ.control(0,1):
+    my_circ.x(2)
+    with my_circ.control(4,5):
+        my_circ.x(3)
+
+# Control-dagger-nested
+with my_circ.control(2):
+    my_circ.x(4)
+    with my_circ.dagger():
+        my_circ.z(5)
+        my_circ.x(10)
+        with my_circ.control(0,1):
+            my_circ.x(3)
+
+# Dagger-control-nested
+with my_circ.dagger():
+    my_circ.z(5)
+    my_circ.x(10)
+    with my_circ.control(0,1):
+        my_circ.x(3)
+
+my_circ.h(8)
+my_circ.h(9)
+my_circ.measure(0,1,2)
+
+my_circ.analyze_circuit()
+print(my_circ.unwrap())

--- a/test/qpandalite/qasm_origin/test_coupling_compiling.py
+++ b/test/qpandalite/qasm_origin/test_coupling_compiling.py
@@ -36,6 +36,8 @@ for _ in range(100):
 	backend = BasicAer.get_backend('qasm_simulator')
 
 	result = transpile(q, basis_gates=my_basis_gates, coupling_map=my_coupling, optimization_level=1)
+
+	# This is to exclude the "id" operation, which is not supported in the OriginIR
 	for index in reversed(range(len(result.data))):
 	    if result.data[index][0].name == "id":
 	        del result.data[index]

--- a/test/qpandalite/qasm_origin/test_coupling_compiling.py
+++ b/test/qpandalite/qasm_origin/test_coupling_compiling.py
@@ -22,7 +22,7 @@ Optimization level 3 spends the most effort to optimize the circuit.
 """
 qubit_number = 6
 my_coupling = CouplingMap.from_line(qubit_number)
-my_basis_gates = ['rx', 'ry', 'rz', 'cz', 'id']
+my_basis_gates = ['h', 'x', 'y', 'z', 'rx', 'ry', 'rz', 'cz', 'id']
 
 for _ in range(100):
 	# Insert your quantum circuit
@@ -30,11 +30,15 @@ for _ in range(100):
 	meas = QuantumCircuit(qubit_number, qubit_number)
 	meas.measure(range(qubit_number), range(qubit_number))
 	q = meas.compose(q, range(qubit_number), front=True)
+	q.data = [(op, qubits, clbits) for op, qubits, clbits in q.data if q.name != "id"]
 
 	# select a backend
 	backend = BasicAer.get_backend('qasm_simulator')
 
 	result = transpile(q, basis_gates=my_basis_gates, coupling_map=my_coupling, optimization_level=1)
+	for index in reversed(range(len(result.data))):
+	    if result.data[index][0].name == "id":
+	        del result.data[index]
 	qasm_string = result.qasm()
 	# print("---Circuit created using Qiskit(QASM)---")
 	# print(qasm_string)

--- a/test/qpandalite/qasm_origin/test_coupling_compiling.py
+++ b/test/qpandalite/qasm_origin/test_coupling_compiling.py
@@ -1,0 +1,50 @@
+import numpy as np
+import math
+from qiskit import QuantumCircuit, BasicAer
+from qiskit.circuit.random import random_circuit
+from qiskit.compiler import transpile
+from qiskit.transpiler import CouplingMap
+import qpandalite.simulator as sim
+from qpandalite.qasm_origin import OpenQASM2_Parser
+from qpandalite.circuit_builder import Circuit
+
+"""
+From QISKit docs: https://qiskit.org/documentation/apidoc/compiler.html#qiskit.compiler.transpile
+
+Multiple formats are supported:
+1. CouplingMap instance
+2. List, must be given as an adjacency matrix, where each entry specifies all directed two-qubit interactions supported by backend, 
+e.g: [[0, 1], [0, 3], [1, 2], [1, 5], [2, 5], [4, 1], [5, 3]]
+
+Optimization level 0 is intended for device characterization experiments and, 
+as such, only maps the input circuit to the constraints of the target backend, without performing any optimizations. 
+Optimization level 3 spends the most effort to optimize the circuit. 
+"""
+qubit_number = 6
+my_coupling = CouplingMap.from_line(qubit_number)
+my_basis_gates = ['rx', 'ry', 'rz', 'cz', 'id']
+
+for _ in range(100):
+	# Insert your quantum circuit
+	q = random_circuit(qubit_number, depth=3)
+	meas = QuantumCircuit(qubit_number, qubit_number)
+	meas.measure(range(qubit_number), range(qubit_number))
+	q = meas.compose(q, range(qubit_number), front=True)
+
+	# select a backend
+	backend = BasicAer.get_backend('qasm_simulator')
+
+	result = transpile(q, basis_gates=my_basis_gates, coupling_map=my_coupling, optimization_level=1)
+	qasm_string = result.qasm()
+	# print("---Circuit created using Qiskit(QASM)---")
+	# print(qasm_string)
+	# # Create a Circuit instance from the QASM string
+	circuit_origin = OpenQASM2_Parser.build_from_qasm_str(qasm_string)
+	# print("---OriginIR Circuit coverted from QASM---")
+	# print(circuit_origin.circuit)
+
+	origin_qc = QuantumCircuit.from_qasm_str(circuit_origin.qasm)
+	# print("---Back?---")
+	# print(origin_qc.qasm())
+	if not origin_qc.qasm() == qasm_string:
+		print("bug")


### PR DESCRIPTION
Beta version for support the translation from OpenQASM to OriginIR and its reverse(OPEN TO TEST),
NOTE: now OriginIR <-> OpenQASM supposed to work in {H, X, Y, Z, RX, RY, RZ, CX, CZ} as test_barrier.py, but dagger not supported yet.

1. Functions dealing with QASM to OriginIR are now in `qasm_line_parser.py`

2. Now we support the h, x, y, z, rx, ry, rz, cx, cz, barrier.

3. Rewrote the analyze_circuit in OriginIR_base_parser.

4. Fixed Several bugs in control and dagger - with statements.

5. Created a folder for testing in case we have errors like 4 again.