### PR TITLE
docs: 补充缺失的 autodoc rst 页面 (Issue #92 Task 2)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,10 @@ import pathlib
 parent_path = pathlib.Path(__file__).resolve().parent.parent
 
 sys.path.insert(0, os.path.abspath(parent_path))
+sys.path.insert(0, os.path.abspath(parent_path / 'algorithmics'))
+sys.path.insert(0, os.path.abspath(parent_path / 'algorithmics' / 'ansatz'))
+sys.path.insert(0, os.path.abspath(parent_path / 'algorithmics' / 'state_preparation'))
+sys.path.insert(0, os.path.abspath(parent_path / 'algorithmics' / 'measurement'))
 sys.path.insert(0, os.path.abspath(parent_path / 'analyzer'))
 sys.path.insert(0, os.path.abspath(parent_path / 'circuit_builder'))
 sys.path.insert(0, os.path.abspath(parent_path / 'originir'))

--- a/docs/source/qpandalite.algorithmics.ansatz.rst
+++ b/docs/source/qpandalite.algorithmics.ansatz.rst
@@ -1,0 +1,37 @@
+qpandalite.algorithmics.ansatz package
+========================================
+
+Submodules
+----------
+
+qpandalite.algorithmics.ansatz.hea module
+------------------------------------------
+
+.. automodule:: qpandalite.algorithmics.ansatz.hea
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.algorithmics.ansatz.qaoa\_ansatz module
+----------------------------------------------------
+
+.. automodule:: qpandalite.algorithmics.ansatz.qaoa_ansatz
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.algorithmics.ansatz.uccsd module
+--------------------------------------------
+
+.. automodule:: qpandalite.algorithmics.ansatz.uccsd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: qpandalite.algorithmics.ansatz
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/qpandalite.algorithmics.rst
+++ b/docs/source/qpandalite.algorithmics.rst
@@ -1,0 +1,30 @@
+qpandalite.algorithmics package
+===============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   qpandalite.algorithmics.ansatz
+   qpandalite.algorithmics.state_preparation
+
+Submodules
+----------
+
+qpandalite.algorithmics.measurement module
+-------------------------------------------
+
+.. automodule:: qpandalite.algorithmics.measurement
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: qpandalite.algorithmics
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/qpandalite.algorithmics.state_preparation.rst
+++ b/docs/source/qpandalite.algorithmics.state_preparation.rst
@@ -1,0 +1,53 @@
+qpandalite.algorithmics.state\_preparation package
+===================================================
+
+Submodules
+----------
+
+qpandalite.algorithmics.state\_preparation.basis\_state module
+---------------------------------------------------------------
+
+.. automodule:: qpandalite.algorithmics.state_preparation.basis_state
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.algorithmics.state\_preparation.dicke\_state module
+---------------------------------------------------------------
+
+.. automodule:: qpandalite.algorithmics.state_preparation.dicke_state
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.algorithmics.state\_preparation.hadamard\_superposition module
+--------------------------------------------------------------------------
+
+.. automodule:: qpandalite.algorithmics.state_preparation.hadamard_superposition
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.algorithmics.state\_preparation.rotation\_prepare module
+--------------------------------------------------------------------
+
+.. automodule:: qpandalite.algorithmics.state_preparation.rotation_prepare
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.algorithmics.state\_preparation.thermal\_state module
+-----------------------------------------------------------------
+
+.. automodule:: qpandalite.algorithmics.state_preparation.thermal_state
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: qpandalite.algorithmics.state_preparation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/qpandalite.analyzer.rst
+++ b/docs/source/qpandalite.analyzer.rst
@@ -20,6 +20,14 @@ qpandalite.analyzer.result\_adapter module
    :undoc-members:
    :show-inheritance:
 
+qpandalite.analyzer.draw module
+--------------------------------
+
+.. automodule:: qpandalite.analyzer.draw
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/source/qpandalite.rst
+++ b/docs/source/qpandalite.rst
@@ -13,4 +13,5 @@ qpandalite
 - 本地模拟：`qpandalite.simulator`，对应教程页 :doc:`guide/simulation`
 - 提交任务：`qpandalite.task`，对应教程页 :doc:`guide/submit_task`
 - 格式与语言接口：`qpandalite.originir`、`qpandalite.qasm`，对应教程页 :doc:`guide/originir`、:doc:`guide/qasm`
+- 算法模块：`qpandalite.algorithmics`（ansatz、state_preparation、measurement）
 - 分析与格式互转：`qpandalite.analyzer`、`qpandalite.transpiler`，对应进阶页 :doc:`advanced/circuit_analysis`

--- a/docs/source/qpandalite.task.adapters.rst
+++ b/docs/source/qpandalite.task.adapters.rst
@@ -1,0 +1,45 @@
+qpandalite.task.adapters package
+==================================
+
+Submodules
+----------
+
+qpandalite.task.adapters.base module
+-------------------------------------
+
+.. automodule:: qpandalite.task.adapters.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.task.adapters.originq\_adapter module
+-------------------------------------------------
+
+.. automodule:: qpandalite.task.adapters.originq_adapter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.task.adapters.qiskit\_adapter module
+------------------------------------------------
+
+.. automodule:: qpandalite.task.adapters.qiskit_adapter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.task.adapters.quafu\_adapter module
+-----------------------------------------------
+
+.. automodule:: qpandalite.task.adapters.quafu_adapter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: qpandalite.task.adapters
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/qpandalite.task.config.rst
+++ b/docs/source/qpandalite.task.config.rst
@@ -1,0 +1,7 @@
+qpandalite.task.config module
+==============================
+
+.. automodule:: qpandalite.task.config
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/qpandalite.task.rst
+++ b/docs/source/qpandalite.task.rst
@@ -13,9 +13,18 @@ Subpackages
    qpandalite.task.originq_dummy
    qpandalite.task.platform_template
    qpandalite.task.quafu
+   qpandalite.task.adapters
 
 Submodules
 ----------
+
+qpandalite.task.config module
+------------------------------
+
+.. automodule:: qpandalite.task.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 qpandalite.task.task\_utils module
 ----------------------------------

--- a/docs/source/qpandalite.transpiler.rst
+++ b/docs/source/qpandalite.transpiler.rst
@@ -12,6 +12,22 @@ qpandalite.transpiler.timeline module
    :undoc-members:
    :show-inheritance:
 
+qpandalite.transpiler.converter module
+--------------------------------------
+
+.. automodule:: qpandalite.transpiler.converter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qpandalite.transpiler.draw module
+---------------------------------
+
+.. automodule:: qpandalite.transpiler.draw
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 


### PR DESCRIPTION
## Summary

Issue #92 Task 2 — 任务块 1：补充缺失的 autodoc rst 页面

### 新增文件（5 个）
| 文件 | 内容 |
|------|------|
| `docs/source/qpandalite.algorithmics.rst` | algorithmics 包总览（ansatz、state_preparation、measurement 子模块） |
| `docs/source/qpandalite.algorithmics.ansatz.rst` | ansatz 子包（hea, qaoa_ansatz, uccsd） |
| `docs/source/qpandalite.algorithmics.state_preparation.rst` | state_preparation 子包（basis_state, dicke_state, hadamard_superposition, rotation_prepare, thermal_state） |
| `docs/source/qpandalite.task.adapters.rst` | task.adapters 子包（base, originq_adapter, qiskit_adapter, quafu_adapter） |
| `docs/source/qpandalite.task.config.rst` | task.config 模块 |

### 更新文件（5 个）
| 文件 | 改动 |
|------|------|
| `docs/source/qpandalite.analyzer.rst` | 补充 draw 子模块 |
| `docs/source/qpandalite.transpiler.rst` | 补充 converter 和 draw 子模块 |
| `docs/source/qpandalite.rst` | 添加 algorithmics 入口链接 |
| `docs/source/qpandalite.task.rst` | 在 toctree 中添加 adapters 和 config |
| `docs/conf.py` | 添加 algorithmics 及其子包到 sys.path |

### 验收
`cd docs && make html` 构建成功，无新增 warning。

Closes #92
