### PR TITLE
fix: 文档导航与锚点修复

### DIFF
--- a/docs/_static/hide_myst_anchors.js
+++ b/docs/_static/hide_myst_anchors.js
@@ -1,6 +1,15 @@
-/* Hide MyST anchor syntax {#...} from heading text */
-document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('h1, h2, h3, h4, h5, h6, .toc .reference, .toctree .reference').forEach(function(el) {
-        el.innerHTML = el.innerHTML.replace(/\s*\{#[a-zA-Z0-9_-]+\}/g, '');
+/* Hide MyST anchor syntax {#...} from heading text and navigation */
+function removeMystAnchors() {
+    document.querySelectorAll('h1, h2, h3, h4, h5, h6, a, span, .toc .reference, .toctree .reference, .nav-link, .reference.internal').forEach(function(el) {
+        if (el.innerHTML && /\{#[a-zA-Z0-9_-]+\}/.test(el.innerHTML)) {
+            el.innerHTML = el.innerHTML.replace(/\s*\{#[a-zA-Z0-9_-]+\}/g, '');
+        }
     });
-});
+}
+document.addEventListener('DOMContentLoaded', removeMystAnchors);
+// Also run after dynamic content loads (theme navigation)
+if (typeof MutationObserver !== 'undefined') {
+    var observer = new MutationObserver(function() { setTimeout(removeMystAnchors, 100); });
+    observer.observe(document.body, { childList: true, subtree: true });
+    setTimeout(function() { observer.disconnect(); }, 5000);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,7 @@ html_theme_options = {
     "navigation_with_keys": True,
     "show_toc_level": 2,
     "header_links_before_dropdown": 6,
+    "navigation_include_hidden": True,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,27 @@ QPanda-lite 是一个 Python 原生、轻量且强调透明性的量子计算框
 **格式与底层：** :doc:`OriginIR <source/guide/originir>` / :doc:`OpenQASM 2.0 <source/guide/qasm>` / :doc:`进阶分析 <source/advanced/circuit_analysis>` / :doc:`Opcode <source/advanced/opcode>`
 
 .. toctree::
+   :maxdepth: 2
+   :caption: 教程
+
+   source/guide/installation
+   source/guide/quickstart
+   source/guide/circuit
+   source/guide/simulation
+   source/guide/submit_task
+   source/guide/originir
+   source/guide/qasm
+   source/guide/testing
+
+.. toctree::
+   :maxdepth: 2
+   :caption: 进阶
+
+   source/advanced/circuit_analysis
+   source/advanced/opcode
+   source/advanced/noise_simulation
+
+.. toctree::
    :maxdepth: 1
    :caption: API 参考
 
@@ -39,21 +60,10 @@ QPanda-lite 是一个 Python 原生、轻量且强调透明性的量子计算框
    source/qpandalite.algorithmics
    source/qpandalite.task
 
-.. Hidden toctrees so pages remain accessible via :doc: links
+.. Hidden toctrees for sub-module API pages
 .. toctree::
    :hidden:
 
-   source/guide/installation
-   source/guide/quickstart
-   source/guide/circuit
-   source/guide/simulation
-   source/guide/submit_task
-   source/guide/originir
-   source/guide/qasm
-   source/guide/testing
-   source/advanced/circuit_analysis
-   source/advanced/opcode
-   source/advanced/noise_simulation
    source/qpandalite.qcloud_config
    source/qpandalite.algorithmics.ansatz
    source/qpandalite.algorithmics.state_preparation


### PR DESCRIPTION
## 修复内容

### 任务 1：侧边栏导航为空
- `html_theme_options` 添加 `navigation_include_hidden: True`

### 任务 2：导航顺序调整
- index.rst toctree 重排：教程 → 进阶 → API 参考
- guide/advanced 改为可见 toctree（不再 hidden）

### 任务 3：MyST `{#}` 锚点标记
- `hide_myst_anchors.js` 增强：添加 `MutationObserver` 处理动态加载内容
- 扩展选择器覆盖更多导航元素

### 验收
- `make html` 构建成功，56 warnings（不增加）
