### PR TITLE
fix: exclude Kraus1Q from OriginIR test default params

### DIFF
--- a/qpandalite/circuit_builder/originir_spec.py
+++ b/qpandalite/circuit_builder/originir_spec.py
@@ -112,3 +112,9 @@ available_originir_error_channels.update({
 
 def generate_sub_error_channel_originir(channel_list):
     return {k : v for k, v in available_originir_error_channels.items() if k in channel_list}
+
+# Subset excluding Kraus1Q (random generation not yet implemented)
+available_originir_error_channels_without_kraus = {
+    k: v for k, v in available_originir_error_channels.items()
+    if k not in available_originir_error_channel_1qnp
+}

--- a/qpandalite/test/test_random_OriginIR.py
+++ b/qpandalite/test/test_random_OriginIR.py
@@ -4,6 +4,7 @@ import numpy as np
 from qpandalite.circuit_builder.random_originir import random_originir
 from qpandalite.circuit_builder.originir_spec import (available_originir_gates, 
                                                available_originir_error_channels,
+                                               available_originir_error_channels_without_kraus,
                                                generate_sub_gateset_originir,
                                                generate_sub_error_channel_originir)
 
@@ -49,7 +50,7 @@ def test_random_originir_compare_density_operator(backend_1 = 'density_operator'
                                                   random_batchsize = 100,
                                                   n_qubits = 5, n_gates = 20, 
                                                   gate_set = available_originir_gates,
-                                                  error_channel = available_originir_error_channels):
+                                                  error_channel = available_originir_error_channels_without_kraus):
     
     err_list = []    
     good_circuit_list = []


### PR DESCRIPTION
## 问题

`test_random_originir_compare_density_operator` 的默认参数 `error_channel=available_originir_error_channels` 包含 Kraus1Q，但 Kraus1Q 的随机生成未实现（param=-1），导致生成空参数的 `Kraus1Q q[0], ()`，解析器抛 NotImplementedError。

## 修改

1. 在 `originir_spec.py` 中新增 `available_originir_error_channels_without_kraus` 子集
2. 将函数默认参数改为使用该子集

关联：PR #57 只修了 `test_random_originir_density_operator`，遗漏了这个函数。