### PR TITLE
fix: improve PyPI distribution workflow (#78)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,38 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/qpandalite/
+
+    permissions:
+      id-token: write  # required for trusted publishing
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "cmake>=3.15"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 # setup.py is retained for custom CMakeExtension / CMakeBuild logic
 
@@ -56,5 +56,5 @@ packages = { find = { exclude = ["qpandalite.test", "qpandalite.test.*"] } }
 version = { attr = "qpandalite.version.__version__" }
 
 [tool.setuptools.package-data]
-"qpandalite" = ["test/QASMBench.pkl"]
+"qpandalite" = ["test/QASMBench.pkl", "*.pyi"]
 "qpandalite.simulator" = ["qpandalite_cpp.pyi"]


### PR DESCRIPTION
## Summary

Improve PyPI distribution workflow for QPanda-lite:

- **Add `.github/workflows/pypi-publish.yml`**: Automated PyPI publishing on GitHub release or `v*` tag push using `pypa/gh-action-pypi-publish` with trusted publishing.
- **Fix stub file distribution**: Add `*.pyi` to `[tool.setuptools.package-data] "qpandalite"` to ensure all `.pyi` stub files are included in sdist/wheel.
- **Remove cmake from build-system.requires**: `cmake>=3.15` is not needed for sdist builds (only for building C++ wheels locally). The C++ extension build is handled separately by `setup.py`.

### Version Sync Status
- `qpandalite/version.py`: `__version__ = "0.2.6"`
- Latest git tag: `0.2.6`
- Status: ✅ In sync

### sdist Verification
- `python -m build --sdist` — ✅ Successful
- Contains README.md, LICENSE, pyproject.toml, setup.py, .pyi files — ✅ Complete

### Note on PyPI Token
Trusted publishing requires `PYPI_API_TOKEN` to be configured in repository Settings → Secrets. Alternatively, use OIDC trusted publishing by adding repository to PyPI project settings.

Closes #78
