### PR TITLE
fix: improve PyPI distribution workflow (#78)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,38 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/qpandalite/
+
+    permissions:
+      id-token: write  # required for trusted publishing
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "cmake>=3.15"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 # setup.py is retained for custom CMakeExtension / CMakeBuild logic
 
@@ -56,5 +56,5 @@ packages = { find = { exclude = ["qpandalite.test", "qpandalite.test.*"] } }
 version = { attr = "qpandalite.version.__version__" }
 
 [tool.setuptools.package-data]
-"qpandalite" = ["test/QASMBench.pkl"]
+"qpandalite" = ["test/QASMBench.pkl", "*.pyi"]
 "qpandalite.simulator" = ["qpandalite_cpp.pyi"]


### PR DESCRIPTION
Restore from accidentally closed PR #79.

- Add pypi-publish.yml for automatic release on tag v* / release
- Add *.pyi to package-data for stub distribution  
- Remove cmake from build-system.requires (not needed for sdist)
- Version 0.2.6 in sync with git tag

Closes #78