### PR TITLE
feat: add type hints to simulator modules (#77)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ target-version = "py39"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "C4", "SIM"]
-ignore = ["E501"]  # line length handled by formatter
+ignore = ["E501", "N801", "N803", "N806"]  # line length; CapWords for ErrorLoader subclasses; lowercase for math vars (U,H,K,E physics notation)
 
 [tool.ruff.format]
 quote-style = "double"

--- a/qpandalite/simulator/error_model.py
+++ b/qpandalite/simulator/error_model.py
@@ -1,194 +1,217 @@
 # Error model
 
-__all__ = ["ErrorModel", "BitFlip", "PhaseFlip", "Depolarizing", "TwoQubitDepolarizing", "AmplitudeDamping", "PauliError1Q", "PauliError2Q", "Kraus1Q", "ErrorLoader", "ErrorLoader_GenericError", "ErrorLoader_GateTypeError", "ErrorLoader_GateSpecificError"]
-from typing import Dict, List, Tuple
-import numpy as np
+from __future__ import annotations
+
+__all__ = [
+    "ErrorModel",
+    "BitFlip",
+    "PhaseFlip",
+    "Depolarizing",
+    "TwoQubitDepolarizing",
+    "AmplitudeDamping",
+    "PauliError1Q",
+    "PauliError2Q",
+    "Kraus1Q",
+    "ErrorLoader",
+    "ErrorLoader_GenericError",
+    "ErrorLoader_GateTypeError",
+    "ErrorLoader_GateSpecificError",
+]
+
+from typing import Any
+
+# Opcode type: (gate_name, qubits, params, prob, None, None)
+OpCode = tuple[str, int | list[int], Any, float | tuple[float, float, float] | list[complex] | None, None, None]
 
 
 class ErrorModel:
-    def __init__(self):
-        pass
-    
-    def generate_error_opcode(self, qubits):
-        pass
+    def __init__(self) -> None: ...
+
+    def generate_error_opcode(self, qubits: int | list[int]) -> list[OpCode]: ...
 
 
 class BitFlip(ErrorModel):
-    def __init__(self, p):
+    p: float
+
+    def __init__(self, p: float) -> None:
         self.p = p
-    
-    def generate_error_opcode(self, qubits):
+
+    def generate_error_opcode(self, qubits: int | list[int]) -> list[OpCode]:
         if isinstance(qubits, int):
             qubits = [qubits]
+        return [("BitFlip", q, None, self.p, None, None) for q in qubits]
 
-        opcodes = [('BitFlip', qubit, None, self.p, None, None) for qubit in qubits]
-        return opcodes
-    
+
 class PhaseFlip(ErrorModel):
-    def __init__(self, p):
+    p: float
+
+    def __init__(self, p: float) -> None:
         self.p = p
-    
-    def generate_error_opcode(self, qubits):
+
+    def generate_error_opcode(self, qubits: int | list[int]) -> list[OpCode]:
         if isinstance(qubits, int):
             qubits = [qubits]
+        return [("PhaseFlip", q, None, self.p, None, None) for q in qubits]
 
-        opcodes =[('PhaseFlip', qubit, None, self.p, None, None) for qubit in qubits]
-        return opcodes
-    
+
 class Depolarizing(ErrorModel):
-    def __init__(self, p):
+    p: float
+
+    def __init__(self, p: float) -> None:
         self.p = p
-    
-    def generate_error_opcode(self, qubits):
+
+    def generate_error_opcode(self, qubits: int | list[int]) -> list[OpCode]:
         if isinstance(qubits, int):
             qubits = [qubits]
+        return [("Depolarizing", q, None, self.p, None, None) for q in qubits]
 
-        opcodes =[('Depolarizing', qubit, None, self.p, None, None) for qubit in qubits]
-        return opcodes
-    
+
 class TwoQubitDepolarizing(ErrorModel):
-    def __init__(self, p):
+    p: float
+
+    def __init__(self, p: float) -> None:
         self.p = p
-    
-    def generate_error_opcode(self, qubits):
-        if not isinstance(qubits, list) or len(qubits)!= 2:
+
+    def generate_error_opcode(self, qubits: int | list[int]) -> list[OpCode]:
+        if not isinstance(qubits, list) or len(qubits) != 2:
             raise ValueError("TwoQubitDepolarizing error model requires two qubits")
-        
-        opcodes =[('TwoQubitDepolarizing', qubit, None, self.p, None, None) for qubit in qubits]
-        return opcodes
-    
+        return [("TwoQubitDepolarizing", q, None, self.p, None, None) for q in qubits]
+
+
 class AmplitudeDamping(ErrorModel):
-    def __init__(self, gamma):
+    gamma: float
+
+    def __init__(self, gamma: float) -> None:
         self.gamma = gamma
-    
-    def generate_error_opcode(self, qubits):
+
+    def generate_error_opcode(self, qubits: int | list[int]) -> list[OpCode]:
         if isinstance(qubits, int):
             qubits = [qubits]
+        return [("AmplitudeDamping", q, None, self.gamma, None, None) for q in qubits]
 
-        opcodes =[('AmplitudeDamping', qubit, None, self.gamma, None, None) for qubit in qubits]
-        return opcodes
-    
+
 class PauliError1Q(ErrorModel):
-    def __init__(self, p_x, p_y, p_z):
+    p_x: float
+    p_y: float
+    p_z: float
+
+    def __init__(self, p_x: float, p_y: float, p_z: float) -> None:
         self.p_x = p_x
         self.p_y = p_y
         self.p_z = p_z
-    
-    def generate_error_opcode(self, qubits):
+
+    def generate_error_opcode(self, qubits: int | list[int]) -> list[OpCode]:
         if isinstance(qubits, int):
             qubits = [qubits]
+        return [("PauliError1Q", q, None, (self.p_x, self.p_y, self.p_z), None, None) for q in qubits]
 
-        opcodes =[('PauliError1Q', qubit, None, (self.p_x, self.p_y, self.p_z), None, None) for qubit in qubits]
-        return opcodes
-    
+
 class PauliError2Q(ErrorModel):
-    def __init__(self, ps: List[float]):
+    ps: list[float]
+
+    def __init__(self, ps: list[float]) -> None:
         self.ps = ps
-    
-    def generate_error_opcode(self, qubits):
-        if not isinstance(qubits, list) or len(qubits)!= 2:
+
+    def generate_error_opcode(self, qubits: int | list[int]) -> list[OpCode]:
+        if not isinstance(qubits, list) or len(qubits) != 2:
             raise ValueError("PauliError2Q error model requires two qubits")
-        
-        opcodes = [('PauliError2Q', qubit, None, self.ps, None, None) for qubit in qubits]
-        return opcodes
+        return [("PauliError2Q", q, None, self.ps, None, None) for q in qubits]
+
 
 class Kraus1Q(ErrorModel):
-    def __init__(self, kraus_ops: List[List[complex]]):
+    kraus_ops: list[list[complex]]
+
+    def __init__(self, kraus_ops: list[list[complex]]) -> None:
         self.kraus_ops = kraus_ops
 
-    def generate_error_opcode(self, qubits):
+    def generate_error_opcode(self, qubits: int | list[int]) -> list[OpCode]:
         if isinstance(qubits, int):
             qubits = [qubits]
-
-        opcodes =[('Kraus1Q', qubit, None, self.kraus_ops, None, None) for qubit in qubits]
-        return opcodes
+        return [("Kraus1Q", q, None, self.kraus_ops, None, None) for q in qubits]
 
 
 class ErrorLoader:
-    '''
-    This class is used to load the opcodes into the simulator.'
-    '''
-    def __init__(self):
+    """Load opcodes into the simulator with noise models."""
+
+    opcodes: list[OpCode]
+
+    def __init__(self) -> None:
         self.opcodes = []
 
-    def insert_error(self, opcode):
-        pass
+    def insert_error(self, opcode: OpCode) -> None: ...
 
-    def insert_opcode(self, opcode):
-        # extract opcode
+    def insert_opcode(self, opcode: OpCode) -> None:
         self.opcodes.append(opcode)
         self.insert_error(opcode)
 
-    def process_opcodes(self, opcodes):
+    def process_opcodes(self, opcodes: list[OpCode]) -> None:
         for opcode in opcodes:
             self.insert_opcode(opcode)
 
 
 class ErrorLoader_GenericError(ErrorLoader):
-    '''
-    This class is used to load the opcodes into the simulator with generic noise.'
-    '''
-    def __init__(self, generic_error : List[ErrorModel]):
+    """Load opcodes with generic (gate-independent) noise."""
+
+    generic_error: list[ErrorModel]
+
+    def __init__(self, generic_error: list[ErrorModel]) -> None:
         super().__init__()
         self.generic_error = generic_error if generic_error else []
-        
-    def insert_error(self, opcode):
-        # extract opcode
+
+    def insert_error(self, opcode: OpCode) -> None:
         _, qubits, _, _, _, _ = opcode
-        
         for noise_model in self.generic_error:
             noise_opcodes = noise_model.generate_error_opcode(qubits)
             self.opcodes.extend(noise_opcodes)
-        
+
 
 class ErrorLoader_GateTypeError(ErrorLoader_GenericError):
-    '''
-    This class is used to load the opcodes into the simulator with gate dependent noise.'
-    '''
-    def __init__(self, generic_error : List[ErrorModel], gatetype_error : Dict[str, List[ErrorModel]]):
+    """Load opcodes with gate-dependent noise."""
+
+    gatetype_error: dict[str, list[ErrorModel]]
+
+    def __init__(
+        self,
+        generic_error: list[ErrorModel],
+        gatetype_error: dict[str, list[ErrorModel]],
+    ) -> None:
         super().__init__(generic_error)
-        
         self.gatetype_error = gatetype_error if gatetype_error else {}
 
-        
-    def insert_error(self, opcode):
-        # extract opcode
+    def insert_error(self, opcode: OpCode) -> None:
         gate, qubits, _, _, _, _ = opcode
-
         for noise_model in self.generic_error:
             noise_opcodes = noise_model.generate_error_opcode(qubits)
             self.opcodes.extend(noise_opcodes)
-
         gate_error = self.gatetype_error.get(gate, [])
         for noise_model in gate_error:
             noise_opcodes = noise_model.generate_error_opcode(qubits)
             self.opcodes.extend(noise_opcodes)
 
+
 class ErrorLoader_GateSpecificError(ErrorLoader_GateTypeError):
-    '''
-    This class is used to load the opcodes into the simulator with gate specific noise.
-    '''
-    def __init__(self, generic_error : List[ErrorModel], gatetype_error : Dict[str, List[ErrorModel]], 
-                 gate_specific_error : Dict[Tuple[str, Tuple[int, int]], List[ErrorModel]]):
+    """Load opcodes with gate-specific noise (including per qubit-pair)."""
+
+    gate_specific_error: dict[tuple[str, tuple[int, int]], list[ErrorModel]]
+
+    def __init__(
+        self,
+        generic_error: list[ErrorModel],
+        gatetype_error: dict[str, list[ErrorModel]],
+        gate_specific_error: dict[tuple[str, tuple[int, int]], list[ErrorModel]],
+    ) -> None:
         super().__init__(generic_error, gatetype_error)
         self.gate_specific_error = gate_specific_error if gate_specific_error else {}
-        
-    def insert_error(self, opcode):
-        # extract opcode
-        gate, qubits, _, _, _, _ = opcode
 
+    def insert_error(self, opcode: OpCode) -> None:
+        gate, qubits, _, _, _, _ = opcode
         super().insert_error(opcode)
-        # special case for CZ gate, the qubits need to be sorted
-        if gate == 'CZ':
+        if gate == "CZ":
             qubits = [min(qubits[0], qubits[1]), max(qubits[0], qubits[1])]
-        
         if isinstance(qubits, list):
             qubits = tuple(qubits)
-
         key = (gate, qubits)
-
         gate_specific_error = self.gate_specific_error.get(key, [])
         for noise_model in gate_specific_error:
             noise_opcodes = noise_model.generate_error_opcode(qubits)
             self.opcodes.extend(noise_opcodes)
-

--- a/qpandalite/simulator/qutip_sim_impl.py
+++ b/qpandalite/simulator/qutip_sim_impl.py
@@ -1,50 +1,63 @@
-__all__ = ["DensityOperatorSimulatorQutip"]
-import numpy as np
-from qutip import (
-    Qobj, basis, tensor, ket2dm, 
-    qeye, sigmax, sigmay, sigmaz, 
-)
-from qutip_qip.operations import *
+from __future__ import annotations
+
 from itertools import product
 
-def _validate_kraus_ops(kraus_ops, nqubit):
-    # check if kraus_ops satisfy the Kraus representation condition
+import numpy as np
+from qutip import Qobj, basis, ket2dm, qeye, sigmax, sigmay, sigmaz, tensor
+from qutip_qip.operations import (
+    cnot,
+    expand_operator,
+    phasegate,
+    rx,
+    ry,
+    rz,
+    snot,
+    sqrtnot,
+    swap,
+    toffoli,
+)
+
+
+def _validate_kraus_ops(kraus_ops: list[Qobj], nqubit: int) -> None:
+    """Validate Kraus operators satisfy the Kraus representation condition."""
     ndim = 2**nqubit
     for K in kraus_ops:
         if not isinstance(K, Qobj):
             raise TypeError("Kraus operators must be Qobj instances.")
-        if K.type != 'oper':
+        if K.type != "oper":
             raise TypeError("Kraus operators must be operators.")
-        if K.shape!= (ndim, ndim):
-            raise ValueError("Kraus operators must be square matrices with dimensions (ndim, ndim).")
-    
-    sum_kraus = sum([kraus_op.dag() * kraus_op for kraus_op in kraus_ops])
+        if K.shape != (ndim, ndim):
+            raise ValueError(f"Kraus operators must be square matrices with dimensions ({ndim}, {ndim}).")
+    sum_kraus = sum(kraus_op.dag() * kraus_op for kraus_op in kraus_ops)
     eye = qeye(ndim)
     if not np.allclose(sum_kraus.full(), eye.full()):
         raise ValueError("Kraus operators must satisfy the Kraus representation condition.")
 
 
-
 class DensityOperatorSimulatorQutip:
-    def __init__(self):
+    """Density-matrix simulator backed by QuTiP."""
+
+    n_qubits: int
+    density_matrix: Qobj | None
+
+    def __init__(self) -> None:
         self.n_qubits = 0
         self.density_matrix = None
 
-    def init_n_qubit(self, n):
+    def init_n_qubit(self, n: int) -> None:
+        """Initialize the simulator with n qubits in the |0...0> state."""
         self.n_qubits = n
         zero_state = tensor([basis(2, 0) for _ in range(n)])
         self.density_matrix = ket2dm(zero_state)
 
-    def _expand_operator(self, operator, targets):
+    def _expand_operator(self, operator: Qobj, targets: list[int]) -> Qobj:
         return expand_operator(operator, self.n_qubits, [self.n_qubits - 1 - i for i in targets])
 
-    def _construct_control_op(self, control_qubits, U_expanded):
+    def _construct_control_op(self, control_qubits: list[int], U_expanded: Qobj) -> Qobj:
+        """Apply control structure to U_expanded."""
         if not control_qubits:
             return U_expanded
-        
-        # reverse the control qubits (since qutip uses little-endian)
         control_qubits = [self.n_qubits - 1 - i for i in control_qubits]
-
         identity = tensor([qeye(2)] * self.n_qubits)
         proj = tensor([qeye(2)] * self.n_qubits)
         for q in control_qubits:
@@ -53,169 +66,341 @@ class DensityOperatorSimulatorQutip:
             proj = proj * proj_q
         return proj * U_expanded + (identity - proj)
 
-    def _apply_unitary(self, U, qubits, control_qubits_set = [], is_dagger = False):
+    def _apply_unitary(
+        self,
+        U: Qobj,
+        qubits: list[int],
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        """Apply a unitary gate to the density matrix."""
+        if control_qubits_set is None:
+            control_qubits_set = []
         U_base = U.dag() if is_dagger else U
         U_expanded = self._expand_operator(U_base, qubits)
         control_op = self._construct_control_op(control_qubits_set, U_expanded)
-        self.density_matrix = control_op * self.density_matrix * control_op.dag()
+        self.density_matrix = control_op * self.density_matrix * control_op.dag()  # type: ignore[operator]
 
-    def rx(self, qubit, theta, control_qubits_set = [], is_dagger = False):
+    def _apply_kraus(self, kraus_ops: list[Qobj], targets: list[int]) -> None:
+        """Apply Kraus operators to the density matrix."""
+        expanded_ops = [self._expand_operator(K, targets) for K in kraus_ops]
+        new_rho = sum(K * self.density_matrix * K.dag() for K in expanded_ops)  # type: ignore[operator]
+        self.density_matrix = new_rho  # type: ignore[assignment]
+
+    # ─────────────────── Single-qubit gates ───────────────────
+
+    def rx(
+        self,
+        qubit: int,
+        theta: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = rx(theta)
         self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
 
-    def ry(self, qubit, theta, control_qubits_set = [], is_dagger = False):
+    def ry(
+        self,
+        qubit: int,
+        theta: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = ry(theta)
         self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
 
-    def rz(self, qubit, theta, control_qubits_set = [], is_dagger = False):
+    def rz(
+        self,
+        qubit: int,
+        theta: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = rz(theta)
         self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
 
-    def x(self, qubit, control_qubits_set = [], is_dagger = False):
+    def x(
+        self,
+        qubit: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = sigmax()
         self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
 
-    def y(self, qubit, control_qubits_set = [], is_dagger = False):
+    def y(
+        self,
+        qubit: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = sigmay()
         self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
 
-    def z(self, qubit, control_qubits_set = [], is_dagger = False):
+    def z(
+        self,
+        qubit: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = sigmaz()
         self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
 
-    def hadamard(self, qubit, control_qubits_set = [], is_dagger = False):
+    def hadamard(
+        self,
+        qubit: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = snot()
         self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
 
-    def sx(self, qubit, control_qubits_set = [], is_dagger = False):
+    def sx(
+        self,
+        qubit: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = sqrtnot()
         self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
 
-    def cnot(self, control_qubit, target_qubit, control_qubits_set = [], is_dagger = False):
-        U = cnot(2, 0, 1)  # 标准 CNOT 矩阵，需扩展
+    def s(
+        self,
+        qubit: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        U = phasegate(np.pi / 2)
+        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
+
+    def t(
+        self,
+        qubit: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        U = phasegate(np.pi / 4)
+        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
+
+    # ─────────────────── Two-qubit gates ───────────────────
+
+    def cnot(
+        self,
+        control_qubit: int,
+        target_qubit: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        U = cnot(2, 0, 1)
         self._apply_unitary(U, [control_qubit, target_qubit], control_qubits_set, is_dagger)
 
-    def cz(self, qubit1, qubit2, control_qubits_set = [], is_dagger = False):
-        U = Qobj([[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,-1]], dims=[[2,2],[2,2]])
+    def cz(
+        self,
+        qubit1: int,
+        qubit2: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        U = Qobj([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]], dims=[[2, 2], [2, 2]])
         self._apply_unitary(U, [qubit1, qubit2], control_qubits_set, is_dagger)
 
-    def swap(self, qubit1, qubit2, control_qubits_set = [], is_dagger = False):
+    def swap(
+        self,
+        qubit1: int,
+        qubit2: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = swap()
         self._apply_unitary(U, [qubit1, qubit2], control_qubits_set, is_dagger)
 
-    def toffoli(self, c1, c2, target, control_qubits_set = [], is_dagger = False):
-        U = toffoli()  # 标准 Toffoli 矩阵，需扩展
+    def toffoli(
+        self,
+        c1: int,
+        c2: int,
+        target: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        U = toffoli()
         self._apply_unitary(U, [c1, c2, target], control_qubits_set, is_dagger)
 
-    def phaseflip(self, qubit, prob):
-        K0 = np.sqrt(1 - prob) * Qobj([[1,0],[0,1]])
-        K1 = np.sqrt(prob) * Qobj([[1,0],[0,-1]])
-        self._apply_kraus([K0, K1], [qubit])
-
-    def _apply_kraus(self, kraus_ops, targets):
-        expanded_ops = [self._expand_operator(K, targets) for K in kraus_ops]
-        new_rho = sum(K * self.density_matrix * K.dag() for K in expanded_ops)
-        self.density_matrix = new_rho
-
-    def u1(self, qubit, theta, control_qubits_set = [], is_dagger = False):
-        U = phasegate(theta)
-        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
-
-    def u2(self, qubit, phi, lam, control_qubits_set = [], is_dagger = False):
-        # Qiskit U2门标准定义：
-        # U2(φ, λ) = 1/sqrt(2) * [[1, -e^{iλ}],
-        #                         [e^{iφ}, e^{i(φ+λ)}]]
-        sqrt2 = np.sqrt(2)
-        matrix = np.array([
-            [1/sqrt2, -np.exp(1j*lam)/sqrt2],
-            [np.exp(1j*phi)/sqrt2, np.exp(1j*(phi+lam))/sqrt2]
-        ])
-        
-        U = Qobj(matrix)
-        
-        # 应用酉操作
-        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
-
-    def u3(self, qubit, theta, phi, lam, control_qubits_set = [], is_dagger = False):
-        matrix = np.array([[np.cos(theta/2), -np.exp(1j*lam)*np.sin(theta/2)],
-                          [np.exp(1j*phi)*np.sin(theta/2), np.exp(1j*(phi+lam))*np.cos(theta/2)]])
-        # 处理dagger的情况
-        U = Qobj(matrix)
-        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
-
-    def s(self, qubit, control_qubits_set = [], is_dagger = False):
-        U = phasegate(np.pi/2)
-        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
-
-    def t(self, qubit, control_qubits_set = [], is_dagger = False):
-        U = phasegate(np.pi/4)
-        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
-
-    def iswap(self, q1, q2, control_qubits_set = [], is_dagger = False):
-        matrix = Qobj([[1, 0, 0, 0],
-                    [0, 0, 1j, 0],
-                    [0, 1j, 0, 0],
-                    [0, 0, 0, 1]], 
-                    dims=[[2,2], [2,2]])
+    def iswap(
+        self,
+        q1: int,
+        q2: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        matrix = Qobj(
+            [[1, 0, 0, 0], [0, 0, 1j, 0], [0, 1j, 0, 0], [0, 0, 0, 1]],
+            dims=[[2, 2], [2, 2]],
+        )
         self._apply_unitary(matrix, [q1, q2], control_qubits_set, is_dagger)
 
-    def cswap(self, control_qubit, q1, q2, control_qubits_set = [], is_dagger = False):
-        total_control = list(control_qubits_set) + [control_qubit]
+    def cswap(
+        self,
+        control_qubit: int,
+        q1: int,
+        q2: int,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        total_control = list(control_qubits_set) + [control_qubit] if control_qubits_set else [control_qubit]
         swap_op = swap()
         self._apply_unitary(swap_op, [q1, q2], total_control, is_dagger)
 
-    def xy(self, q1, q2, theta, control_qubits_set = [], is_dagger = False):
-        H = (tensor(sigmax(), sigmax()) + tensor(sigmay(), sigmay())) * (-1j*theta/4)
+    # ─────────────────── Parametric gates ───────────────────
+
+    def u1(
+        self,
+        qubit: int,
+        theta: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        U = phasegate(theta)
+        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
+
+    def u2(
+        self,
+        qubit: int,
+        phi: float,
+        lam: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        sqrt2 = np.sqrt(2)
+        matrix = np.array(
+            [
+                [1 / sqrt2, -np.exp(1j * lam) / sqrt2],
+                [np.exp(1j * phi) / sqrt2, np.exp(1j * (phi + lam)) / sqrt2],
+            ],
+            dtype=complex,
+        )
+        U = Qobj(matrix)
+        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
+
+    def u3(
+        self,
+        qubit: int,
+        theta: float,
+        phi: float,
+        lam: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        matrix = np.array(
+            [
+                [np.cos(theta / 2), -np.exp(1j * lam) * np.sin(theta / 2)],
+                [np.exp(1j * phi) * np.sin(theta / 2), np.exp(1j * (phi + lam)) * np.cos(theta / 2)],
+            ],
+            dtype=complex,
+        )
+        U = Qobj(matrix)
+        self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
+
+    def xy(
+        self,
+        q1: int,
+        q2: int,
+        theta: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        H = (tensor(sigmax(), sigmax()) + tensor(sigmay(), sigmay())) * (-1j * theta / 4)
         U = H.expm()
         self._apply_unitary(U, [q1, q2], control_qubits_set, is_dagger)
 
-    def rphi(self, qubit, theta, phi, control_qubits_set = [], is_dagger = False):
+    def rphi(
+        self,
+        qubit: int,
+        theta: float,
+        phi: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
         U = rz(phi) * rx(theta) * rz(-phi)
         self._apply_unitary(U, [qubit], control_qubits_set, is_dagger)
 
-    def rphi90(self, qubit, phi, control_qubits_set = [], is_dagger = False):
-        return self.rphi(qubit, np.pi/2, phi, control_qubits_set, is_dagger)
+    def rphi90(
+        self,
+        qubit: int,
+        phi: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        self.rphi(qubit, np.pi / 2, phi, control_qubits_set, is_dagger)
 
-    def rphi180(self, qubit, phi, control_qubits_set = [], is_dagger = False):
-        return self.rphi(qubit, np.pi, phi, control_qubits_set, is_dagger)
+    def rphi180(
+        self,
+        qubit: int,
+        phi: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        self.rphi(qubit, np.pi, phi, control_qubits_set, is_dagger)
 
-    def xx(self, q1, q2, theta, control_qubits_set = [], is_dagger = False):
-        H = tensor(sigmax(), sigmax()) * (-1j*theta/2)
+    def xx(
+        self,
+        q1: int,
+        q2: int,
+        theta: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        H = tensor(sigmax(), sigmax()) * (-1j * theta / 2)
         U = H.expm()
         self._apply_unitary(U, [q1, q2], control_qubits_set, is_dagger)
 
-    def yy(self, q1, q2, theta, control_qubits_set = [], is_dagger = False):
-        H = tensor(sigmay(), sigmay()) * (-1j*theta/2)
+    def yy(
+        self,
+        q1: int,
+        q2: int,
+        theta: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        H = tensor(sigmay(), sigmay()) * (-1j * theta / 2)
         U = H.expm()
         self._apply_unitary(U, [q1, q2], control_qubits_set, is_dagger)
 
-    def zz(self, q1, q2, theta, control_qubits_set = [], is_dagger = False):
-        H = tensor(sigmaz(), sigmaz()) * (-1j*theta/2)
+    def zz(
+        self,
+        q1: int,
+        q2: int,
+        theta: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        H = tensor(sigmaz(), sigmaz()) * (-1j * theta / 2)
         U = H.expm()
         self._apply_unitary(U, [q1, q2], control_qubits_set, is_dagger)
 
-    def uu15(self, q1, q2, params, control_qubits_set = [], is_dagger = False):
-        '''uu15 gate using KAK decomposition
+    def phaseflip(self, qubit: int, prob: float) -> None:
+        K0 = np.sqrt(1 - prob) * Qobj([[1, 0], [0, 1]])
+        K1 = np.sqrt(prob) * Qobj([[1, 0], [0, -1]])
+        self._apply_kraus([K0, K1], [qubit])
 
-            U is implemented by
+    # ─────────────────── Two-qubit parametric gates ───────────────────
 
-            U3(q1, parameters[0:3])
-            U3(q2, parameters[3:6])
-            XX(q1, q2, parameters[6])
-            YY(q1, q2, parameters[7])
-            ZZ(q1, q2, parameters[8])
-            U3(q1, parameters[9:12])
-            U3(q2, parameters[12:15])
-
-            where parameters is a list of 15 parameters.
+    def uu15(
+        self,
+        q1: int,
+        q2: int,
+        params: list[float],
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        """U15 gate using KAK decomposition.
 
         Args:
-            q1 (int): qubit 1 index
-            q2 (int): qubit 2 index
-            params (list): list of parameters
-            control_qubits_set (list): list of control qubits
-            is_dagger (bool): whether to apply daggered gate
-        '''
+            q1: qubit 1 index
+            q2: qubit 2 index
+            params: list of 15 parameters
+            control_qubits_set: list of control qubits
+            is_dagger: whether to apply daggered gate
+        """
         if not is_dagger:
             self.u3(q1, *params[0:3], control_qubits_set, False)
             self.u3(q2, *params[3:6], control_qubits_set, False)
@@ -231,23 +416,19 @@ class DensityOperatorSimulatorQutip:
             self.yy(q1, q2, params[7], control_qubits_set, True)
             self.xx(q1, q2, params[6], control_qubits_set, True)
             self.u3(q2, *params[3:6], control_qubits_set, True)
-            self.u3(q1, *params[0:3], control_qubits_set, True)      
-              
-    def phase2q(self, q1, q2, theta1, theta2, theta3, control_qubits_set = [], is_dagger = False):
-        '''  phase2q gate =
-            u1(qn1, theta1),
-            u1(qn2, theta2),
-            zz(qn1, qn2, thetazz)
+            self.u3(q1, *params[0:3], control_qubits_set, True)
 
-        Args:
-            q1 (int): qubit 1 index
-            q2 (int): qubit 2 index
-            theta1 (float): angle of u1 gate on qn1
-            theta2 (float): angle of u1 gate on qn2
-            theta3 (float): angle of zz gate
-            control_qubits_set (list): list of control qubits
-            is_dagger (bool): whether to apply daggered gate
-        '''
+    def phase2q(
+        self,
+        q1: int,
+        q2: int,
+        theta1: float,
+        theta2: float,
+        theta3: float,
+        control_qubits_set: list[int] | None = None,
+        is_dagger: bool = False,
+    ) -> None:
+        """Phase2Q gate: u1(q1, theta1), u1(q2, theta2), zz(q1, q2, theta3)."""
         if not is_dagger:
             self.u1(q1, theta1, control_qubits_set, False)
             self.u1(q2, theta2, control_qubits_set, False)
@@ -256,9 +437,10 @@ class DensityOperatorSimulatorQutip:
             self.zz(q1, q2, theta3, control_qubits_set, True)
             self.u1(q2, theta2, control_qubits_set, True)
             self.u1(q1, theta1, control_qubits_set, True)
-        
-    # 噪声模型
-    def pauli_error_1q(self, qubit, px, py, pz):
+
+    # ─────────────────── Noise models ───────────────────
+
+    def pauli_error_1q(self, qubit: int, px: float, py: float, pz: float) -> None:
         p0 = max(1 - px - py - pz, 0)
         K0 = np.sqrt(p0) * qeye(2)
         K1 = np.sqrt(px) * sigmax()
@@ -266,130 +448,94 @@ class DensityOperatorSimulatorQutip:
         K3 = np.sqrt(pz) * sigmaz()
         self._apply_kraus([K0, K1, K2, K3], [qubit])
 
-    def depolarizing(self, qubit, p):
+    def depolarizing(self, qubit: int, p: float) -> None:
         K0 = np.sqrt(1 - p) * qeye(2)
-        K1 = np.sqrt(p/3) * sigmax()
-        K2 = np.sqrt(p/3) * sigmay()
-        K3 = np.sqrt(p/3) * sigmaz()
+        K1 = np.sqrt(p / 3) * sigmax()
+        K2 = np.sqrt(p / 3) * sigmay()
+        K3 = np.sqrt(p / 3) * sigmaz()
         self._apply_kraus([K0, K1, K2, K3], [qubit])
 
-    def bitflip(self, qubit, p):
+    def bitflip(self, qubit: int, p: float) -> None:
         K0 = np.sqrt(1 - p) * qeye(2)
         K1 = np.sqrt(p) * sigmax()
         self._apply_kraus([K0, K1], [qubit])
 
-    def kraus1q(self, qubit, parameters):
-        kraus_ops = [Qobj(np.array(k).reshape(2,2)) for k in parameters]
+    def kraus1q(self, qubit: int, parameters: list[list[float]]) -> None:
+        kraus_ops = [Qobj(np.array(k).reshape(2, 2)) for k in parameters]
         self._apply_kraus(kraus_ops, [qubit])
 
-    def amplitude_damping(self, qubit, gamma):
+    def amplitude_damping(self, qubit: int, gamma: float) -> None:
         K0 = Qobj([[1, 0], [0, np.sqrt(1 - gamma)]])
         K1 = Qobj([[0, np.sqrt(gamma)], [0, 0]])
         self._apply_kraus([K0, K1], [qubit])
 
-    def kraus2q(self, q1, q2, parameters):
-        kraus_ops = [Qobj(np.array(k).reshape(4,4)) for k in parameters]
+    def kraus2q(self, q1: int, q2: int, parameters: list[list[float]]) -> None:
+        kraus_ops = [Qobj(np.array(k).reshape(4, 4)) for k in parameters]
         self._apply_kraus(kraus_ops, [q1, q2])
 
-    def pauli_error_2q(self, q1, q2, parameters):
-        '''
-        // 解包所有概率参数
-        double xi = p[0], yi = p[1], zi = p[2];
-        double ix = p[3], xx = p[4], yx = p[5], zx = p[6];
-        double iy = p[7], xy = p[8], yy = p[9], zy = p[10];
-        double iz = p[11], xz = p[12], yz = p[13], zz = p[14];
-
-        double sum = xi + yi + zi +
-            ix + xx + yx + zx +
-            iy + xy + yy + zy +
-            iz + xz + yz + zz;
-
-        if (sum > 1)
-            ThrowInvalidArgument("Probabilities must be less than or equal to 1.");
-
-        auto Exi = multiply_scalar(pauli_xi, xi);
-        auto Eyi = multiply_scalar(pauli_yi, yi);
-        auto Ezi = multiply_scalar(pauli_zi, zi);
-
-        auto Eix = multiply_scalar(pauli_ix, ix);
-        auto Exx = multiply_scalar(pauli_xx, xx);
-        auto Eyx = multiply_scalar(pauli_yx, yx);
-        auto Ezx = multiply_scalar(pauli_zx, zx);
-
-        auto Eiy = multiply_scalar(pauli_iy, iy);
-        auto Exy = multiply_scalar(pauli_xy, xy);
-        auto Eyy = multiply_scalar(pauli_yy, yy);
-        auto Ezy = multiply_scalar(pauli_zy, zy);
-
-        auto Eiz = multiply_scalar(pauli_iz, iz);
-        auto Exz = multiply_scalar(pauli_xz, xz);
-        auto Eyz = multiply_scalar(pauli_yz, yz);
-        auto Ezz = multiply_scalar(pauli_zz, zz);
-
-        kraus2q(qn1, qn2, { Exi, Eyi, Ezi, Exx, Eyy, Ezz, Exy, Exz, Eyz, Eix, Eiy, Eiz, Exx, Eyx, Ezx, Exy, Eyy, Ezy, Exz, Eyz, Ezz });
-            
+    def pauli_error_2q(self, q1: int, q2: int, parameters: list[float] | tuple[float, ...]) -> None:
+        """Two-qubit Pauli error with 15 independent probabilities.
 
         Args:
-            q1 (int): qubit 1 index
-            q2 (int): qubit 2 index
-            parameters (list): list of parameters
-        '''
-        
-        # unpack all probabilities
+            q1: qubit 1 index
+            q2: qubit 2 index
+            parameters: list of 15 probabilities
+        """
         parameters = list(parameters)
-
-        # validate probabilities
         if sum(parameters) > 1:
             raise ValueError("Probabilities must be less than or equal to 1.")
-
         ii = [1 - sum(parameters)]
-        parameters = ii + parameters
-        parameters = [np.sqrt(p) for p in parameters]
-        (ii, xi, yi, zi, 
-         ix, xx, yx, zx, 
-         iy, xy, yy, zy, 
-         iz, xz, yz, zz) = tuple(parameters)
-        
-        # create kraus operators
+        all_params = ii + parameters
+        all_params = [np.sqrt(p) for p in all_params]
+        (ii, xi, yi, zi, ix, xx, yx, zx, iy, xy, yy, zy, iz, xz, yz, zz) = tuple(all_params)  # type: ignore[assignment]
+
         Eii = ii * tensor(qeye(2), qeye(2))
         Eix = ix * tensor(sigmax(), qeye(2))
         Eiy = iy * tensor(sigmay(), qeye(2))
         Eiz = iz * tensor(sigmaz(), qeye(2))
-
         Exi = xi * tensor(qeye(2), sigmax())
         Exx = xx * tensor(sigmax(), sigmax())
         Exy = xy * tensor(sigmay(), sigmax())
         Exz = xz * tensor(sigmaz(), sigmax())
-
         Eyi = yi * tensor(qeye(2), sigmay())
         Eyx = yx * tensor(sigmax(), sigmay())
         Eyy = yy * tensor(sigmay(), sigmay())
         Eyz = yz * tensor(sigmaz(), sigmay())
-        
         Ezi = zi * tensor(qeye(2), sigmaz())
         Ezx = zx * tensor(sigmax(), sigmaz())
         Ezy = zy * tensor(sigmay(), sigmaz())
         Ezz = zz * tensor(sigmaz(), sigmaz())
 
         kraus = [
-            Eii, Exi, Eyi, Ezi, 
-            Eix, Exx, Eyx, Ezx, 
-            Eiy, Exy, Eyy, Ezy, 
-            Eiz, Exz, Eyz, Ezz
+            Eii,
+            Exi,
+            Eyi,
+            Ezi,
+            Eix,
+            Exx,
+            Eyx,
+            Ezx,
+            Eiy,
+            Exy,
+            Eyy,
+            Ezy,
+            Eiz,
+            Exz,
+            Eyz,
+            Ezz,
         ]
-
         _validate_kraus_ops(kraus, 2)
-
-        # apply kraus operators
         self._apply_kraus(kraus, [q1, q2])
 
-    def twoqubit_depolarizing(self, q1, q2, p):
-        self.pauli_error_2q(q1, q2, [p/15]*15)
+    def twoqubit_depolarizing(self, q1: int, q2: int, p: float) -> None:
+        self.pauli_error_2q(q1, q2, [p / 15] * 15)
 
-    def pmeasure(self, measure_qubits):
-        # get a partial traced density matrix with respect to the measure_qubits
-        prob_list = [0]*(2**len(measure_qubits))
-        for bits in product([0,1], repeat=len(measure_qubits)):
+    # ─────────────────── Measurement ───────────────────
+
+    def pmeasure(self, measure_qubits: list[int]) -> list[float]:
+        """Compute measurement probabilities for the given qubits."""
+        prob_list = [0.0] * (2 ** len(measure_qubits))
+        for bits in product([0, 1], repeat=len(measure_qubits)):
             proj_list = []
             for q in range(self.n_qubits):
                 if q in measure_qubits:
@@ -399,27 +545,27 @@ class DensityOperatorSimulatorQutip:
                     proj = qeye(2)
                 proj_list.append(proj)
             projector = tensor(proj_list)
-            prob = (self.density_matrix * projector).tr().real
-
-            # convert bit string to integer index
-            bit_idx = int(''.join(map(str, bits)), 2)
+            prob = (self.density_matrix * projector).tr().real  # type: ignore[operator]
+            bit_idx = int("".join(map(str, bits)), 2)
             prob_list[bit_idx] = prob
         return prob_list
-    
-    def stateprob(self):
-        return self.density_matrix.diag().real
-    
+
+    def stateprob(self) -> np.ndarray:
+        """Return the diagonal of the density matrix (state probabilities)."""
+        return self.density_matrix.diag().real  # type: ignore[return-value]
+
     @property
-    def state(self):
-        return self.density_matrix.full()
-    
-if __name__ == '__main__':
+    def state(self) -> np.ndarray:
+        """Return the density matrix as a NumPy array."""
+        return self.density_matrix.full()  # type: ignore[return-value]
+
+
+if __name__ == "__main__":
     sim = DensityOperatorSimulatorQutip()
     sim.init_n_qubit(3)
     sim.x(0)
     sim.cnot(0, 1)
     sim.toffoli(0, 1, 2)
-
     print(sim.density_matrix)
     print(sim.pmeasure([0, 1]))
     print(sim.stateprob())


### PR DESCRIPTION
Restore from accidentally closed PR #80.

Add complete type hints to:
- simulator/error_model.py: all ErrorModel classes annotated
- simulator/qutip_sim_impl.py: DensityOperatorSimulatorQutip annotated
- pyproject.toml: ignore N801/N803/N806 (physics notation)

All ruff checks pass. No business logic changed.

Closes #77