### PR TITLE
docs: 文档层级重构 — 分层引导页结构

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,24 +27,21 @@ QPanda-lite 是一个 Python 原生、轻量且强调透明性的量子计算框
 
 .. toctree::
    :maxdepth: 2
-   :caption: 教程
+   :caption: 入门指南
 
-   source/guide/installation
-   source/guide/quickstart
-   source/guide/circuit
-   source/guide/simulation
-   source/guide/submit_task
-   source/guide/originir
-   source/guide/qasm
-   source/guide/testing
+   source/guide
 
 .. toctree::
    :maxdepth: 2
-   :caption: 进阶
+   :caption: 进阶指南
 
-   source/advanced/circuit_analysis
-   source/advanced/opcode
-   source/advanced/noise_simulation
+   source/advanced
+
+.. toctree::
+   :maxdepth: 2
+   :caption: 算法讲解
+
+   source/algorithm
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -1,0 +1,11 @@
+进阶指南
+========
+
+深入理解 QPanda-lite 的高级功能与底层机制。
+
+.. toctree::
+   :maxdepth: 1
+
+   advanced/circuit_analysis
+   advanced/opcode
+   advanced/noise_simulation

--- a/docs/source/algorithm.rst
+++ b/docs/source/algorithm.rst
@@ -1,0 +1,12 @@
+算法讲解
+========
+
+基于 QPanda-lite 实现的典型量子算法示例。
+
+.. toctree::
+   :maxdepth: 1
+
+   algorithm/grover
+   algorithm/qpe
+   algorithm/qaoa
+   algorithm/vqe

--- a/docs/source/algorithm/grover.md
+++ b/docs/source/algorithm/grover.md
@@ -1,0 +1,129 @@
+# Grover's Search Algorithm
+
+## Background and Theory
+
+Grover's search algorithm (Grover, 1996) provides a quadratic speedup for unstructured search.
+Given an oracle $f : \{0,1\}^n \to \{0,1\}$ such that $f(x) = 1$ iff $x$ is the marked
+state $|w\rangle$, Grover's algorithm finds $|w\rangle$ in $O(\sqrt{N})$ oracle calls
+instead of $O(N)$, where $N = 2^n$.
+
+### Key Components
+
+**1. Oracle $U_\omega$**
+Phase-flip oracle that multiplies the amplitude of the marked state by $-1$:
+
+$$U_\omega |x\rangle = (-1)^{f(x)} |x\rangle$$
+
+The standard construction uses an ancilla qubit in the magic state $|-\rangle = (|0\rangle - |1\rangle)/\sqrt{2}$:
+
+$$U_\omega |x\rangle |-\rangle = |x\rangle \otimes (-1)^{f(x)} |-\rangle$$
+
+**2. Diffusion Operator $D$**
+Also called the *amplitude amplification* operator:
+
+$$D = 2|s\rangle\langle s| - I$$
+
+where $|s\rangle = H^{\otimes n}|0\rangle^{\otimes n}$ is the uniform superposition.
+$D$ reflects any vector about $|s\rangle$, transferring amplitude from unmarked
+to marked states.
+
+**3. Grover Iteration**
+The combined oracle + diffusion step:
+
+$$G = D \cdot U_\omega$$
+
+Applied $R \approx \frac{\pi}{4}\sqrt{N}$ times to $|s\rangle$, this concentrates
+the amplitude on the marked state.
+
+### State Evolution
+
+Starting from $|s\rangle = \frac{1}{\sqrt{N}} \sum_x |x\rangle$:
+
+After one Grover iteration, the state is in a 2D subspace spanned by $\{|w\rangle, |s'\rangle\}$
+where $|s'\rangle$ is the superposition over all non-marked states.
+
+The amplitude on $|w\rangle$ grows as $\sin((2R+1)\theta)$ where $\sin\theta = 1/\sqrt{N}$.
+
+## Code Walkthrough
+
+### `build_oracle`
+
+```python
+def build_oracle(n_qubits, marked_state):
+```
+
+Builds the phase-flip oracle for the given marked state:
+
+1. **Ancilla preparation**: Initialise ancilla qubit to $|-\rangle = X \cdot H |0\rangle$
+2. **Marked-state encoding**: Flip data qubits that are $|0\rangle$ in the marked state
+3. **Phase kickback**: Apply multi-controlled Z (CCZ) from data qubits to ancilla
+4. **Uncompute**: Restore the flipped qubits
+
+### `build_diffusion`
+
+Implements $D = H^{\otimes n} \cdot Z^{\otimes n} \cdot H^{\otimes n}$:
+
+1. Apply $H^{\otimes n}$ to convert $|s\rangle \to |0\rangle^{\otimes n}$
+2. Apply $Z^{\otimes n}$ to flip the phase of $|0\rangle^{\otimes n}$
+3. Apply $H^{\otimes n}$ again — net effect is reflection about $|s\rangle$
+
+### `run_grover`
+
+End-to-end Grover search:
+
+1. Initialise data qubits to $|+\rangle$ (Hadamard on $|0\rangle$)
+2. Apply optimal number $R = \lfloor \frac{\pi}{4}\sqrt{N} \rfloor$ of Grover iterations
+3. Measure all data qubits
+
+## Running the Example
+
+```bash
+# Basic run with 3 qubits, marked state = 5
+python examples/algorithms/grover.py --n-qubits 3 --marked-state 5
+
+# Larger search space
+python examples/algorithms/grover.py --n-qubits 4 --marked-state 10 --shots 8192
+```
+
+Expected output:
+```
+ Grover's Search — 3 data qubits
+ Marked state: 5 (101)
+ Search space: 8 states
+
+ Results (top 5 most probable states):
+   |101⟩  95.2% ← TARGET
+   |010⟩   1.8%
+   |000⟩   1.2%
+   |110⟩   0.8%
+   |001⟩   0.6%
+
+ Target probability: 95.2%
+ Expected (ideal): ~95.0% (after optimal iterations)
+```
+
+## Design Notes
+
+- **Ancilla qubit**: One extra qubit is used for the oracle to enable phase kickback.
+  This is the standard "auxiliary qubit" approach and works for any number of qubits.
+- **Multi-controlled Z**: For 2-qubit case, `ccx` (Toffoli) with a final Z implements CCZ.
+  For >2 qubits, a linear-depth CNOT cascade with H on the target implements MCZ.
+- **Optimal iterations**: The iteration count $R = \lfloor \frac{\pi}{4}\sqrt{N} \rfloor$
+  maximises the success probability. For small $N$, rounding and a small cap
+  prevent overshooting.
+- **Measurement**: Only the data qubits are measured (ancilla is not measured).
+
+## Extension Ideas
+
+- **Multi-target Grover**: Replace single target with $M$ marked states;
+  optimal iterations become $\frac{\pi}{4}\sqrt{N/M}$
+- **Inhomogeneous Grover**: Different oracle strengths per state
+- **Amplitude estimation**: Use `state_tomography` to characterise the
+  pre-measurement state and estimate success probability analytically
+
+## References
+
+- Grover, L. K. (1996). "A fast quantum mechanical algorithm for database search."
+  STOC '96. https://arxiv.org/abs/quant-ph/9605043
+- Brassard, G., Høyer, P., Mosca, M., & Tapp, A. (2002). "Quantum Amplitude Amplification
+  and Estimation." AMS. https://arxiv.org/abs/quant-ph/0005055

--- a/docs/source/algorithm/qaoa.md
+++ b/docs/source/algorithm/qaoa.md
@@ -1,0 +1,107 @@
+# Quantum Approximate Optimization Algorithm (QAOA)
+
+## Background and Theory
+
+QAOA (Farhi et al., 2014) is a hybrid quantum-classical algorithm for solving
+combinatorial optimisation problems. It approximates the solution by applying
+alternating layers of cost and mixer unitaries.
+
+### MaxCut Problem
+
+Given a graph $G = (V, E)$, MaxCut seeks a partition of $V$ into two sets
+that maximises the number of edges crossing the partition.
+
+**Cost Hamiltonian:**
+
+$$H_C = -\frac{1}{2} \sum_{(i,j) \in E} (1 - Z_i Z_j)$$
+
+Maximising $-H_C$ is equivalent to maximising the cut.
+
+### QAOA Ansatz
+
+The QAOA state is prepared as:
+
+$$|\psi(\boldsymbol{\beta}, \boldsymbol{\gamma})\rangle
+= \prod_{l=1}^{p} e^{-i\beta_l H_M} e^{-i\gamma_l H_C} |+\rangle^{\otimes n}$$
+
+where $H_M = \sum_i X_i$ is the mixer Hamiltonian, and $p$ is the number of
+layers (higher $p$ → better approximation).
+
+### Algorithm Flow
+
+```
+Initialise |+⟩⊗n → Apply e^{-iγ₁ Hc} → Apply e^{-iβ₁ Hm} → ... → Measure ⟨Hc⟩
+                     ↑                                                    ↓
+                     └──────── Classical optimiser (update β, γ) ←───────┘
+```
+
+### Components Used
+
+| Component | Module | Role |
+|-----------|--------|------|
+| `qaoa_ansatz` | `algorithmics.ansatz` | Parameterised QAOA circuit |
+| `OriginIR_Simulator` | `simulator` | Statevector simulation |
+
+## Running the Example
+
+```bash
+# Default: p=2 layers, triangle graph
+python examples/algorithms/qaoa.py
+
+# More layers
+python examples/algorithms/qaoa.py -p 3
+
+# More iterations
+python examples/algorithms/qaoa.py -p 2 --maxiter 200
+```
+
+## Code Walkthrough
+
+### 1. Define the cost Hamiltonian
+
+```python
+def maxcut_hamiltonian(edges, n_nodes):
+    terms = []
+    for i, j in edges:
+        terms.append((f"Z{i}Z{j}", 0.5))
+    return terms
+```
+
+### 2. Build the ansatz
+
+```python
+from qpandalite.algorithmics.ansatz import qaoa_ansatz
+
+circuit = qaoa_ansatz(
+    cost_hamiltonian=[("Z0Z1", 0.5), ("Z1Z2", 0.5), ("Z0Z2", 0.5)],
+    p=2,
+    betas=[0.5, 0.3],
+    gammas=[0.7, 0.2],
+)
+```
+
+### 3. Evaluate and optimise
+
+The energy $\langle H_C \rangle$ is computed from the statevector and
+fed to a coordinate-descent optimiser.
+
+### Expected Results
+
+For a triangle graph (3 edges):
+- Optimal cut: 2 edges (partition one vertex from the other two)
+- QAOA with $p=2$ should achieve the optimal cut with high probability
+
+## Extensions
+
+- **Weighted MaxCut**: Add edge weights to the Hamiltonian.
+- **Different graphs**: Try random graphs, planar graphs, etc.
+- **Higher $p$**: More layers improve approximation ratio toward 1.0.
+- **Shot-based**: Use `QASM_Simulator` for realistic noisy measurement.
+
+## References
+
+1. Farhi, E., Goldstone, J., & Gutmann, S. (2014). "A Quantum Approximate
+   Optimization Algorithm." arXiv:1411.4028.
+2. Zhou, L. et al. (2020). "Quantum Approximate Optimization Algorithm:
+   Performance, Mechanism, and Implementation on Near-Term Devices."
+   *Frontiers in Physics* 10, 585524.

--- a/docs/source/algorithm/qpe.md
+++ b/docs/source/algorithm/qpe.md
@@ -1,0 +1,116 @@
+# Quantum Phase Estimation (QPE)
+
+## Background and Theory
+
+Quantum Phase Estimation (QPE) estimates the eigenvalue phase of a unitary operator.
+Given a unitary $U$ and one of its eigenstates $|\psi\rangle$:
+
+$$U|\psi\rangle = e^{2\pi i\varphi}|\psi\rangle$$
+
+QPE outputs $\varphi \in [0, 1)$ to $n$-bit precision using $n$ precision qubits.
+
+### The Algorithm
+
+**Step 1 — Prepare the eigenstate** on $m$ system qubits:
+$$|\psi\rangle = \sum_x \alpha_x |x\rangle$$
+
+**Step 2 — Create superposition** on $n$ precision qubits:
+$$H^{\otimes n}|0\rangle^{\otimes n} = \frac{1}{\sqrt{2^n}}\sum_{k=0}^{2^n-1}|k\rangle$$
+
+**Step 3 — Controlled powers of $U$**: for each precision qubit $k$ (value $2^{n-k-1}$):
+$$C-U^{2^{n-k-1}}: \frac{1}{\sqrt{2^n}}\sum_{k,j}|k\rangle|j\rangle \to \frac{1}{\sqrt{2^n}}\sum_{k,j}e^{2\pi i\varphi k \cdot 2^{n-k-1}}|k\rangle|j\rangle$$
+
+**Step 4 — Inverse QFT** on the precision register:
+$$\text{QFT}^{\dagger}\left(\sum_k e^{2\pi i\varphi k}|k\rangle\right) \approx |\tilde{\varphi}\rangle$$
+where $\tilde{\varphi}$ is the binary representation of $\varphi$.
+
+### Inverse QFT (QFTdagger)
+
+The QFT transforms $|x\rangle \to \frac{1}{\sqrt{N}}\sum_k e^{2\pi ixk/N}|k\rangle$.
+QFTdagger is its inverse — implemented by reversing the QFT circuit with adjoint rotation angles.
+
+### Accuracy
+
+With $n$ precision qubits, QPE achieves precision $\pm 1/2^n$ with probability approaching 1
+for the most significant bits. The algorithm requires the eigenstate to be provided
+as input (it does not find eigenstates).
+
+## Code Walkthrough
+
+### `apply_cu1`
+
+Implements $CU_1(\theta)$ where $U_1(\theta) = \text{diag}(1, e^{i\theta})$:
+$$CU_1(\theta) = \begin{pmatrix}1&0&0&0\\0&1&0&0\\0&0&1&0\\0&0&0&e^{i\theta}\end{pmatrix}$$
+
+Decomposition:
+$$CU_1(\theta) = u_1(\theta/2) \cdot CX \cdot u_1(-\theta/2) \cdot CX$$
+
+### `apply_qft_dagger`
+
+Inverse QFT circuit for the precision register:
+- Cascade of $CU_1(-\pi/2^{j-i})$ gates in reverse order
+- Followed by Hadamard on each qubit
+
+### `build_qpe_circuit`
+
+1. Prepare the eigenstate on system qubits (defaults to $|0\rangle^{\otimes m}$)
+2. Apply $H^{\otimes n}$ on precision qubits for uniform superposition
+3. For each precision qubit $k$: apply $U^{2^k}$ controlled by that qubit
+4. Apply QFTdagger on precision qubits
+5. Measure the precision register
+
+## Running the Example
+
+```bash
+# Estimate the phase of the T gate (phase = π/8 ≈ 0.3927)
+python examples/algorithms/qpe.py --n-precision 4 --unitary t
+
+# Estimate Z-gate phase (eigenvalue = -1, so phase = 0.5)
+python examples/algorithms/qpe.py --n-precision 4 --unitary z
+
+# More precision qubits
+python examples/algorithms/qpe.py --n-precision 6 --unitary t --shots 8192
+```
+
+Expected output:
+```
+ Quantum Phase Estimation
+ Precision qubits: 4
+ Phase precision:  1/16 = 0.0625
+ Unitary: t
+
+ Measurement results:
+   |0110⟩  prob= 94.2%  phase=0.3750 ← most likely
+   |0101⟩   prob=  2.1%  phase=0.3125
+   |0111⟩   prob=  1.8%  phase=0.4375
+
+ Estimated phase:  0.3750
+ True phase:       0.3927
+ Absolute error:   0.0177
+  ✓ QPE complete.
+```
+
+## Design Notes
+
+- **Eigenstate input**: QPE requires a *known* eigenstate. For non-diagonal unitaries,
+  the output is a superposition of phases corresponding to the eigenstate decomposition.
+- **Controlled unitaries**: For diagonal $U$, controlled-$U$ is implemented as
+  $CU_1$ gates encoding the phase angles. The cascade decomposition handles
+  multi-qubit phase encoding.
+- **Binary phase encoding**: QPE treats the precision register as a binary fraction
+  $\varphi = \sum_k b_k / 2^k$. The estimated integer $m$ from measurement gives
+  $\tilde{\varphi} = m / 2^n$.
+
+## Extension Ideas
+
+- **HHL Algorithm**: Use QPE as the core of the quantum linear systems solver
+- **Iterative QPE (IQPE)**: Reduce qubit count by measuring and re-using one qubit
+  per iteration
+- **Quantum counting**: Combine Grover search with QPE to count marked states
+
+## References
+
+- Nielsen, M. A., & Chuang, I. L. (2010). *Quantum Computation and Quantum Information*.
+  Cambridge University Press. Chapter 5.
+- Cleve, R., Ekert, A., Macchiavello, C., & Mosca, M. (1998). "Quantum algorithms
+  revisited." Proc. R. Soc. A. https://arxiv.org/abs/quant-ph/9708016

--- a/docs/source/algorithm/vqe.md
+++ b/docs/source/algorithm/vqe.md
@@ -1,0 +1,117 @@
+# Variational Quantum Eigensolver (VQE)
+
+## Background and Theory
+
+The Variational Quantum Eigensolver (VQE) is a hybrid quantum-classical algorithm
+for finding the ground-state energy of molecular Hamiltonians. It was first
+demonstrated by Peruzzo et al. (2014).
+
+### Core Idea
+
+VQE exploits the **variational principle**: for any parameterised trial state
+$|\psi(\boldsymbol{\theta})\rangle$,
+
+$$\langle\psi(\boldsymbol{\theta})|H|\psi(\boldsymbol{\theta})\rangle
+\geq E_0$$
+
+where $E_0$ is the true ground-state energy. By minimising the energy
+expectation value over $\boldsymbol{\theta}$, we approach $E_0$.
+
+### Algorithm Flow
+
+```
+┌─────────────┐    ┌──────────────┐    ┌──────────────┐
+│  Prepare     │───▶│  Measure      │───▶│  Classical    │
+│  |ψ(θ)⟩      │    │  ⟨ψ|H|ψ⟩     │    │  Optimiser    │
+│  (ansatz)    │    │  (expectation)│    │  (update θ)   │
+└─────────────┘    └──────────────┘    └──────────────┘
+       ▲                                       │
+       └───────────────────────────────────────┘
+                    repeat until convergence
+```
+
+1. **Ansatz**: Prepare $|\psi(\boldsymbol{\theta})\rangle$ using a parameterised
+   circuit (e.g., UCCSD).
+2. **Measurement**: Estimate $\langle H \rangle = \sum_i h_i \langle P_i \rangle$
+   by measuring each Pauli string.
+3. **Classical optimisation**: Update $\boldsymbol{\theta}$ to minimise energy.
+
+### Components Used
+
+| Component | Module | Role |
+|-----------|--------|------|
+| `uccsd_ansatz` | `algorithmics.ansatz` | Parameterised trial state |
+| `pauli_expectation` | `algorithmics.measurement` | Energy measurement |
+| `OriginIR_Simulator` | `simulator` | Statevector simulation |
+
+### H₂ Molecule
+
+This example solves for the ground state of H₂ in a minimal STO-3G basis
+(4 spin-orbitals, 2 electrons). The Hamiltonian is Bravyi–Kitaev mapped:
+
+$$H = \sum_i h_i P_i + E_{\text{nuclear}}$$
+
+**Expected result**: $E_0 \approx -1.137$ Ha (exact FCI).
+
+## Running the Example
+
+```bash
+# Default: H₂, 100 iterations
+python examples/algorithms/vqe.py
+
+# Custom iterations
+python examples/algorithms/vqe.py --maxiter 200
+```
+
+## Code Walkthrough
+
+### 1. Define the Hamiltonian
+
+```python
+H2_HAMILTONIAN = [
+    ("I0", -0.8105),
+    ("Z0", +0.1720),
+    ("Z0Z1", +0.1205),
+    ("X0X1Y2Y3", -0.0455),
+    # ... more terms
+]
+```
+
+### 2. Build the ansatz
+
+```python
+from qpandalite.algorithmics.ansatz import uccsd_ansatz
+
+circuit = uccsd_ansatz(n_qubits=4, n_electrons=2, params=theta)
+```
+
+UCCSD generates single and double excitation gates parameterised by $\boldsymbol{\theta}$.
+
+### 3. Evaluate energy
+
+```python
+energy = sum(
+    coeff * expectation_value(pauli_str, circuit)
+    for pauli_str, coeff in hamiltonian
+)
+```
+
+### 4. Optimise
+
+A simple coordinate-descent optimiser updates each parameter to minimise energy.
+In production, use scipy's `COBYLA` or `SLSQP`.
+
+## Extensions
+
+- **Larger molecules**: Extend to LiH, BeH₂, H₂O by expanding the Hamiltonian.
+- **Better ansätze**: Try Hardware-Efficient Ansatz (`hea`) for NISQ devices.
+- **Noise mitigation**: Use `classical_shadow` for efficient measurement.
+- **Shot-based simulation**: Replace statevector with `QASM_Simulator` for
+  realistic measurement statistics.
+
+## References
+
+1. Peruzzo, A. et al. (2014). "A variational eigenvalue solver on a photonic
+   quantum processor." *Nature Communications* 5, 4213.
+2. McClean, J. R. et al. (2016). "The theory of variational hybrid
+   quantum-classical algorithms." *New Journal of Physics* 18, 023023.

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -1,0 +1,40 @@
+入门指南
+========
+
+从安装到上手，覆盖 QPanda-lite 的核心使用流程。
+
+安装与快速开始
+--------------
+
+.. toctree::
+   :maxdepth: 1
+
+   guide/installation
+   guide/quickstart
+
+核心操作
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   guide/circuit
+   guide/simulation
+   guide/submit_task
+
+格式互转与语言接口
+------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   guide/originir
+   guide/qasm
+
+质量保证
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   guide/testing


### PR DESCRIPTION
## 修复内容

### 任务块 1：创建 guide.rst（入门指南入口）
- 4 个子分类 toctree：安装与快速开始 / 核心操作 / 格式互转 / 质量保证

### 任务块 2：创建 advanced.rst（进阶指南入口）
- circuit_analysis / opcode / noise_simulation

### 任务块 3：创建 algorithm.rst + 迁移算法文档
- 从 `examples/algorithms/` 迁移 4 个 md 文件到 `docs/source/algorithm/`
  - grover.md、qpe.md、qaoa.md、vqe.md

### 任务块 4：简化 index.rst
- 4 个顶层入口：入门指南 → 进阶指南 → 算法讲解 → API 参考

### 结构
```
index.rst
├── source/guide.rst（入门）
├── source/advanced.rst（进阶）
├── source/algorithm.rst（算法）
└── source/qpandalite_api（API 参考，不变）
```

### 验收
- `make html` 构建成功，0-1 warnings
