### PR TITLE
fix: correct README examples (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ from qpandalite.circuit_builder import Circuit
 c = Circuit()
 c.rx(1, 0.1)
 c.cnot(1, 0)
-c.measure(0, 1, 2, 3)
+c.measure(0, 1)
 print(c.circuit)
 ```
 
@@ -200,7 +200,7 @@ sim = qsim.OriginIR_Simulator(reverse_key=False)
 
 originir = '''
 QINIT 72
-CREG 2
+CREG 3
 RY q[45],(0.9424777960769379)
 RY q[46],(0.9424777960769379)
 CZ q[45],q[46]
@@ -212,7 +212,7 @@ MEASURE q[46],c[2]
 MEASURE q[52],c[1]
 '''
 
-res = sim.simulate(originir)
+res = sim.simulate_statevector(originir)
 print(res)
 print(sim.state)
 ```


### PR DESCRIPTION
## Summary

Restore from accidentally closed PR #76.

Fix README example code:

- Build a Circuit: measure was misleading - qubits 2,3 were never used. Changed to measure(0,1).
- Circuit Simulation: simulate() does not exist on OriginIR_Simulator. Changed to simulate_statevector().
- Circuit Simulation: CREG 2 but MEASURE used c[2], exceeding range. Changed to CREG 3.

All 3 examples verified runnable with the fixes.

Closes #12