### PR TITLE
docs: translate algorithm docs to Chinese

### DIFF
--- a/docs/source/algorithm/grover.md
+++ b/docs/source/algorithm/grover.md
@@ -1,50 +1,48 @@
-# Grover's Search Algorithm
+# Grover 搜索算法
 
-## Background and Theory
+## 背景与理论
 
-Grover's search algorithm (Grover, 1996) provides a quadratic speedup for unstructured search.
-Given an oracle $f : \{0,1\}^n \to \{0,1\}$ such that $f(x) = 1$ iff $x$ is the marked
-state $|w\rangle$, Grover's algorithm finds $|w\rangle$ in $O(\sqrt{N})$ oracle calls
-instead of $O(N)$, where $N = 2^n$.
+Grover 搜索算法（Grover, 1996）为非结构化搜索提供了二次加速。
+给定一个预言机 $f : \{0,1\}^n \to \{0,1\}$，满足 $f(x) = 1$ 当且仅当 $x$ 是目标态 $|w\rangle$，
+Grover 算法只需 $O(\sqrt{N})$ 次预言机调用即可找到 $|w\rangle$，
+而非经典算法所需的 $O(N)$ 次，其中 $N = 2^n$。
 
-### Key Components
+### 核心组件
 
-**1. Oracle $U_\omega$**
-Phase-flip oracle that multiplies the amplitude of the marked state by $-1$:
+**1. 预言机 $U_\omega$**
+相位翻转预言机，将目标态的振幅乘以 $-1$：
 
 $$U_\omega |x\rangle = (-1)^{f(x)} |x\rangle$$
 
-The standard construction uses an ancilla qubit in the magic state $|-\rangle = (|0\rangle - |1\rangle)/\sqrt{2}$:
+标准构造使用一个处于魔术态 $|-\rangle = (|0\rangle - |1\rangle)/\sqrt{2}$ 的辅助比特：
 
 $$U_\omega |x\rangle |-\rangle = |x\rangle \otimes (-1)^{f(x)} |-\rangle$$
 
-**2. Diffusion Operator $D$**
-Also called the *amplitude amplification* operator:
+**2. 扩散算子 $D$**
+也称为*振幅放大*算子：
 
 $$D = 2|s\rangle\langle s| - I$$
 
-where $|s\rangle = H^{\otimes n}|0\rangle^{\otimes n}$ is the uniform superposition.
-$D$ reflects any vector about $|s\rangle$, transferring amplitude from unmarked
-to marked states.
+其中 $|s\rangle = H^{\otimes n}|0\rangle^{\otimes n}$ 是均匀叠加态。
+$D$ 将任意向量关于 $|s\rangle$ 做反射，将非目标态的振幅转移到目标态。
 
-**3. Grover Iteration**
-The combined oracle + diffusion step:
+**3. Grover 迭代**
+组合的预言机 + 扩散步：
 
 $$G = D \cdot U_\omega$$
 
-Applied $R \approx \frac{\pi}{4}\sqrt{N}$ times to $|s\rangle$, this concentrates
-the amplitude on the marked state.
+对 $|s\rangle$ 施加 $R \approx \frac{\pi}{4}\sqrt{N}$ 次后，振幅将集中于目标态。
 
-### State Evolution
+### 状态演化
 
-Starting from $|s\rangle = \frac{1}{\sqrt{N}} \sum_x |x\rangle$:
+从 $|s\rangle = \frac{1}{\sqrt{N}} \sum_x |x\rangle$ 出发：
 
-After one Grover iteration, the state is in a 2D subspace spanned by $\{|w\rangle, |s'\rangle\}$
-where $|s'\rangle$ is the superposition over all non-marked states.
+经过一次 Grover 迭代后，状态处于由 $\{|w\rangle, |s'\rangle\}$ 张成的二维子空间中，
+其中 $|s'\rangle$ 是所有非目标态的叠加。
 
-The amplitude on $|w\rangle$ grows as $\sin((2R+1)\theta)$ where $\sin\theta = 1/\sqrt{N}$.
+$|w\rangle$ 上的振幅按 $\sin((2R+1)\theta)$ 增长，其中 $\sin\theta = 1/\sqrt{N}$。
 
-## Code Walkthrough
+## 代码解析
 
 ### `build_oracle`
 
@@ -52,40 +50,40 @@ The amplitude on $|w\rangle$ grows as $\sin((2R+1)\theta)$ where $\sin\theta = 1
 def build_oracle(n_qubits, marked_state):
 ```
 
-Builds the phase-flip oracle for the given marked state:
+为给定目标态构建相位翻转预言机：
 
-1. **Ancilla preparation**: Initialise ancilla qubit to $|-\rangle = X \cdot H |0\rangle$
-2. **Marked-state encoding**: Flip data qubits that are $|0\rangle$ in the marked state
-3. **Phase kickback**: Apply multi-controlled Z (CCZ) from data qubits to ancilla
-4. **Uncompute**: Restore the flipped qubits
+1. **辅助比特准备**：将辅助比特初始化为 $|-\rangle = X \cdot H |0\rangle$
+2. **目标态编码**：翻转目标态中处于 $|0\rangle$ 的数据比特
+3. **相位回踢**：从数据比特到辅助比特施加多控 Z（CCZ）
+4. **逆计算**：恢复之前翻转的比特
 
 ### `build_diffusion`
 
-Implements $D = H^{\otimes n} \cdot Z^{\otimes n} \cdot H^{\otimes n}$:
+实现 $D = H^{\otimes n} \cdot Z^{\otimes n} \cdot H^{\otimes n}$：
 
-1. Apply $H^{\otimes n}$ to convert $|s\rangle \to |0\rangle^{\otimes n}$
-2. Apply $Z^{\otimes n}$ to flip the phase of $|0\rangle^{\otimes n}$
-3. Apply $H^{\otimes n}$ again — net effect is reflection about $|s\rangle$
+1. 施加 $H^{\otimes n}$ 将 $|s\rangle \to |0\rangle^{\otimes n}$
+2. 施加 $Z^{\otimes n}$ 翻转 $|0\rangle^{\otimes n}$ 的相位
+3. 再次施加 $H^{\otimes n}$——净效果是关于 $|s\rangle$ 的反射
 
 ### `run_grover`
 
-End-to-end Grover search:
+端到端的 Grover 搜索：
 
-1. Initialise data qubits to $|+\rangle$ (Hadamard on $|0\rangle$)
-2. Apply optimal number $R = \lfloor \frac{\pi}{4}\sqrt{N} \rfloor$ of Grover iterations
-3. Measure all data qubits
+1. 将数据比特初始化为 $|+\rangle$（对 $|0\rangle$ 施加 Hadamard）
+2. 施加最优迭代次数 $R = \lfloor \frac{\pi}{4}\sqrt{N} \rfloor$ 次 Grover 迭代
+3. 测量所有数据比特
 
-## Running the Example
+## 运行示例
 
 ```bash
-# Basic run with 3 qubits, marked state = 5
+# 基本运行：3 个比特，目标态 = 5
 python examples/algorithms/grover.py --n-qubits 3 --marked-state 5
 
-# Larger search space
+# 更大的搜索空间
 python examples/algorithms/grover.py --n-qubits 4 --marked-state 10 --shots 8192
 ```
 
-Expected output:
+预期输出：
 ```
  Grover's Search — 3 data qubits
  Marked state: 5 (101)
@@ -102,24 +100,18 @@ Expected output:
  Expected (ideal): ~95.0% (after optimal iterations)
 ```
 
-## Design Notes
+## 设计说明
 
-- **Ancilla qubit**: One extra qubit is used for the oracle to enable phase kickback.
-  This is the standard "auxiliary qubit" approach and works for any number of qubits.
-- **Multi-controlled Z**: For 2-qubit case, `ccx` (Toffoli) with a final Z implements CCZ.
-  For >2 qubits, a linear-depth CNOT cascade with H on the target implements MCZ.
-- **Optimal iterations**: The iteration count $R = \lfloor \frac{\pi}{4}\sqrt{N} \rfloor$
-  maximises the success probability. For small $N$, rounding and a small cap
-  prevent overshooting.
-- **Measurement**: Only the data qubits are measured (ancilla is not measured).
+- **辅助比特**：预言机使用一个额外的辅助比特来实现相位回踢。这是标准的"辅助比特"方法，适用于任意数量的比特。
+- **多控 Z 门**：对于 2 比特情况，使用 `ccx`（Toffoli）加末尾的 Z 门实现 CCZ。对于超过 2 个比特，使用线性深度的 CNOT 级联配合目标比特上的 H 门来实现 MCZ。
+- **最优迭代次数**：迭代次数 $R = \lfloor \frac{\pi}{4}\sqrt{N} \rfloor$ 可最大化成功概率。对于较小的 $N$，取整和上限可以防止过冲。
+- **测量**：仅测量数据比特（辅助比特不测量）。
 
-## Extension Ideas
+## 扩展方向
 
-- **Multi-target Grover**: Replace single target with $M$ marked states;
-  optimal iterations become $\frac{\pi}{4}\sqrt{N/M}$
-- **Inhomogeneous Grover**: Different oracle strengths per state
-- **Amplitude estimation**: Use `state_tomography` to characterise the
-  pre-measurement state and estimate success probability analytically
+- **多目标 Grover**：将单个目标替换为 $M$ 个目标态；最优迭代次数变为 $\frac{\pi}{4}\sqrt{N/M}$
+- **非均匀 Grover**：对每个状态使用不同的预言机强度
+- **振幅估计**：使用 `state_tomography` 表征测量前的状态，并解析地估计成功概率
 
 ## References
 

--- a/docs/source/algorithm/hadamard_superposition.md
+++ b/docs/source/algorithm/hadamard_superposition.md
@@ -1,42 +1,39 @@
-# Hadamard Superposition State Preparation
+# Hadamard 叠加态制备
 
-## Background
+## 背景
 
-The Hadamard gate $H$ creates an equal superposition from a computational basis state:
+Hadamard 门 $H$ 从计算基态创建等概率叠加态：
 
 $$H|0\rangle = \frac{|0\rangle + |1\rangle}{\sqrt{2}} = |+\rangle$$
 
-Applying Hadamard on all $n$ qubits produces the uniform superposition:
+对所有 $n$ 个比特施加 Hadamard 门可产生均匀叠加态：
 
 $$H^{\otimes n}|0\rangle^{\otimes n} = \frac{1}{\sqrt{2^n}} \sum_{x=0}^{2^n-1} |x\rangle$$
 
-This is one of the most fundamental quantum states, used as the starting point for
-Grover's search, QAOA, Deutsch-Jozsa, and many other algorithms.
+这是最基本的量子态之一，被用作 Grover 搜索、QAOA、Deutsch-Jozsa 等众多算法的起始态。
 
-## Running the Example
+## 运行示例
 
 ```bash
 python examples/state_preparation/hadamard_superposition.py --n-qubits 3
 ```
 
-## Code Walkthrough
+## 代码解析
 
 ```python
 from qpandalite.algorithmics.state_preparation import hadamard_superposition
 
 c = Circuit()
 hadamard_superposition(c, qubits=[0, 1, 2])
-# Circuit now has H gates on all specified qubits
+# 电路现在在所有指定比特上都有 H 门
 ```
 
-### Key Features
+### 主要特性
 
-- **Subset selection**: Apply Hadamard only to specific qubits while leaving
-  others in $|0\rangle$.
-- **Automatic allocation**: Qubits are allocated automatically based on the
-  specified indices.
+- **子集选择**：仅对特定比特施加 Hadamard 门，其余比特保持在 $|0\rangle$。
+- **自动分配**：根据指定的索引自动分配比特。
 
-## Output
+## 输出
 
-The demo prints the statevector amplitudes and probability distribution,
-verifying that all amplitudes have equal magnitude $1/\sqrt{2^n}$.
+示例程序打印态矢量振幅和概率分布，
+验证所有振幅具有相等的幅值 $1/\sqrt{2^n}$。

--- a/docs/source/algorithm/qaoa.md
+++ b/docs/source/algorithm/qaoa.md
@@ -1,63 +1,61 @@
-# Quantum Approximate Optimization Algorithm (QAOA)
+# 量子近似优化算法（QAOA）
 
-## Background and Theory
+## 背景与理论
 
-QAOA (Farhi et al., 2014) is a hybrid quantum-classical algorithm for solving
-combinatorial optimisation problems. It approximates the solution by applying
-alternating layers of cost and mixer unitaries.
+QAOA（Farhi 等人，2014）是一种用于求解组合优化问题的量子-经典混合算法。
+它通过交替施加代价酉和混合酉来逼近最优解。
 
-### MaxCut Problem
+### MaxCut 问题
 
-Given a graph $G = (V, E)$, MaxCut seeks a partition of $V$ into two sets
-that maximises the number of edges crossing the partition.
+给定图 $G = (V, E)$，MaxCut 寻求将 $V$ 划分为两个集合，
+使得跨越分割的边数最大化。
 
-**Cost Hamiltonian:**
+**代价哈密顿量：**
 
 $$H_C = -\frac{1}{2} \sum_{(i,j) \in E} (1 - Z_i Z_j)$$
 
-Maximising $-H_C$ is equivalent to maximising the cut.
+最大化 $-H_C$ 等价于最大化切割数。
 
-### QAOA Ansatz
+### QAOA 拟设
 
-The QAOA state is prepared as:
+QAOA 态的制备方式为：
 
 $$|\psi(\boldsymbol{\beta}, \boldsymbol{\gamma})\rangle
 = \prod_{l=1}^{p} e^{-i\beta_l H_M} e^{-i\gamma_l H_C} |+\rangle^{\otimes n}$$
 
-where $H_M = \sum_i X_i$ is the mixer Hamiltonian, and $p$ is the number of
-layers (higher $p$ → better approximation).
+其中 $H_M = \sum_i X_i$ 是混合哈密顿量，$p$ 是层数（$p$ 越大 → 近似效果越好）。
 
-### Algorithm Flow
+### 算法流程
 
 ```
-Initialise |+⟩⊗n → Apply e^{-iγ₁ Hc} → Apply e^{-iβ₁ Hm} → ... → Measure ⟨Hc⟩
+初始化 |+⟩⊗n → 施加 e^{-iγ₁ Hc} → 施加 e^{-iβ₁ Hm} → ... → 测量 ⟨Hc⟩
                      ↑                                                    ↓
-                     └──────── Classical optimiser (update β, γ) ←───────┘
+                     └──────── 经典优化器（更新 β, γ） ←────────────────┘
 ```
 
-### Components Used
+### 使用的组件
 
-| Component | Module | Role |
+| 组件 | 模块 | 功能 |
 |-----------|--------|------|
-| `qaoa_ansatz` | `algorithmics.ansatz` | Parameterised QAOA circuit |
-| `OriginIR_Simulator` | `simulator` | Statevector simulation |
+| `qaoa_ansatz` | `algorithmics.ansatz` | 参数化 QAOA 电路 |
+| `OriginIR_Simulator` | `simulator` | 态矢量模拟 |
 
-## Running the Example
+## 运行示例
 
 ```bash
-# Default: p=2 layers, triangle graph
+# 默认：p=2 层，三角形图
 python examples/algorithms/qaoa.py
 
-# More layers
+# 更多层数
 python examples/algorithms/qaoa.py -p 3
 
-# More iterations
+# 更多迭代次数
 python examples/algorithms/qaoa.py -p 2 --maxiter 200
 ```
 
-## Code Walkthrough
+## 代码解析
 
-### 1. Define the cost Hamiltonian
+### 1. 定义代价哈密顿量
 
 ```python
 def maxcut_hamiltonian(edges, n_nodes):
@@ -67,7 +65,7 @@ def maxcut_hamiltonian(edges, n_nodes):
     return terms
 ```
 
-### 2. Build the ansatz
+### 2. 构建拟设
 
 ```python
 from qpandalite.algorithmics.ansatz import qaoa_ansatz
@@ -80,23 +78,23 @@ circuit = qaoa_ansatz(
 )
 ```
 
-### 3. Evaluate and optimise
+### 3. 评估与优化
 
-The energy $\langle H_C \rangle$ is computed from the statevector and
-fed to a coordinate-descent optimiser.
+能量 $\langle H_C \rangle$ 由态矢量计算得出，
+并输入坐标下降优化器。
 
-### Expected Results
+### 预期结果
 
-For a triangle graph (3 edges):
-- Optimal cut: 2 edges (partition one vertex from the other two)
-- QAOA with $p=2$ should achieve the optimal cut with high probability
+对于三角形图（3 条边）：
+- 最优切割：2 条边（将一个顶点与其余两个分开）
+- $p=2$ 的 QAOA 应以高概率达到最优切割
 
-## Extensions
+## 扩展方向
 
-- **Weighted MaxCut**: Add edge weights to the Hamiltonian.
-- **Different graphs**: Try random graphs, planar graphs, etc.
-- **Higher $p$**: More layers improve approximation ratio toward 1.0.
-- **Shot-based**: Use `QASM_Simulator` for realistic noisy measurement.
+- **加权 MaxCut**：在哈密顿量中添加边权重。
+- **不同图结构**：尝试随机图、平面图等。
+- **更高的 $p$**：更多层数可将近似比提升至接近 1.0。
+- **基于采样的模拟**：使用 `QASM_Simulator` 进行真实噪声测量模拟。
 
 ## References
 

--- a/docs/source/algorithm/qpe.md
+++ b/docs/source/algorithm/qpe.md
@@ -1,78 +1,77 @@
-# Quantum Phase Estimation (QPE)
+# 量子相位估计（QPE）
 
-## Background and Theory
+## 背景与理论
 
-Quantum Phase Estimation (QPE) estimates the eigenvalue phase of a unitary operator.
-Given a unitary $U$ and one of its eigenstates $|\psi\rangle$:
+量子相位估计（QPE）用于估计酉算子特征值的相位。
+给定酉算子 $U$ 及其一个特征态 $|\psi\rangle$：
 
 $$U|\psi\rangle = e^{2\pi i\varphi}|\psi\rangle$$
 
-QPE outputs $\varphi \in [0, 1)$ to $n$-bit precision using $n$ precision qubits.
+QPE 使用 $n$ 个精度比特输出 $\varphi \in [0, 1)$，精度为 $n$ 比特。
 
-### The Algorithm
+### 算法步骤
 
-**Step 1 — Prepare the eigenstate** on $m$ system qubits:
+**步骤 1 — 在 $m$ 个系统比特上制备特征态**：
 $$|\psi\rangle = \sum_x \alpha_x |x\rangle$$
 
-**Step 2 — Create superposition** on $n$ precision qubits:
+**步骤 2 — 在 $n$ 个精度比特上创建叠加态**：
 $$H^{\otimes n}|0\rangle^{\otimes n} = \frac{1}{\sqrt{2^n}}\sum_{k=0}^{2^n-1}|k\rangle$$
 
-**Step 3 — Controlled powers of $U$**: for each precision qubit $k$ (value $2^{n-k-1}$):
+**步骤 3 — 受控 $U$ 的幂次**：对每个精度比特 $k$（值为 $2^{n-k-1}$）：
 $$C-U^{2^{n-k-1}}: \frac{1}{\sqrt{2^n}}\sum_{k,j}|k\rangle|j\rangle \to \frac{1}{\sqrt{2^n}}\sum_{k,j}e^{2\pi i\varphi k \cdot 2^{n-k-1}}|k\rangle|j\rangle$$
 
-**Step 4 — Inverse QFT** on the precision register:
+**步骤 4 — 对精度寄存器施加逆 QFT**：
 $$\text{QFT}^{\dagger}\left(\sum_k e^{2\pi i\varphi k}|k\rangle\right) \approx |\tilde{\varphi}\rangle$$
-where $\tilde{\varphi}$ is the binary representation of $\varphi$.
+其中 $\tilde{\varphi}$ 是 $\varphi$ 的二进制表示。
 
-### Inverse QFT (QFTdagger)
+### 逆 QFT（QFTdagger）
 
-The QFT transforms $|x\rangle \to \frac{1}{\sqrt{N}}\sum_k e^{2\pi ixk/N}|k\rangle$.
-QFTdagger is its inverse — implemented by reversing the QFT circuit with adjoint rotation angles.
+QFT 将 $|x\rangle \to \frac{1}{\sqrt{N}}\sum_k e^{2\pi ixk/N}|k\rangle$。
+QFTdagger 是其逆变换——通过反转 QFT 电路并使用伴随旋转角度来实现。
 
-### Accuracy
+### 精度
 
-With $n$ precision qubits, QPE achieves precision $\pm 1/2^n$ with probability approaching 1
-for the most significant bits. The algorithm requires the eigenstate to be provided
-as input (it does not find eigenstates).
+使用 $n$ 个精度比特时，QPE 可达到 $\pm 1/2^n$ 的精度，最高有效位接近概率为 1。
+算法需要将特征态作为输入提供（它不能自行寻找特征态）。
 
-## Code Walkthrough
+## 代码解析
 
 ### `apply_cu1`
 
-Implements $CU_1(\theta)$ where $U_1(\theta) = \text{diag}(1, e^{i\theta})$:
+实现 $CU_1(\theta)$，其中 $U_1(\theta) = \text{diag}(1, e^{i\theta})$：
 $$CU_1(\theta) = \begin{pmatrix}1&0&0&0\\0&1&0&0\\0&0&1&0\\0&0&0&e^{i\theta}\end{pmatrix}$$
 
-Decomposition:
+分解方式：
 $$CU_1(\theta) = u_1(\theta/2) \cdot CX \cdot u_1(-\theta/2) \cdot CX$$
 
 ### `apply_qft_dagger`
 
-Inverse QFT circuit for the precision register:
-- Cascade of $CU_1(-\pi/2^{j-i})$ gates in reverse order
-- Followed by Hadamard on each qubit
+精度寄存器的逆 QFT 电路：
+- 以逆序级联施加 $CU_1(-\pi/2^{j-i})$ 门
+- 然后在每个比特上施加 Hadamard
 
 ### `build_qpe_circuit`
 
-1. Prepare the eigenstate on system qubits (defaults to $|0\rangle^{\otimes m}$)
-2. Apply $H^{\otimes n}$ on precision qubits for uniform superposition
-3. For each precision qubit $k$: apply $U^{2^k}$ controlled by that qubit
-4. Apply QFTdagger on precision qubits
-5. Measure the precision register
+1. 在系统比特上制备特征态（默认为 $|0\rangle^{\otimes m}$）
+2. 在精度比特上施加 $H^{\otimes n}$ 产生均匀叠加
+3. 对每个精度比特 $k$：施加由该比特控制的 $U^{2^k}$
+4. 对精度比特施加 QFTdagger
+5. 测量精度寄存器
 
-## Running the Example
+## 运行示例
 
 ```bash
-# Estimate the phase of the T gate (phase = π/8 ≈ 0.3927)
+# 估计 T 门的相位（相位 = π/8 ≈ 0.3927）
 python examples/algorithms/qpe.py --n-precision 4 --unitary t
 
-# Estimate Z-gate phase (eigenvalue = -1, so phase = 0.5)
+# 估计 Z 门的相位（特征值 = -1，即相位 = 0.5）
 python examples/algorithms/qpe.py --n-precision 4 --unitary z
 
-# More precision qubits
+# 更多精度比特
 python examples/algorithms/qpe.py --n-precision 6 --unitary t --shots 8192
 ```
 
-Expected output:
+预期输出：
 ```
  Quantum Phase Estimation
  Precision qubits: 4
@@ -90,23 +89,17 @@ Expected output:
   ✓ QPE complete.
 ```
 
-## Design Notes
+## 设计说明
 
-- **Eigenstate input**: QPE requires a *known* eigenstate. For non-diagonal unitaries,
-  the output is a superposition of phases corresponding to the eigenstate decomposition.
-- **Controlled unitaries**: For diagonal $U$, controlled-$U$ is implemented as
-  $CU_1$ gates encoding the phase angles. The cascade decomposition handles
-  multi-qubit phase encoding.
-- **Binary phase encoding**: QPE treats the precision register as a binary fraction
-  $\varphi = \sum_k b_k / 2^k$. The estimated integer $m$ from measurement gives
-  $\tilde{\varphi} = m / 2^n$.
+- **特征态输入**：QPE 需要一个*已知*的特征态。对于非对角酉算子，输出是对应特征态分解的多个相位的叠加。
+- **受控酉算子**：对于对角的 $U$，受控-$U$ 通过编码相位角的 $CU_1$ 门实现。级联分解处理多比特相位编码。
+- **二进制相位编码**：QPE 将精度寄存器视为二进制小数 $\varphi = \sum_k b_k / 2^k$。测量得到的整数 $m$ 给出 $\tilde{\varphi} = m / 2^n$。
 
-## Extension Ideas
+## 扩展方向
 
-- **HHL Algorithm**: Use QPE as the core of the quantum linear systems solver
-- **Iterative QPE (IQPE)**: Reduce qubit count by measuring and re-using one qubit
-  per iteration
-- **Quantum counting**: Combine Grover search with QPE to count marked states
+- **HHL 算法**：将 QPE 作为量子线性方程组求解器的核心
+- **迭代 QPE（IQPE）**：通过每次迭代测量并重用一个比特来减少比特数量
+- **量子计数**：结合 Grover 搜索与 QPE 来计数目标态数量
 
 ## References
 

--- a/docs/source/algorithm/rotation_prepare.md
+++ b/docs/source/algorithm/rotation_prepare.md
@@ -1,62 +1,58 @@
-# Arbitrary State Preparation via Rotation
+# 基于旋转的任意态制备
 
-## Background
+## 背景
 
-The **Shende–Bullock–Markov (SBM)** algorithm prepares an arbitrary $n$-qubit
-quantum state from $|0\rangle^{\otimes n}$ using a sequence of multiplexed
-rotations. The key insight is:
+**Shende–Bullock–Markov (SBM)** 算法通过一系列多路旋转，从 $|0\rangle^{\otimes n}$ 制备任意 $n$ 比特量子态。其核心思想是：
 
-1. Start from the target state and **disentangle** qubits one at a time,
-   reducing to $|00\ldots0\rangle$.
-2. Collect the inverse gates.
-3. Apply them in **reverse order** to go from $|00\ldots0\rangle$ to the target.
+1. 从目标态出发，逐一**解纠缠**各比特，最终退化为 $|00\ldots0\rangle$。
+2. 收集逆操作对应的门。
+3. 按**逆序**施加这些门，即可从 $|00\ldots0\rangle$ 得到目标态。
 
-### Gate Complexity
+### 门复杂度
 
-The SBM decomposition uses $O(2^n)$ CNOT gates and $O(2^n)$ single-qubit
-rotations — optimal for general state preparation.
+SBM 分解需要 $O(2^n)$ 个 CNOT 门和 $O(2^n)$ 个单比特旋转——这是通用态制备的最优复杂度。
 
-## Running the Example
+## 运行示例
 
 ```bash
-# Bell state
+# Bell 态
 python examples/state_preparation/rotation_prepare.py --state bell
 
-# GHZ state (3 qubits)
+# GHZ 态（3 比特）
 python examples/state_preparation/rotation_prepare.py --state ghz
 
-# W state (3 qubits)
+# W 态（3 比特）
 python examples/state_preparation/rotation_prepare.py --state w
 
-# Random state
+# 随机态
 python examples/state_preparation/rotation_prepare.py --state random
 ```
 
-## Code Walkthrough
+## 代码讲解
 
 ```python
 import numpy as np
 from qpandalite.algorithmics.state_preparation import rotation_prepare
 
-target = np.array([1, 0, 0, 1]) / np.sqrt(2)  # Bell state
+target = np.array([1, 0, 0, 1]) / np.sqrt(2)  # Bell 态
 c = Circuit()
 rotation_prepare(c, target)
 ```
 
-### Key Features
+### 主要特性
 
-- **Automatic normalisation**: The target vector is normalised if needed.
-- **Any dimension**: Supports $n$-qubit states ($2^n$-dimensional vectors).
-- **High fidelity**: Achieves fidelity > $1 - 10^{-8}$ in simulation.
+- **自动归一化**：目标向量会在需要时自动归一化。
+- **任意维度**：支持 $n$ 比特态（$2^n$ 维向量）。
+- **高保真度**：在模拟中可实现保真度 > $1 - 10^{-8}$。
 
-## States Demonstrated
+## 演示的量子态
 
-| State | Description |
-|-------|-------------|
+| 量子态 | 描述 |
+|--------|------|
 | Bell | $(|00\rangle + |11\rangle)/\sqrt{2}$ |
 | GHZ | $(|0\rangle^{\otimes n} + |1\rangle^{\otimes n})/\sqrt{2}$ |
-| W | Equal superposition of single-excitation states |
-| Random | Haar-random normalised state |
+| W | 单激发态的等幅叠加 |
+| Random | Haar 随机归一化态 |
 
 ## References
 

--- a/docs/source/algorithm/shadow_tomography.md
+++ b/docs/source/algorithm/shadow_tomography.md
@@ -1,52 +1,46 @@
-# Classical Shadow Tomography
+# 经典阴影层析
 
-## Background
+## 背景
 
-Classical Shadow tomography (Huang, Kueng & Preskill, 2020) is a highly efficient
-method for predicting many properties of a quantum system from few measurements.
+经典阴影层析（Huang, Kueng & Preskill, 2020）是一种高效方法，可以从少量测量中预测量子系统的许多性质。
 
-### Key Idea
+### 核心思想
 
-Instead of full state tomography (which requires $O(4^n)$ measurements), classical
-shadow collects $N$ random Pauli measurements ("snapshots") and uses them to
-predict $M$ observables with sample complexity:
+不同于需要 $O(4^n)$ 次测量的完整态层析，经典阴影收集 $N$ 次随机 Pauli 测量（"快照"），利用它们预测 $M$ 个可观测量，样本复杂度为：
 
 $$N = O\left(\log(M) \cdot \max_i \|O_i\|_{\text{shadow}}^2 / \epsilon^2\right)$$
 
-This is **exponentially more efficient** than full tomography for predicting
-local observables.
+对于预测局部可观测量而言，这比完整层析**指数级更高效**。
 
-### Protocol
+### 协议流程
 
-1. **Random basis measurement**: For each snapshot, randomly choose $X$, $Y$, or
-   $Z$ basis for each qubit. Measure and record outcome.
-2. **Classical post-processing**: Reconstruct "classical shadow" — a snapshot
-   of the density matrix.
-3. **Prediction**: Average over snapshots to estimate any observable.
+1. **随机基测量**：对每次快照，为每个比特随机选择 $X$、$Y$ 或 $Z$ 基进行测量并记录结果。
+2. **经典后处理**：重建"经典阴影"——密度矩阵的一个快照。
+3. **预测**：对所有快照取平均以估计任意可观测量。
 
-## Running the Example
+## 运行示例
 
 ```bash
 python examples/measurement/shadow_tomography.py --n-shadow 100 --n-shots 1000
 ```
 
-## Code Walkthrough
+## 代码讲解
 
 ```python
 from qpandalite.algorithmics.measurement import classical_shadow, shadow_expectation
 
-# Collect shadow snapshots
+# 收集阴影快照
 shadows = classical_shadow(circuit, qubits=[0, 1], shots=1000, n_shadow=100)
 
-# Estimate observables
+# 估计可观测量
 est = shadow_expectation(shadows, {"Z0Z1": 1.0})
 ```
 
-### Key Features
+### 主要特性
 
-- **Efficient**: Predict many observables from few measurements.
-- **Flexible**: Works with any Pauli observable.
-- **No calibration needed**: Random Pauli measurements are device-ready.
+- **高效**：从少量测量中预测多个可观测量。
+- **灵活**：适用于任意 Pauli 可观测量。
+- **无需校准**：随机 Pauli 测量可直接在设备上执行。
 
 ## References
 

--- a/docs/source/algorithm/state_tomography.md
+++ b/docs/source/algorithm/state_tomography.md
@@ -1,61 +1,55 @@
-# Quantum State Tomography
+# 量子态层析
 
-## Background
+## 背景
 
-Quantum state tomography reconstructs the full density matrix $\rho$ of a quantum
-state from a complete set of measurements. For $n$ qubits, this requires
-measuring in all $3^n$ Pauli bases (XX, XY, XZ, YX, ..., ZZ).
+量子态层析通过一组完整的测量来重建量子态的完整密度矩阵 $\rho$。对于 $n$ 个比特，需要在所有 $3^n$ 种 Pauli 基（XX, XY, XZ, YX, ..., ZZ）下进行测量。
 
-### Protocol
+### 协议流程
 
-For each of the $3^n$ combinations of single-qubit Pauli bases:
+对于 $3^n$ 种单比特 Pauli 基的每种组合：
 
-1. **Rotate**: Apply basis-change gates to map the measurement basis to
-   the computational ($Z$) basis.
-2. **Measure**: Collect shot-based measurement outcomes.
-3. **Reconstruct**: Combine all measurement results to build the density matrix
-   via linear inversion or maximum-likelihood estimation.
+1. **旋转**：施加基变换门，将测量基映射到计算基（$Z$ 基）。
+2. **测量**：收集基于采样的测量结果。
+3. **重建**：通过线性反演或最大似然估计，将所有测量结果组合起来构建密度矩阵。
 
-### Complexity
+### 复杂度
 
-- Measurements: $O(3^n \cdot S)$ where $S$ is shots per basis
-- Classical post-processing: $O(4^n)$ for density matrix reconstruction
-- **Limitation**: Exponential scaling makes this practical only for small systems
+- 测量次数：$O(3^n \cdot S)$，其中 $S$ 为每个基的采样次数
+- 经典后处理：密度矩阵重建需要 $O(4^n)$
+- **局限性**：指数级增长使其仅适用于小规模系统
 
-For larger systems, consider **Classical Shadow tomography** (see
-`shadow_tomography.py`) which has much better scaling.
+对于更大规模的系统，可以考虑**经典阴影层析**（参见 `shadow_tomography.py`），它具有更好的扩展性。
 
-## Running the Example
+## 运行示例
 
 ```bash
 python examples/measurement/state_tomography.py --n-shots 2000
 ```
 
-## Code Walkthrough
+## 代码讲解
 
 ```python
 from qpandalite.algorithmics.measurement import state_tomography, tomography_summary
 
-# Run tomography
+# 执行层析
 results = state_tomography(circuit, qubits=[0, 1], shots=2000)
 
-# Get reconstructed density matrix
+# 获取重建的密度矩阵
 rho = tomography_summary(results, n_qubits=2)
 ```
 
-### Key Features
+### 主要特性
 
-- **Full reconstruction**: Recovers the complete density matrix including
-  off-diagonal coherences.
-- **Shot-based**: Works with realistic (noisy) measurement outcomes.
-- **Fidelity estimation**: Compare reconstructed state with target.
+- **完整重建**：恢复完整密度矩阵，包括非对角相干项。
+- **基于采样**：适用于真实的（含噪声的）测量结果。
+- **保真度估计**：可将重建态与目标态进行对比。
 
-## Output
+## 输出
 
-The demo shows:
-- Reconstructed density matrix
-- Fidelity with the exact state
-- Population comparison (diagonal elements)
+演示程序展示：
+- 重建的密度矩阵
+- 与精确态的保真度
+- 布居数对比（对角元素）
 
 ## References
 

--- a/docs/source/algorithm/vqe.md
+++ b/docs/source/algorithm/vqe.md
@@ -1,71 +1,64 @@
-# Variational Quantum Eigensolver (VQE)
+# 变分量子本征求解器（VQE）
 
-## Background and Theory
+## 背景与理论
 
-The Variational Quantum Eigensolver (VQE) is a hybrid quantum-classical algorithm
-for finding the ground-state energy of molecular Hamiltonians. It was first
-demonstrated by Peruzzo et al. (2014).
+变分量子本征求解器（Variational Quantum Eigensolver, VQE）是一种混合量子-经典算法，用于求解分子哈密顿量的基态能量。该算法由 Peruzzo 等人（2014）首次演示。
 
-### Core Idea
+### 核心思想
 
-VQE exploits the **variational principle**: for any parameterised trial state
-$|\psi(\boldsymbol{\theta})\rangle$,
+VQE 利用**变分原理**：对于任意参数化试探态 $|\psi(\boldsymbol{\theta})\rangle$，
 
 $$\langle\psi(\boldsymbol{\theta})|H|\psi(\boldsymbol{\theta})\rangle
 \geq E_0$$
 
-where $E_0$ is the true ground-state energy. By minimising the energy
-expectation value over $\boldsymbol{\theta}$, we approach $E_0$.
+其中 $E_0$ 是真实的基态能量。通过在 $\boldsymbol{\theta}$ 上最小化能量期望值，我们可以逼近 $E_0$。
 
-### Algorithm Flow
+### 算法流程
 
 ```
 ┌─────────────┐    ┌──────────────┐    ┌──────────────┐
-│  Prepare     │───▶│  Measure      │───▶│  Classical    │
-│  |ψ(θ)⟩      │    │  ⟨ψ|H|ψ⟩     │    │  Optimiser    │
-│  (ansatz)    │    │  (expectation)│    │  (update θ)   │
+│  制备        │───▶│  测量         │───▶│  经典         │
+│  |ψ(θ)⟩      │    │  ⟨ψ|H|ψ⟩     │    │  优化器       │
+│  (拟设)      │    │  (期望值)     │    │  (更新 θ)     │
 └─────────────┘    └──────────────┘    └──────────────┘
        ▲                                       │
        └───────────────────────────────────────┘
-                    repeat until convergence
+                    重复直至收敛
 ```
 
-1. **Ansatz**: Prepare $|\psi(\boldsymbol{\theta})\rangle$ using a parameterised
-   circuit (e.g., UCCSD).
-2. **Measurement**: Estimate $\langle H \rangle = \sum_i h_i \langle P_i \rangle$
-   by measuring each Pauli string.
-3. **Classical optimisation**: Update $\boldsymbol{\theta}$ to minimise energy.
+1. **拟设（Ansatz）**：使用参数化线路（如 UCCSD）制备 $|\psi(\boldsymbol{\theta})\rangle$。
+2. **测量**：通过测量每个 Pauli 串来估计 $\langle H \rangle = \sum_i h_i \langle P_i \rangle$。
+3. **经典优化**：更新 $\boldsymbol{\theta}$ 以最小化能量。
 
-### Components Used
+### 使用的主要组件
 
-| Component | Module | Role |
-|-----------|--------|------|
-| `uccsd_ansatz` | `algorithmics.ansatz` | Parameterised trial state |
-| `pauli_expectation` | `algorithmics.measurement` | Energy measurement |
-| `OriginIR_Simulator` | `simulator` | Statevector simulation |
+| 组件 | 模块 | 功能 |
+|------|------|------|
+| `uccsd_ansatz` | `algorithmics.ansatz` | 参数化试探态 |
+| `pauli_expectation` | `algorithmics.measurement` | 能量测量 |
+| `OriginIR_Simulator` | `simulator` | 态矢量模拟 |
 
-### H₂ Molecule
+### H₂ 分子
 
-This example solves for the ground state of H₂ in a minimal STO-3G basis
-(4 spin-orbitals, 2 electrons). The Hamiltonian is Bravyi–Kitaev mapped:
+本示例求解最小 STO-3G 基组下 H₂ 的基态（4 个自旋轨道，2 个电子）。哈密顿量经过 Bravyi–Kitaev 变换：
 
 $$H = \sum_i h_i P_i + E_{\text{nuclear}}$$
 
-**Expected result**: $E_0 \approx -1.137$ Ha (exact FCI).
+**预期结果**：$E_0 \approx -1.137$ Ha（精确 FCI 值）。
 
-## Running the Example
+## 运行示例
 
 ```bash
-# Default: H₂, 100 iterations
+# 默认：H₂，100 次迭代
 python examples/algorithms/vqe.py
 
-# Custom iterations
+# 自定义迭代次数
 python examples/algorithms/vqe.py --maxiter 200
 ```
 
-## Code Walkthrough
+## 代码讲解
 
-### 1. Define the Hamiltonian
+### 1. 定义哈密顿量
 
 ```python
 H2_HAMILTONIAN = [
@@ -73,11 +66,11 @@ H2_HAMILTONIAN = [
     ("Z0", +0.1720),
     ("Z0Z1", +0.1205),
     ("X0X1Y2Y3", -0.0455),
-    # ... more terms
+    # ... 更多项
 ]
 ```
 
-### 2. Build the ansatz
+### 2. 构建拟设
 
 ```python
 from qpandalite.algorithmics.ansatz import uccsd_ansatz
@@ -85,9 +78,9 @@ from qpandalite.algorithmics.ansatz import uccsd_ansatz
 circuit = uccsd_ansatz(n_qubits=4, n_electrons=2, params=theta)
 ```
 
-UCCSD generates single and double excitation gates parameterised by $\boldsymbol{\theta}$.
+UCCSD 生成由 $\boldsymbol{\theta}$ 参数化的单激发和双激发门。
 
-### 3. Evaluate energy
+### 3. 计算能量
 
 ```python
 energy = sum(
@@ -96,18 +89,16 @@ energy = sum(
 )
 ```
 
-### 4. Optimise
+### 4. 优化
 
-A simple coordinate-descent optimiser updates each parameter to minimise energy.
-In production, use scipy's `COBYLA` or `SLSQP`.
+使用简单的坐标下降优化器逐个更新参数以最小化能量。在实际应用中，可使用 scipy 的 `COBYLA` 或 `SLSQP`。
 
-## Extensions
+## 扩展方向
 
-- **Larger molecules**: Extend to LiH, BeH₂, H₂O by expanding the Hamiltonian.
-- **Better ansätze**: Try Hardware-Efficient Ansatz (`hea`) for NISQ devices.
-- **Noise mitigation**: Use `classical_shadow` for efficient measurement.
-- **Shot-based simulation**: Replace statevector with `QASM_Simulator` for
-  realistic measurement statistics.
+- **更大分子**：通过扩展哈密顿量，可以求解 LiH、BeH₂、H₂O 等分子。
+- **更好的拟设**：尝试硬件高效拟设（`hea`），适用于 NISQ 设备。
+- **噪声缓解**：使用 `classical_shadow` 进行高效测量。
+- **基于采样的模拟**：将态矢量模拟替换为 `QASM_Simulator`，获得更真实的测量统计。
 
 ## References
 


### PR DESCRIPTION
## Summary

将 `docs/source/algorithm/` 下 8 个英文文档翻译为中文。

### 翻译文件

| 文件 | 主题 |
|------|------|
| grover.md | Grover 搜索算法 |
| hadamard_superposition.md | Hadamard 叠加态制备 |
| qaoa.md | 量子近似优化算法 |
| qpe.md | 量子相位估计 |
| rotation_prepare.md | 基于旋转的任意态制备 |
| shadow_tomography.md | 经典阴影层析 |
| state_tomography.md | 量子态层析 |
| vqe.md | 变分量子本征求解器 |

### 翻译规则

- 标题、正文、列表项 → 中文
- 数学公式（LaTeX）、代码块、API 名称、变量名 → 保留英文
