### PR TITLE
feat: add circuits module — batch 3 (Issue #116)

### DIFF
--- a/docs/source/algorithm.rst
+++ b/docs/source/algorithm.rst
@@ -14,3 +14,8 @@
    algorithm/rotation_prepare
    algorithm/shadow_tomography
    algorithm/state_tomography
+   algorithm/qft
+   algorithm/deutsch-jozsa
+   algorithm/thermal_state
+   algorithm/dicke_state
+   algorithm/grover_oracle

--- a/docs/source/algorithm/deutsch-jozsa.md
+++ b/docs/source/algorithm/deutsch-jozsa.md
@@ -1,0 +1,135 @@
+# Deutsch-Jozsa 算法
+
+## 背景与理论
+
+Deutsch-Jozsa 算法（Deutsch & Jozsa, 1992）是量子计算中最早展示相对于经典计算指数加速的算法之一。
+
+给定一个黑盒函数 $f: \{0,1\}^n \to \{0,1\}$，已知 $f$ 要么是**恒定的**（constant，对所有输入返回相同值），要么是**均衡的**（balanced，对一半输入返回 0，另一半返回 1）。Deutsch-Jozsa 算法仅需**一次**量子查询即可确定 $f$ 的类型，而经典确定性算法在最坏情况下需要 $2^{n-1} + 1$ 次查询。
+
+### 电路结构
+
+算法步骤如下：
+
+1. **初始化**：将 $n$ 个数据比特置于 $|+\rangle$ 态，辅助比特置于 $|-\rangle$ 态：
+
+$$|\psi_0\rangle = \frac{1}{\sqrt{2^n}} \sum_{x=0}^{2^n-1} |x\rangle \otimes |-\rangle$$
+
+2. **Oracle 查询**：应用预言机 $U_f$：
+
+$$U_f|x\rangle|y\rangle = |x\rangle|y \oplus f(x)\rangle$$
+
+利用相位回踢（phase kickback），效果等价于：
+
+$$|\psi_1\rangle = \frac{1}{\sqrt{2^n}} \sum_{x} (-1)^{f(x)} |x\rangle \otimes |-\rangle$$
+
+3. **Hadamard 变换**：对数据比特施加 $H^{\otimes n}$：
+
+$$|\psi_2\rangle = \frac{1}{2^n} \sum_{x,z} (-1)^{x \cdot z + f(x)} |z\rangle \otimes |-\rangle$$
+
+4. **测量**：测量数据比特。若 $f$ 恒定，输出必为 $|0\rangle^{\otimes n}$；若 $f$ 均衡，输出必不为全零。
+
+### Oracle 构造
+
+**恒定 Oracle**：不施加任何门（输出恒为 0）。
+
+**均衡 Oracle**：对选定的数据比特施加 CNOT 到辅助比特。当输入中有奇数个目标比特为 1 时，辅助比特翻转。这保证了一半输入映射到 0，一半映射到 1。
+
+## 代码解析
+
+### `deutsch_jozsa_oracle`
+
+```python
+from qpandalite.algorithmics.circuits import deutsch_jozsa_oracle
+
+# 构建均衡 oracle（3 个数据比特）
+oracle = deutsch_jozsa_oracle(n_qubits=3, balanced=True)
+
+# 构建恒定 oracle
+oracle = deutsch_jozsa_oracle(n_qubits=3, balanced=False)
+```
+
+参数说明：
+
+- `n_qubits`: 数据比特数，oracle 总共使用 `n_qubits + 1` 个比特（含辅助比特）
+- `balanced`: `True` 构建均衡 oracle，`False` 构建恒定 oracle
+- `target_bits`: 控制辅助比特翻转的数据比特索引，`None` 表示全部数据比特
+
+### `deutsch_jozsa_circuit`
+
+```python
+from qpandalite.circuit_builder import Circuit
+from qpandalite.algorithmics.circuits import deutsch_jozsa_circuit, deutsch_jozsa_oracle
+
+n = 3
+oracle = deutsch_jozsa_oracle(n, balanced=True)
+c = Circuit(n + 1)
+deutsch_jozsa_circuit(c, oracle)
+```
+
+函数自动完成：
+
+1. 数据比特初始化为 $|+\rangle$，辅助比特初始化为 $|-\rangle$
+2. 嵌入 oracle 电路
+3. 数据比特施加 Hadamard 门
+4. 测量数据比特
+
+### 判定逻辑
+
+```python
+result = run_simulation(c)
+if all_zero_probability > 0.9:
+    print("CONSTANT")
+else:
+    print("BALANCED")
+```
+
+## 运行示例
+
+```bash
+# 均衡 oracle（默认）
+python examples/circuits/deutsch-jozsa.py --n-qubits 3 --oracle-type balanced
+
+# 恒定 oracle
+python examples/circuits/deutsch-jozsa.py --n-qubits 3 --oracle-type constant
+
+# 更大比特数
+python examples/circuits/deutsch-jozsa.py --n-qubits 5 --oracle-type balanced --shots 8192
+```
+
+预期输出（balanced）：
+```
+ Deutsch-Jozsa Algorithm — 3 data qubits
+ Oracle type: balanced
+
+ Results (top outcomes):
+   |101⟩  25.0%
+   |011⟩  25.0%
+   ...
+
+  → BALANCED function (non-zero measurements detected)
+```
+
+预期输出（constant）：
+```
+ Deutsch-Jozsa Algorithm — 3 data qubits
+ Oracle type: constant
+
+ Results (top outcomes):
+   |000⟩ 100.0% ← all zeros
+
+  → CONSTANT function (all measurements = |000⟩)
+```
+
+## 设计说明
+
+- **Oracle 构造**：均衡 oracle 通过 CNOT 门实现，结构简单且通用。用户可以通过 `target_bits` 参数自定义哪些数据比特参与控制。
+- **辅助比特**：使用标准的相位回踢技术，辅助比特初始化为 $|-\rangle$。
+- **原地修改**：`deutsch_jozsa_circuit` 直接修改传入的 Circuit 对象，与项目 API 风格一致。
+- **确定性结果**：Deutsch-Jozsa 算法在无噪声情况下结果是确定性的——恒定函数必然测量到全零。
+
+## References
+
+- Deutsch, D. & Jozsa, R. (1992). "Rapid solutions of problems by quantum computation."
+  Proceedings of the Royal Society of London A, 439, 553–558.
+- Nielsen, M. A. & Chuang, I. L. (2010). "Quantum Computation and Quantum Information."
+  Cambridge University Press, Section 1.4.

--- a/docs/source/algorithm/dicke_state.md
+++ b/docs/source/algorithm/dicke_state.md
@@ -1,0 +1,105 @@
+# Dicke 态制备电路组件
+
+## 背景与理论
+
+**Dicke 态** $|D(n,k)\rangle$ 是 $n$ 个量子比特上所有 Hamming 权重为 $k$ 的计算基态的等权叠加：
+
+$$|D(n,k)\rangle = \frac{1}{\sqrt{\binom{n}{k}}} \sum_{\substack{x \in \{0,1\}^n \\ |x| = k}} |x\rangle$$
+
+其中 $|x|$ 表示比特串 $x$ 中 1 的个数。
+
+Dicke 态在量子信息中有广泛应用：
+- **量子计量学**：作为 GHZ 态的噪声鲁棒替代，用于参数估计
+- **量子纠错**：与纠错码的码字态密切相关
+- **多体物理**：描述自旋系统的对称态
+
+### SCUC 算法
+
+本实现采用 Bärtschi & Eidenbenz (2019) 提出的 **SCUC**（Sequential Conditional Unitary Cascade）确定性算法，电路深度为 $O(nk)$，仅使用 CNOT 和单量子比特旋转门。
+
+算法步骤：
+
+1. **初始化**：将前 $k$ 个量子比特置为 $|1\rangle$（施加 X 门），得到 $|1\cdots10\cdots0\rangle$
+2. **逐层传播**：对每一层 $j = k, k-1, \ldots, 1$，从左到右扫描：
+   - 对位置 $i = j-1, j, \ldots, n-2$，施加受控旋转门
+   - 该门将部分振幅从"位置 $i$ 为 1"重新分配到"位置 $i+1$ 为 1"
+3. **结果**：经过全部 $k$ 层后，所有 $\binom{n}{k}$ 个基态获得等权振幅
+
+核心子程序是受控旋转 $U(i,j)$，等价于以量子比特 $i$ 为控制、量子比特 $i+1$ 为目标的 $CR_y(2\theta)$，其中 $\theta = \arccos\sqrt{j/(i+2)}$。
+
+## 代码解析
+
+### `dicke_state_circuit`
+
+```python
+from qpandalite.algorithmics.circuits import dicke_state_circuit
+```
+
+函数签名：
+
+```python
+def dicke_state_circuit(
+    circuit: Circuit,
+    k: int,
+    qubits: Optional[List[int]] = None,
+) -> None:
+```
+
+**参数**：
+- `circuit`：量子线路对象（原地修改）
+- `k`：激发数（目标态中 $|1\rangle$ 的个数），满足 $1 \leq k \leq n$
+- `qubits`：目标量子比特索引列表
+
+**实现要点**：
+1. 对前 $k$ 个量子比特施加 X 门，初始化为 $|1^k 0^{n-k}\rangle$
+2. 受控旋转 $U(i,j)$ 分解为 4 个基本门：$R_y(\theta)$ → CNOT → $R_y(-\theta)$ → CNOT
+3. 层循环 $j$ 从 $k$ 递减到 1，位置循环 $i$ 从 $j-1$ 递增到 $n-2$
+
+### 门数分析
+
+总门数为 $O(nk)$：
+- X 门：$k$ 个
+- 受控旋转：$\sum_{j=1}^{k}(n - j) = kn - k(k+1)/2$ 个，每个分解为 4 个基本门
+- 总基本门数约 $4kn - 2k(k+1) + k$
+
+## 运行示例
+
+```bash
+# 默认：|D(4,2)⟩，6 个基态各有 1/6 概率
+python examples/circuits/dicke_state.py
+
+# 自定义参数
+python examples/circuits/dicke_state.py --n-qubits 5 --k 2 --shots 4096
+```
+
+预期输出：
+```
+Dicke State |D(4,2)⟩ Preparation
+Expected: 6 basis states, each with probability 0.166667
+
+Measured probability distribution (shots=8192):
+  State         Measured   Weight     Theory
+  ------------ ---------- -------- ----------
+  |0011⟩      0.166626     2✓  0.166667
+  |0101⟩      0.167358     2✓  0.166667
+  |0110⟩      0.165894     2✓  0.166667
+  |1001⟩      0.166382     2✓  0.166667
+  |1010⟩      0.167236     2✓  0.166667
+  |1100⟩      0.166504     2✓  0.166667
+
+Total weight on Hamming-weight-2 subspace: 1.000000 (expected: 1.0)
+```
+
+## 扩展方向
+
+- **广义 Dicke 态**：对每个基态赋予不同权重（非均匀叠加）
+- **噪声鲁棒性分析**：研究 Dicke 态在退相干下的纠缠保持能力
+- **对称性保持子空间**：利用 Dicke 态构造更大的对称态子空间
+
+## References
+
+- Bärtschi, A., & Eidenbenz, S. (2019). "Deterministic Preparation of Dicke States."
+  Lecture Notes in Computer Science, vol 11644. Springer.
+  https://arxiv.org/abs/1904.07358
+- Dicke, R. H. (1954). "Coherence in Spontaneous Radiation Processes."
+  Physical Review, 93(1), 99–110.

--- a/docs/source/algorithm/grover_oracle.md
+++ b/docs/source/algorithm/grover_oracle.md
@@ -1,0 +1,102 @@
+# Grover Oracle 构造
+
+## 概述
+
+Grover 搜索算法是量子计算中最重要的算法之一，可以在无序数据库中以 $O(\sqrt{N})$ 的复杂度搜索目标元素，相比经典算法的 $O(N)$ 提供了二次加速。
+
+Grover 算法的核心由两个组件构成：
+
+1. **Oracle（预言机）**：识别目标态并翻转其相位
+2. **Diffusion（扩散算子）**：放大目标态的概率振幅
+
+## Oracle 构造原理
+
+### 相位翻转 Oracle
+
+Oracle 的作用是将标记态 $|w\rangle$ 的相位翻转：
+
+$$U_f |x\rangle = (-1)^{[x = w]} |x\rangle$$
+
+### 实现方法
+
+我们使用辅助比特（ancilla）和相位回踢（phase kickback）技术：
+
+1. 将辅助比特初始化为 $|-\rangle = \frac{|0\rangle - |1\rangle}{\sqrt{2}}$
+2. 对数据比特施加 X 门，将标记态的位模式取反（使 0 位变为 1）
+3. 施加多控 Z 门（MCZ），当所有控制比特为 $|1\rangle$ 时翻转辅助比特相位
+4. 撤销 X 门
+
+### MCZ 分解
+
+多控 Z 门通过线性深度的 CNOT 级联实现：
+
+```
+H(target)
+CNOT: ctrl[0] → ctrl[1]
+CNOT: ctrl[1] → ctrl[2]
+...
+CNOT: ctrl[-1] → target
+CNOT: ctrl[1] → ctrl[2]  (反向)
+CNOT: ctrl[0] → ctrl[1]
+H(target)
+```
+
+这种分解使用 $O(n)$ 个 CNOT 门，不需要额外的辅助比特。
+
+## 扩散算子
+
+扩散算子（又称振幅放大算子）的定义为：
+
+$$D = 2|s\rangle\langle s| - I$$
+
+其中 $|s\rangle = H^{\otimes n}|0\rangle^{\otimes n}$ 是均匀叠加态。
+
+等价实现：
+
+$$D = H^{\otimes n} \cdot (2|0\rangle\langle 0| - I) \cdot H^{\otimes n}$$
+
+其中 $2|0\rangle\langle 0| - I$ 通过 X 门 + MCZ + X 门实现。
+
+## API 使用
+
+### grover_oracle
+
+```python
+from qpandalite.circuit_builder import Circuit
+from qpandalite.algorithmics.circuits import grover_oracle, grover_diffusion
+
+c = Circuit()
+n_qubits = 3
+
+# 均匀叠加
+for i in range(n_qubits):
+    c.h(i)
+
+# 构造 oracle
+ancilla = grover_oracle(c, marked_state=5, qubits=[0, 1, 2])
+
+# 构造扩散算子
+grover_diffusion(c, qubits=[0, 1, 2], ancilla=ancilla)
+```
+
+### grover_diffusion
+
+```python
+grover_diffusion(c, qubits=[0, 1, 2], ancilla=3)
+```
+
+- `qubits`：数据比特索引列表，默认 `[0, 1]`
+- `ancilla`：辅助比特索引，默认自动分配为 `max(qubits) + 1`
+
+## 完整示例
+
+参见 `examples/circuits/grover_oracle.py`，演示了完整的 Grover 搜索流程：
+
+```bash
+python examples/circuits/grover_oracle.py --n-qubits 3 --marked-state 5 --shots 4096
+```
+
+## 参考文献
+
+- Grover, L. K. (1996). "A fast quantum mechanical algorithm for database search." STOC '96.
+- Nielsen, M. A., & Chuang, I. L. (2010). Quantum Computation and Quantum Information.

--- a/docs/source/algorithm/qft.md
+++ b/docs/source/algorithm/qft.md
@@ -1,0 +1,114 @@
+# 量子傅里叶变换（QFT）
+
+## 背景与理论
+
+量子傅里叶变换（Quantum Fourier Transform, QFT）是许多量子算法的核心子程序，
+包括 Shor 大数分解算法和量子相位估计。QFT 将计算基态 $|j\rangle$ 映射为：
+
+$$\text{QFT}|j\rangle = \frac{1}{\sqrt{N}} \sum_{k=0}^{N-1} e^{2\pi i\, jk/N} |k\rangle$$
+
+其中 $N = 2^n$，$n$ 为量子比特数。
+
+### 电路结构
+
+对 $n$ 个量子比特的 QFT，电路按如下方式构建：
+
+对于第 $j$ 个量子比特（从最高位到最低位）：
+
+1. 施加 Hadamard 门 $H$
+2. 对每个后续量子比特 $k > j$，施加受控相位旋转 $R_k$，角度为 $\pi / 2^{k-j}$
+
+最后，通过 SWAP 门层反转量子比特顺序，使输出符合标准的大端序约定。
+
+### 受控相位门
+
+$$R_k = \begin{pmatrix} 1 & 0 \\ 0 & e^{2\pi i / 2^k} \end{pmatrix}$$
+
+在实现中，受控相位门通过 CNOT + Rz 分解实现：
+
+$$CR_z(\theta) = R_z(\theta/2) \cdot \text{CNOT} \cdot R_z(-\theta/2) \cdot \text{CNOT}$$
+
+### 逆 QFT
+
+逆量子傅里叶变换（inverse QFT）可通过将 QFT 电路取逆（dagger）得到。
+在 QPanda-lite 中，可以对 QFT 子电路调用 `dagger()` 方法。
+
+## 代码解析
+
+### `qft_circuit`
+
+```python
+from qpandalite.algorithmics.circuits import qft_circuit
+
+c = Circuit(3)
+qft_circuit(c, qubits=[0, 1, 2], swaps=True)
+```
+
+函数签名：
+
+- `circuit`: 量子电路对象（原地修改）
+- `qubits`: 目标量子比特索引列表，`None` 表示使用所有比特
+- `swaps`: 是否添加 SWAP 门反转比特顺序（默认 `True`）
+
+实现逻辑：
+
+1. 对每个量子比特 $j$ 施加 Hadamard 门
+2. 对每个 $k > j$ 施加受控相位旋转 $R(\pi/2^{k-j})$
+3. 若 `swaps=True`，添加 SWAP 层
+
+### 完整示例
+
+```python
+from qpandalite.circuit_builder import Circuit
+from qpandalite.algorithmics.state_preparation import basis_state
+from qpandalite.algorithmics.circuits import qft_circuit
+from qpandalite.simulator.qasm_simulator import QASM_Simulator
+
+# 准备输入态 |5⟩ 并做 QFT
+c = Circuit(3)
+basis_state(c, state=5)
+qft_circuit(c, swaps=True)
+c.measure(0, 1, 2)
+
+# 模拟
+sim = QASM_Simulator()
+result = sim.simulate_shots(c.qasm, shots=4096)
+```
+
+## 运行示例
+
+```bash
+# 基本运行：3 个比特，输入态 |5⟩
+python examples/circuits/qft.py --n-qubits 3 --input-state 5
+
+# 4 个比特，输入态 |7⟩
+python examples/circuits/qft.py --n-qubits 4 --input-state 7 --shots 8192
+```
+
+预期输出：
+```
+ Quantum Fourier Transform — 3 qubits
+ Input state: |5⟩ = |101⟩
+
+ Results (top 8):
+   |000⟩  12.5%
+   |001⟩  12.5%
+   |010⟩  12.5%
+   ...
+
+ Ideal: each basis state has probability 12.50%
+ (QFT of |j⟩ produces equal-amplitude superposition with phase encoding)
+```
+
+## 设计说明
+
+- **CNOT + Rz 分解**：受控相位门通过 CNOT 和单比特 Rz 门实现，避免了需要原生受控相位门的要求。
+- **SWAP 层**：默认启用，确保输出遵循大端序约定。在作为子程序使用时（如 Shor 算法）可以关闭。
+- **原地修改**：函数直接修改传入的 Circuit 对象，与项目中其他电路组件的 API 风格一致。
+
+## References
+
+- Nielsen, M. A. & Chuang, I. L. (2010). "Quantum Computation and Quantum Information."
+  Cambridge University Press, Section 5.1.
+- Shor, P. W. (1994). "Algorithms for quantum computation: discrete logarithms and factoring."
+  FOCS '94.

--- a/docs/source/algorithm/thermal_state.md
+++ b/docs/source/algorithm/thermal_state.md
@@ -1,0 +1,103 @@
+# 热态制备电路组件
+
+## 背景与理论
+
+在统计力学中，量子系统在温度 $T$ 下处于热平衡时，其状态由 **Gibbs 态（热态）** 描述：
+
+$$\rho_\beta = \frac{e^{-\beta H}}{Z}, \quad Z = \mathrm{Tr}(e^{-\beta H})$$
+
+其中 $\beta = 1/(k_B T)$ 是逆温度，$H$ 是系统哈密顿量，$Z$ 是配分函数。
+
+### 可分哈密顿量的热态
+
+对于无横向场的 Ising 型哈密顿量 $H = \sum_{i=0}^{n-1} Z_i$，热态可以分解为各量子比特的直积态：
+
+$$\rho_\beta = \bigotimes_{i=0}^{n-1} \begin{pmatrix} p_0 & 0 \\ 0 & p_1 \end{pmatrix}$$
+
+其中：
+
+$$p_0 = \frac{e^{\beta}}{e^{\beta} + e^{-\beta}}, \qquad p_1 = \frac{e^{-\beta}}{e^{\beta} + e^{-\beta}}$$
+
+这是 **Boltzmann 分布** 在量子比特上的体现：$\beta$ 越大（温度越低），$p_0$ 越接近 1，系统更倾向于处于 $|0\rangle$ 态。
+
+### 电路实现
+
+由于热态是直积态，每个量子比特可以独立制备。对每个量子比特施加旋转门：
+
+$$R_y(\theta)|0\rangle = \cos\frac{\theta}{2}|0\rangle + \sin\frac{\theta}{2}|1\rangle$$
+
+选择 $\theta = 2\arccos(\sqrt{p_0})$，即可得到正确的概率分布：
+
+$$|\cos\frac{\theta}{2}|^2 = p_0, \qquad |\sin\frac{\theta}{2}|^2 = p_1$$
+
+## 代码解析
+
+### `thermal_state_circuit`
+
+```python
+from qpandalite.algorithmics.circuits import thermal_state_circuit
+```
+
+函数签名：
+
+```python
+def thermal_state_circuit(
+    circuit: Circuit,
+    beta: float,
+    qubits: Optional[List[int]] = None,
+) -> None:
+```
+
+**参数**：
+- `circuit`：量子线路对象（原地修改）
+- `beta`：逆温度（$\beta \geq 0$）
+- `qubits`：目标量子比特索引列表
+
+**实现逻辑**：
+1. 计算 $p_0 = e^\beta / (e^\beta + e^{-\beta})$
+2. 计算旋转角 $\theta = 2\arccos(\sqrt{p_0})$
+3. 对每个目标量子比特施加 $R_y(\theta)$
+
+### 与 `state_preparation.thermal_state` 的关系
+
+`state_preparation` 模块中的 `thermal_state` 支持任意哈密顿量，通过矩阵对角化计算热态。本电路组件是 $H = \sum Z_i$ 特例的轻量级实现，不依赖矩阵运算，仅使用单量子比特旋转门。
+
+## 运行示例
+
+```bash
+# 默认参数：3 个比特，β = 1.0
+python examples/circuits/thermal_state.py
+
+# 自定义参数
+python examples/circuits/thermal_state.py --n-qubits 4 --beta 2.0 --shots 4096
+```
+
+预期输出：
+```
+Thermal State Preparation — 3 qubits, β = 1.0
+Single-qubit probabilities: p₀ = 0.880797, p₁ = 0.119203
+
+Measured probability distribution (shots=8192):
+  State         Measured     Theory
+  ------------ ---------- ----------
+  |000⟩      0.679932   0.682121
+  |001⟩      0.092041   0.092378
+  |010⟩      0.091187   0.092378
+  |011⟩      0.012329   0.012514
+  |100⟩      0.090576   0.092378
+  |101⟩      0.012085   0.012514
+  |110⟩      0.012085   0.012514
+  |111⟩      0.001953   0.001700
+```
+
+## 扩展方向
+
+- **含横向场的热态**：$H = \sum Z_i + h\sum X_i$ 不再可分，需要更复杂的电路
+- **变分热态制备**：使用 VQE 类方法近似任意哈密顿量的热态
+- **量子 Metropolis 算法**：通用热态采样方法
+
+## References
+
+- Preskill, J. (1998). *Lecture Notes on Quantum Computation*. Caltech.
+- Wiebe, N., & Granade, C. (2016). "Can basis states be prepared
+  efficiently on a quantum computer?" Phys. Rev. Lett.

--- a/examples/circuits/README.md
+++ b/examples/circuits/README.md
@@ -1,0 +1,19 @@
+# QPanda-Lite Circuit Examples
+
+基于 `qpandalite.algorithmics.circuits` 组件库的示例代码。
+
+## 示例列表
+
+- `qft.py` — 量子傅里叶变换
+- `deutsch-jozsa.py` — Deutsch-Jozsa 算法
+- `thermal_state.py` — 热态制备
+- `dicke_state.py` — Dicke 态制备
+- `grover_oracle.py` — Grover Oracle 构造
+
+## 运行方式
+
+从仓库根目录执行：
+
+```bash
+python examples/circuits/qft.py --n-qubits 3 --input-state 5
+```

--- a/examples/circuits/deutsch-jozsa.py
+++ b/examples/circuits/deutsch-jozsa.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""Deutsch-Jozsa algorithm — complete example.
+
+Demonstrates:
+  * Building constant and balanced oracles
+  * Running the Deutsch-Jozsa algorithm
+  * Distinguishing constant from balanced functions with a single query
+
+Usage:
+    python deutsch-jozsa.py [--n-qubits N] [--oracle-type TYPE] [--shots N]
+
+References:
+    Deutsch, D. & Jozsa, R. (1992). "Rapid solutions of problems by
+    quantum computation." Proceedings of the Royal Society of London A.
+"""
+
+import argparse
+import sys
+
+# Add parent directory to path so we can import qpandalite when running as a script
+sys.path.insert(0, str(__file__.rsplit("/", 2)[0]))
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.simulator.qasm_simulator import QASM_Simulator
+from qpandalite.algorithmics.circuits import deutsch_jozsa_circuit, deutsch_jozsa_oracle
+
+
+def run_deutsch_jozsa(
+    n_qubits: int,
+    oracle_type: str = "balanced",
+    shots: int = 4096,
+) -> dict:
+    """Run the Deutsch-Jozsa algorithm.
+
+    Args:
+        n_qubits: Number of data qubits.
+        oracle_type: "constant" or "balanced".
+        shots: Number of measurement shots.
+
+    Returns:
+        Dictionary mapping bit-strings to frequencies.
+    """
+    balanced = oracle_type == "balanced"
+    oracle = deutsch_jozsa_oracle(n_qubits, balanced=balanced)
+
+    c = Circuit(n_qubits + 1)
+    deutsch_jozsa_circuit(c, oracle)
+
+    sim = QASM_Simulator(least_qubit_remapping=False)
+    result = sim.simulate_shots(c.qasm, shots=shots)
+    total = sum(result.values())
+    return {f"{int(k):0{n_qubits}b}": v / total for k, v in result.items()}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Deutsch-Jozsa Algorithm")
+    parser.add_argument("--n-qubits", type=int, default=3, help="Number of data qubits")
+    parser.add_argument(
+        "--oracle-type",
+        choices=["constant", "balanced"],
+        default="balanced",
+        help="Oracle type (default: balanced)",
+    )
+    parser.add_argument("--shots", type=int, default=4096, help="Number of shots")
+    args = parser.parse_args()
+
+    n = args.n_qubits
+    otype = args.oracle_type
+
+    print(f" Deutsch-Jozsa Algorithm — {n} data qubits")
+    print(f" Oracle type: {otype}")
+    print()
+
+    result = run_deutsch_jozsa(n, oracle_type=otype, shots=args.shots)
+
+    all_zero = "0" * n
+    zero_prob = result.get(all_zero, 0.0)
+
+    sorted_results = sorted(result.items(), key=lambda x: x[1], reverse=True)
+    print(f" Results (top outcomes):")
+    for bitstr, freq in sorted_results[:5]:
+        marker = " ← all zeros" if bitstr == all_zero else ""
+        print(f"   |{bitstr}⟩  {freq * 100:5.1f}%{marker}")
+
+    print()
+    if zero_prob > 0.9:
+        print(f"  → CONSTANT function (all measurements = |{all_zero}⟩)")
+    else:
+        print(f"  → BALANCED function (non-zero measurements detected)")
+
+    print()
+    print(f"  ✓ Run complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/circuits/dicke_state.py
+++ b/examples/circuits/dicke_state.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Dicke state preparation circuit — example.
+
+Demonstrates the dicke_state_circuit building block for preparing
+Dicke states |D(n,k)⟩ — equal superpositions of all n-bit strings
+with exactly k ones.
+
+Usage:
+    python dicke_state.py [--n-qubits N] [--k K] [--shots N]
+"""
+
+import argparse
+import sys
+import math
+from collections import Counter
+
+# Add parent directory to path so we can import qpandalite when running as a script
+sys.path.insert(0, __file__.rsplit("/", 2)[0])
+
+import numpy as np
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.simulator.qasm_simulator import QASM_Simulator
+from qpandalite.algorithmics.circuits import dicke_state_circuit
+
+
+def run_dicke(n_qubits, k, shots):
+    """Run Dicke state preparation and verify probability distribution."""
+    c = Circuit(n_qubits)
+    dicke_state_circuit(c, k=k)
+    c.measure(list(range(n_qubits)))
+
+    sim = QASM_Simulator()
+    result = sim.simulate(c.to_qasm(), shots=shots)
+
+    # Expected number of basis states with exactly k ones
+    from math import comb
+    n_expected = comb(n_qubits, k)
+    expected_prob = 1.0 / n_expected
+
+    total = sum(result.values())
+    probs = {state: count / total for state, count in sorted(result.items())}
+
+    print(f"Dicke State |D({n_qubits},{k})⟩ Preparation")
+    print(f"Expected: {n_expected} basis states, each with probability {expected_prob:.6f}")
+    print(f"\nMeasured probability distribution (shots={shots}):")
+    print(f"  {'State':<12s} {'Measured':>10s} {'Weight':>8s} {'Theory':>10s}")
+    print(f"  {'-'*12} {'-'*10} {'-'*8} {'-'*10}")
+
+    correct_weight = 0
+    for state, prob in probs.items():
+        n_ones = bin(int(state, 2)).count("1")
+        mark = "✓" if n_ones == k else "✗"
+        if n_ones == k:
+            correct_weight += prob
+        print(f"  |{state}⟩  {prob:10.6f} {n_ones:>6d}{mark}  {expected_prob if n_ones == k else 0:10.6f}")
+
+    print(f"\nTotal weight on Hamming-weight-{k} subspace: {correct_weight:.6f} (expected: 1.0)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Dicke state preparation example")
+    parser.add_argument("--n-qubits", type=int, default=4, help="Number of qubits (default: 4)")
+    parser.add_argument("--k", type=int, default=2, help="Number of excitations (default: 2)")
+    parser.add_argument("--shots", type=int, default=8192, help="Number of measurement shots (default: 8192)")
+    args = parser.parse_args()
+
+    if args.k < 1 or args.k > args.n_qubits:
+        print(f"Error: k must satisfy 1 <= k <= n_qubits (got k={args.k}, n={args.n_qubits})")
+        sys.exit(1)
+
+    run_dicke(args.n_qubits, args.k, args.shots)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/circuits/grover_oracle.py
+++ b/examples/circuits/grover_oracle.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""Grover's search using the circuits module.
+
+Demonstrates the full Grover search pipeline using
+:func:`~qpandalite.algorithmics.circuits.grover_oracle` and
+:func:`~qpandalite.algorithmics.circuits.grover_diffusion`.
+
+Usage:
+    python examples/circuits/grover_oracle.py [--n-qubits N] [--marked-state STATE] [--shots N]
+"""
+
+import argparse
+import math
+import sys
+
+sys.path.insert(0, str(__file__.rsplit("/", 2)[0]))
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.simulator.qasm_simulator import QASM_Simulator
+from qpandalite.algorithmics.circuits.grover_oracle import grover_oracle, grover_diffusion
+
+
+def run_grover(n_qubits: int, marked_state: int, shots: int = 4096):
+    """Run Grover's search and return measurement frequencies."""
+    c = Circuit()
+
+    # Uniform superposition on data qubits
+    data_qubits = list(range(n_qubits))
+    for q in data_qubits:
+        c.h(q)
+
+    # Optimal iterations
+    n_iter = max(1, min(int(math.pi / 4 * math.sqrt(2**n_qubits)), 10))
+
+    ancilla = None
+    for _ in range(n_iter):
+        ancilla = grover_oracle(c, marked_state=marked_state, qubits=data_qubits, ancilla=ancilla)
+        grover_diffusion(c, qubits=data_qubits, ancilla=ancilla)
+
+    c.measure(*data_qubits)
+
+    sim = QASM_Simulator(least_qubit_remapping=False)
+    result = sim.simulate_shots(c.qasm, shots=shots)
+    total = sum(result.values())
+    return {f"{k:0{n_qubits}b}": v / total for k, v in result.items()}, n_iter
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Grover's Search (circuits module)")
+    parser.add_argument("--n-qubits", type=int, default=3, help="Number of data qubits")
+    parser.add_argument("--marked-state", type=int, default=5, help="Marked state index")
+    parser.add_argument("--shots", type=int, default=4096, help="Measurement shots")
+    args = parser.parse_args()
+
+    n = args.n_qubits
+    marked = args.marked_state
+    if marked >= 2**n:
+        print(f"Error: marked_state {marked} out of range for {n} qubits")
+        sys.exit(1)
+
+    print(f"  Grover's Search — {n} data qubits")
+    print(f"  Marked state: {marked} ({marked:0{n}b})")
+    print(f"  Search space: {2**n} states")
+    print()
+
+    result, n_iter = run_grover(n, marked, shots=args.shots)
+    marked_str = f"{marked:0{n}b}"
+
+    print(f"  Iterations: {n_iter}")
+    print(f"  Results (top 5):")
+    for state, prob in sorted(result.items(), key=lambda x: -x[1])[:5]:
+        tag = " ← TARGET" if state == marked_str else ""
+        print(f"    |{state}⟩  {prob*100:5.1f}%{tag}")
+
+    print(f"\n  Target probability: {result.get(marked_str, 0)*100:.1f}%")
+    print(f"  ✓ Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/circuits/qft.py
+++ b/examples/circuits/qft.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""Quantum Fourier Transform (QFT) — complete example.
+
+Demonstrates:
+  * Building a QFT circuit using qft_circuit
+  * Preparing a computational basis state as input
+  * Verifying QFT output via state-vector inspection
+  * Running with QASM_Simulator for shot-based sampling
+
+Usage:
+    python qft.py [--n-qubits N] [--input-state STATE] [--shots N]
+
+References:
+    Nielsen, M. A. & Chuang, I. L. (2010). "Quantum Computation and
+    Quantum Information." Cambridge University Press, Section 5.1.
+"""
+
+import argparse
+import sys
+import math
+
+# Add parent directory to path so we can import qpandalite when running as a script
+sys.path.insert(0, str(__file__.rsplit("/", 2)[0]))
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.simulator.qasm_simulator import QASM_Simulator
+from qpandalite.algorithmics.state_preparation import basis_state
+from qpandalite.algorithmics.circuits import qft_circuit
+
+
+def run_qft(n_qubits: int, input_state: int, shots: int = 4096) -> dict:
+    """Run QFT on a computational basis state and return measurement frequencies.
+
+    Args:
+        n_qubits: Number of qubits.
+        input_state: Integer encoding the input basis state.
+        shots: Number of measurement shots.
+
+    Returns:
+        Dictionary mapping bit-strings to frequencies.
+    """
+    c = Circuit(n_qubits)
+
+    # Prepare input state
+    basis_state(c, state=input_state, qubits=list(range(n_qubits)))
+
+    # Apply QFT
+    qft_circuit(c, qubits=list(range(n_qubits)), swaps=True)
+
+    # Measure all qubits
+    c.measure(*list(range(n_qubits)))
+
+    # Simulate
+    sim = QASM_Simulator(least_qubit_remapping=False)
+    result = sim.simulate_shots(c.qasm, shots=shots)
+    total = sum(result.values())
+    return {f"{int(k):0{n_qubits}b}": v / total for k, v in result.items()}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Quantum Fourier Transform (QFT)")
+    parser.add_argument("--n-qubits", type=int, default=3, help="Number of qubits")
+    parser.add_argument(
+        "--input-state",
+        type=int,
+        default=5,
+        help="Input computational basis state (integer, default 5)",
+    )
+    parser.add_argument("--shots", type=int, default=4096, help="Number of shots")
+    args = parser.parse_args()
+
+    n = args.n_qubits
+    state = args.input_state
+    if state >= 2**n:
+        print(f"Error: input_state {state} out of range for {n} qubits (max {2**n - 1})")
+        sys.exit(1)
+
+    print(f" Quantum Fourier Transform — {n} qubits")
+    print(f" Input state: |{state}⟩ = |{state:0{n}b}⟩")
+    print()
+
+    result = run_qft(n, state, shots=args.shots)
+
+    # QFT of |j⟩ should produce equal superposition with phase encoding
+    # For ideal QFT of |j⟩, all outcomes have equal probability 1/N
+    n_outcomes = min(8, len(result))
+    sorted_results = sorted(result.items(), key=lambda x: x[1], reverse=True)
+
+    print(f" Results (top {n_outcomes}):")
+    for bitstr, freq in sorted_results[:n_outcomes]:
+        print(f"   |{bitstr}⟩  {freq * 100:5.1f}%")
+
+    ideal_prob = 100.0 / (2**n)
+    print()
+    print(f" Ideal: each basis state has probability {ideal_prob:.2f}%")
+    print(f" (QFT of |j⟩ produces equal-amplitude superposition with phase encoding)")
+    print()
+    print(f"  ✓ Run complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/circuits/thermal_state.py
+++ b/examples/circuits/thermal_state.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Thermal state preparation circuit — example.
+
+Demonstrates the thermal_state_circuit building block for preparing
+thermal (Gibbs) states of H = Σ Z_i at various inverse temperatures β.
+
+Usage:
+    python thermal_state.py [--n-qubits N] [--beta BETA] [--shots N]
+"""
+
+import argparse
+import sys
+import math
+import numpy as np
+
+# Add parent directory to path so we can import qpandalite when running as a script
+sys.path.insert(0, __file__.rsplit("/", 2)[0])
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.simulator.qasm_simulator import QASM_Simulator
+from qpandalite.algorithmics.circuits import thermal_state_circuit
+
+
+def run_thermal(n_qubits, beta, shots):
+    """Run thermal state preparation and print probability distribution."""
+    c = Circuit(n_qubits)
+    thermal_state_circuit(c, beta=beta)
+    c.measure(list(range(n_qubits)))
+
+    sim = QASM_Simulator()
+    result = sim.simulate(c.to_qasm(), shots=shots)
+
+    # Aggregate counts into probability distribution
+    total = sum(result.values())
+    probs = {state: count / total for state, count in sorted(result.items())}
+
+    # Theoretical distribution
+    exp_b = math.exp(beta)
+    exp_nb = math.exp(-beta)
+    p0 = exp_b / (exp_b + exp_nb)
+    p1 = 1 - p0
+
+    print(f"Thermal State Preparation — {n_qubits} qubits, β = {beta}")
+    print(f"Single-qubit probabilities: p₀ = {p0:.6f}, p₁ = {p1:.6f}")
+    print(f"\nMeasured probability distribution (shots={shots}):")
+    print(f"  {'State':<12s} {'Measured':>10s} {'Theory':>10s}")
+    print(f"  {'-'*12} {'-'*10} {'-'*10}")
+
+    for state, prob in probs.items():
+        # Compute theoretical probability for this basis state
+        n_ones = bin(int(state, 2)).count("1") if state else 0
+        n_zeros = n_qubits - n_ones
+        theory = p0 ** n_zeros * p1 ** n_ones
+        print(f"  |{state}⟩  {prob:10.6f} {theory:10.6f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Thermal state preparation example")
+    parser.add_argument("--n-qubits", type=int, default=3, help="Number of qubits (default: 3)")
+    parser.add_argument("--beta", type=float, default=1.0, help="Inverse temperature β (default: 1.0)")
+    parser.add_argument("--shots", type=int, default=8192, help="Number of measurement shots (default: 8192)")
+    args = parser.parse_args()
+
+    run_thermal(args.n_qubits, args.beta, args.shots)
+
+
+if __name__ == "__main__":
+    main()

--- a/qpandalite/algorithmics/__init__.py
+++ b/qpandalite/algorithmics/__init__.py
@@ -4,8 +4,10 @@ __all__ = [
     "measurement",
     "state_preparation",
     "ansatz",
+    "circuits",
 ]
 
 from . import measurement
 from . import state_preparation
 from . import ansatz
+from . import circuits

--- a/qpandalite/algorithmics/circuits/__init__.py
+++ b/qpandalite/algorithmics/circuits/__init__.py
@@ -1,0 +1,17 @@
+"""Circuits module — reusable quantum circuit building blocks."""
+
+__all__ = [
+    "qft_circuit",
+    "deutsch_jozsa_circuit",
+    "deutsch_jozsa_oracle",
+    "thermal_state_circuit",
+    "dicke_state_circuit",
+    "grover_oracle",
+    "grover_diffusion",
+]
+
+from .qft import qft_circuit
+from .deutsch_jozsa import deutsch_jozsa_circuit, deutsch_jozsa_oracle
+from .thermal_state import thermal_state_circuit
+from .dicke_state import dicke_state_circuit
+from .grover_oracle import grover_oracle, grover_diffusion

--- a/qpandalite/algorithmics/circuits/deutsch_jozsa.py
+++ b/qpandalite/algorithmics/circuits/deutsch_jozsa.py
@@ -1,0 +1,143 @@
+"""Deutsch-Jozsa algorithm circuit and oracle builder."""
+
+__all__ = ["deutsch_jozsa_circuit", "deutsch_jozsa_oracle"]
+
+from typing import List, Optional
+
+from qpandalite.circuit_builder import Circuit
+
+
+def deutsch_jozsa_oracle(
+    n_qubits: int,
+    balanced: bool = True,
+    target_bits: Optional[List[int]] = None,
+) -> Circuit:
+    r"""Build a Deutsch-Jozsa oracle circuit.
+
+    Generates either a **constant** oracle (maps all inputs to 0 or all to 1)
+    or a **balanced** oracle (maps half the inputs to 0 and half to 1).
+
+    * **Constant oracle**: does nothing (output = 0) or flips the ancilla
+      (output = 1).  Here we implement the identity (output always 0).
+
+    * **Balanced oracle**: applies CNOT from each *target_bit* to the
+      ancilla.  If ``target_bits`` is ``None``, all data qubits are used.
+      This yields a balanced function because the ancilla flips exactly
+      when an odd number of target bits are set.
+
+    The oracle acts on ``n_qubits + 1`` qubits: qubits ``[0, n_qubits-1]``
+    are data qubits and qubit ``n_qubits`` is the ancilla.
+
+    Args:
+        n_qubits: Number of data qubits.
+        balanced: If ``True``, build a balanced oracle; otherwise constant.
+        target_bits: Data-qubit indices that control the ancilla flip.
+            Only used when *balanced* is ``True``.  ``None`` means
+            ``list(range(n_qubits))``.
+
+    Returns:
+        A new :class:`Circuit` containing the oracle gates.
+
+    Raises:
+        ValueError: *n_qubits* < 1, or *target_bits* contains invalid indices.
+
+    Example:
+        >>> oracle = deutsch_jozsa_oracle(3, balanced=True)
+        >>> oracle.n_qubits  # 3 data + 1 ancilla
+        4
+    """
+    if n_qubits < 1:
+        raise ValueError(f"n_qubits must be >= 1, got {n_qubits}")
+
+    total = n_qubits + 1
+    oracle = Circuit()
+
+    if not balanced:
+        # Constant oracle: output is always 0 → identity on ancilla
+        return oracle
+
+    if target_bits is None:
+        target_bits = list(range(n_qubits))
+
+    for idx in target_bits:
+        if idx < 0 or idx >= n_qubits:
+            raise ValueError(
+                f"target_bit {idx} out of range for {n_qubits} data qubits"
+            )
+        oracle.cnot(idx, n_qubits)
+
+    return oracle
+
+
+def deutsch_jozsa_circuit(
+    circuit: Circuit,
+    oracle: Circuit,
+    qubits: Optional[List[int]] = None,
+    ancilla: Optional[int] = None,
+) -> None:
+    r"""Apply the Deutsch-Jozsa algorithm to the circuit.
+
+    The Deutsch-Jozsa algorithm determines whether a function
+    :math:`f: \{0,1\}^n \to \{0,1\}` is **constant** or **balanced**
+    using a single quantum query.
+
+    Circuit steps:
+
+    1. Initialise data qubits to :math:`|+\rangle` and ancilla to
+       :math:`|-\rangle` (via ``X`` then ``H``).
+    2. Apply the oracle.
+    3. Apply Hadamard on all data qubits.
+    4. Measure data qubits: all-zeros → constant, otherwise → balanced.
+
+    The caller is responsible for allocating enough qubits:
+    ``len(qubits) + 1`` (one ancilla).
+
+    Args:
+        circuit: Quantum circuit to operate on (mutated in-place).
+        oracle: Oracle sub-circuit to embed.  Must operate on
+            ``len(qubits) + 1`` qubits (data + ancilla).
+        qubits: Data-qubit indices.  ``None`` means
+            ``list(range(n_data))`` where *n_data* = ``oracle.n_qubits - 1``.
+        ancilla: Ancilla qubit index.  ``None`` means the last qubit
+            (``oracle.n_qubits - 1``).
+
+    Raises:
+        ValueError: Qubit count mismatch between circuit and oracle.
+
+    Example:
+        >>> from qpandalite.circuit_builder import Circuit
+        >>> from qpandalite.algorithmics.circuits import (
+        ...     deutsch_jozsa_circuit, deutsch_jozsa_oracle,
+        ... )
+        >>> n = 3
+        >>> oracle = deutsch_jozsa_oracle(n, balanced=True)
+        >>> c = Circuit(n + 1)
+        >>> deutsch_jozsa_circuit(c, oracle)
+    """
+    n_data = oracle.n_qubits - 1
+
+    if qubits is None:
+        qubits = list(range(n_data))
+    if ancilla is None:
+        ancilla = n_data
+
+    if len(qubits) != n_data:
+        raise ValueError(
+            f"Expected {n_data} data qubits, got {len(qubits)}"
+        )
+
+    # Step 1: |+⟩ on data qubits, |−⟩ on ancilla
+    for q in qubits:
+        circuit.h(q)
+    circuit.x(ancilla)
+    circuit.h(ancilla)
+
+    # Step 2: Apply oracle
+    circuit.extend(oracle)
+
+    # Step 3: H on data qubits
+    for q in qubits:
+        circuit.h(q)
+
+    # Step 4: Measure data qubits
+    circuit.measure(*qubits)

--- a/qpandalite/algorithmics/circuits/deutsch_jozsa.py
+++ b/qpandalite/algorithmics/circuits/deutsch_jozsa.py
@@ -49,7 +49,6 @@ def deutsch_jozsa_oracle(
     if n_qubits < 1:
         raise ValueError(f"n_qubits must be >= 1, got {n_qubits}")
 
-    total = n_qubits + 1
     oracle = Circuit()
 
     if not balanced:

--- a/qpandalite/algorithmics/circuits/dicke_state.py
+++ b/qpandalite/algorithmics/circuits/dicke_state.py
@@ -1,0 +1,102 @@
+"""Dicke state preparation circuit using the SCUC algorithm."""
+
+__all__ = ["dicke_state_circuit"]
+
+from typing import List, Optional
+import math
+
+from qpandalite.circuit_builder import Circuit
+
+
+def _dicke_unitary(circuit: Circuit, i: int, j: int, n: int) -> None:
+    r"""Apply a single SCUC rotation unitary.
+
+    Implements the controlled rotation that redistributes amplitude
+    between basis states differing at positions *i* and *i+1* during
+    the Dicke-state construction (layer *j*, position *i*).
+
+    The gate sequence is equivalent to a controlled :math:`R_y(2\theta)`
+    where :math:`\theta = \arccos\!\sqrt{(j)/(i+2)}`, decomposed into
+    elementary CNOT + single-qubit rotations.
+
+    Args:
+        circuit: Circuit to modify (in-place).
+        i: Current qubit index (0-based, ``0 ≤ i < n-1``).
+        j: Current layer index (1-based, ``1 ≤ j ≤ k``).
+        n: Total number of qubits.
+    """
+    # Rotation angle: theta = arccos(sqrt(j / (i + 2)))
+    # where i is 0-based index in the SCUC paper's (i+1) convention
+    theta = math.acos(math.sqrt(j / (i + 2)))
+
+    # Decompose controlled-Ry(2*theta) using CNOT sandwich
+    # Controlled-Ry = Ry(theta) on target, CNOT ctrl->tgt, Ry(-theta) on target, CNOT ctrl->tgt
+    circuit.ry(theta, i + 1)
+    circuit.cnot(i, i + 1)
+    circuit.ry(-theta, i + 1)
+    circuit.cnot(i, i + 1)
+
+
+def dicke_state_circuit(
+    circuit: Circuit,
+    k: int,
+    qubits: Optional[List[int]] = None,
+) -> None:
+    r"""Prepare the Dicke state :math:`|D(n,k)\rangle`.
+
+    The Dicke state :math:`|D(n,k)\rangle` is the equal superposition of
+    all :math:`\binom{n}{k}` computational basis states with exactly *k*
+    qubits in :math:`|1\rangle`:
+
+    .. math::
+
+        |D(n,k)\rangle = \frac{1}{\sqrt{\binom{n}{k}}}
+        \sum_{x\,\in\,\{0,1\}^n,\;|x|=k} |x\rangle
+
+    This implementation uses the **SCUC** (Sequential Conditional Unitary
+    Cascade) algorithm from Bärtschi & Eidenbenz (2019), which constructs
+    the state using only CNOT and single-qubit rotation gates in
+    :math:`O(nk)` depth.
+
+    Algorithm outline:
+      1. Initialize the first *k* qubits to :math:`|1\rangle` (X gates).
+      2. For each layer ``j = k, k-1, …, 1`` and each position
+         ``i = j-1, j, …, n-2``, apply a controlled rotation that
+         redistributes weight to basis states with a ``1`` at position
+         ``i+1`` instead of position ``i``.
+
+    Args:
+        circuit: Quantum circuit to operate on (mutated in-place).
+        k: Number of excitations (``1``s) in the target Dicke state.
+            Must satisfy ``1 <= k <= n``.
+        qubits: Qubit indices to use.  ``None`` means all qubits of
+            *circuit* (``list(range(circuit.n_qubits))``).  Must contain
+            at least *k* qubits.
+
+    Raises:
+        ValueError: If *k* is not in ``[1, n]``.
+
+    Example:
+        >>> from qpandalite.circuit_builder import Circuit
+        >>> from qpandalite.algorithmics.circuits import dicke_state_circuit
+        >>> c = Circuit(4)
+        >>> dicke_state_circuit(c, k=2)
+    """
+    if qubits is None:
+        qubits = list(range(circuit.n_qubits))
+
+    n = len(qubits)
+
+    if k < 1 or k > n:
+        raise ValueError(f"k must satisfy 1 <= k <= n (got k={k}, n={n})")
+
+    # Step 1: Initialize first k qubits to |1⟩
+    for i in range(k):
+        circuit.x(qubits[i])
+
+    # Step 2: SCUC cascade
+    # For each layer j from k down to 1
+    for j in range(k, 0, -1):
+        # For each position i from j-1 to n-2
+        for i in range(j - 1, n - 1):
+            _dicke_unitary(circuit, i, j, n)

--- a/qpandalite/algorithmics/circuits/grover_oracle.py
+++ b/qpandalite/algorithmics/circuits/grover_oracle.py
@@ -1,0 +1,218 @@
+"""Grover oracle and diffusion operator construction.
+
+Provides reusable building blocks for Grover's quantum search algorithm:
+
+* :func:`grover_oracle` — phase-flip oracle for a marked computational basis state.
+* :func:`grover_diffusion` — Grover diffusion (amplitude amplification) operator.
+
+Both functions operate on a :class:`~qpandalite.circuit_builder.Circuit` object
+passed in by the caller, following the standard circuit-building convention of
+``qpandalite.algorithmics.circuits``.
+
+References:
+    Grover, L. K. (1996). "A fast quantum mechanical algorithm for database
+    search." STOC '96.  https://arxiv.org/abs/quant-ph/9605043
+"""
+
+__all__ = ["grover_oracle", "grover_diffusion"]
+
+from typing import List, Optional
+
+from qpandalite.circuit_builder import Circuit
+
+
+def _apply_mcz(
+    circuit: Circuit,
+    controls: List[int],
+    target: int,
+) -> None:
+    """Apply a multi-controlled Z gate using the linear-depth CNOT cascade.
+
+    The decomposition is::
+
+        H(target)
+        CNOT cascade: controls[0] → controls[1] → … → controls[-1] → target
+        CNOT cascade back (reverse order)
+        H(target)
+
+    This applies a Z rotation on *target* iff every control qubit is in ``|1>``.
+
+    Args:
+        circuit: Circuit to append gates to (mutated in-place).
+        controls: List of control qubit indices.
+        target: Target qubit index.
+    """
+    n = len(controls)
+    if n == 0:
+        circuit.z(target)
+        return
+    if n == 1:
+        circuit.cz(controls[0], target)
+        return
+
+    circuit.h(target)
+
+    # Cascade CNOTs forward
+    circuit.cx(controls[0], controls[1])
+    for i in range(1, n - 1):
+        circuit.cx(controls[i], controls[i + 1])
+    circuit.cx(controls[-1], target)
+
+    # Cascade CNOTs back
+    for i in range(n - 2, 0, -1):
+        circuit.cx(controls[i], controls[i + 1])
+    circuit.cx(controls[0], controls[1])
+
+    circuit.h(target)
+
+
+def grover_oracle(
+    circuit: Circuit,
+    marked_state: int,
+    qubits: Optional[List[int]] = None,
+    ancilla: Optional[int] = None,
+) -> int:
+    r"""Construct a phase-flip oracle for a marked basis state.
+
+    The oracle flips the phase of the computational basis state whose integer
+    encoding is *marked_state*, leaving all other states unchanged:
+
+    .. math::
+
+        U_f |x\rangle = (-1)^{[x = \text{marked}]} |x\rangle
+
+    The implementation uses an ancilla qubit prepared in :math:`|-\rangle` and
+    a multi-controlled Z gate.  X gates are applied before and after the MCZ to
+    match the bit pattern of *marked_state*.
+
+    Args:
+        circuit: Quantum circuit to operate on (mutated in-place).
+        marked_state: Non-negative integer encoding the marked basis state.
+        qubits: Data qubit indices.  ``None`` means ``list(range(n_bits))``
+            where *n_bits* is the number of bits needed to represent
+            *marked_state* (at least 1).
+        ancilla: Ancilla qubit index for the MCZ target.  ``None`` means
+            ``max(qubits) + 1`` (auto-allocated).
+
+    Returns:
+        The ancilla qubit index that was used.
+
+    Raises:
+        ValueError: *marked_state* is negative or exceeds the addressable
+            space of *qubits*.
+
+    Example:
+        >>> from qpandalite.circuit_builder import Circuit
+        >>> from qpandalite.algorithmics.circuits import grover_oracle
+        >>> c = Circuit()
+        >>> for i in range(3):
+        ...     c.h(i)          # uniform superposition
+        >>> anc = grover_oracle(c, marked_state=5, qubits=[0, 1, 2])
+    """
+    if marked_state < 0:
+        raise ValueError(f"marked_state must be non-negative, got {marked_state}")
+
+    n_bits = max(1, marked_state.bit_length())
+    if qubits is None:
+        qubits = list(range(n_bits))
+    n = len(qubits)
+
+    if marked_state >= (1 << n):
+        raise ValueError(
+            f"marked_state {marked_state} requires {marked_state.bit_length()} "
+            f"bits but only {n} qubits were provided"
+        )
+
+    if ancilla is None:
+        ancilla = max(qubits) + 1
+
+    # Initialise ancilla to |−⟩ = X·H·|0⟩
+    circuit.x(ancilla)
+    circuit.h(ancilla)
+
+    # Bit pattern of marked_state (MSB first, aligned to qubits)
+    marked_bits = [(marked_state >> (n - 1 - i)) & 1 for i in range(n)]
+
+    # Flip qubits that should be |0⟩ in the marked state
+    for i, bit in enumerate(marked_bits):
+        if bit == 0:
+            circuit.x(qubits[i])
+
+    # Multi-controlled Z targeting the ancilla
+    _apply_mcz(circuit, qubits, ancilla)
+
+    # Flip back
+    for i, bit in enumerate(marked_bits):
+        if bit == 0:
+            circuit.x(qubits[i])
+
+    # Restore ancilla from |−⟩ back to |0⟩ (optional but keeps state clean)
+    circuit.h(ancilla)
+    circuit.x(ancilla)
+
+    return ancilla
+
+
+def grover_diffusion(
+    circuit: Circuit,
+    qubits: Optional[List[int]] = None,
+    ancilla: Optional[int] = None,
+) -> None:
+    r"""Construct the Grover diffusion (amplitude amplification) operator.
+
+    The diffusion operator is:
+
+    .. math::
+
+        D = 2|s\rangle\langle s| - I
+
+    where :math:`|s\rangle = H^{\otimes n}|0\rangle^{\otimes n}` is the
+    uniform superposition.  It is equivalent to:
+
+    .. math::
+
+        D = H^{\otimes n} \cdot \bigl(2|0\rangle\langle 0| - I\bigr)
+            \cdot H^{\otimes n}
+
+    The ``2|0⟩⟨0| - I`` part is implemented as X gates followed by a
+    multi-controlled Z and X gates again.
+
+    Args:
+        circuit: Quantum circuit to operate on (mutated in-place).
+        qubits: Data qubit indices.  ``None`` means ``[0, 1]`` (2 qubits).
+        ancilla: Ancilla qubit for the MCZ decomposition.  ``None`` means
+            ``max(qubits) + 1``.  Not needed when *qubits* has length 1
+            (a single Z gate suffices).
+
+    Raises:
+        ValueError: Fewer than 1 qubit specified.
+    """
+    if qubits is None:
+        qubits = [0, 1]
+    n = len(qubits)
+    if n < 1:
+        raise ValueError("At least 1 qubit is required")
+
+    # H on all qubits
+    for q in qubits:
+        circuit.h(q)
+
+    # X on all qubits
+    for q in qubits:
+        circuit.x(q)
+
+    # Multi-controlled Z
+    if n == 1:
+        circuit.z(qubits[0])
+    else:
+        if ancilla is None:
+            ancilla = max(qubits) + 1
+        _apply_mcz(circuit, qubits, ancilla)
+
+    # X on all qubits (undo)
+    for q in qubits:
+        circuit.x(q)
+
+    # H on all qubits (undo)
+    for q in qubits:
+        circuit.h(q)

--- a/qpandalite/algorithmics/circuits/qft.py
+++ b/qpandalite/algorithmics/circuits/qft.py
@@ -1,0 +1,80 @@
+"""Quantum Fourier Transform (QFT) circuit."""
+
+__all__ = ["qft_circuit"]
+
+from typing import List, Optional
+import math
+
+from qpandalite.circuit_builder import Circuit
+
+
+def qft_circuit(
+    circuit: Circuit,
+    qubits: Optional[List[int]] = None,
+    swaps: bool = True,
+) -> None:
+    r"""Apply the Quantum Fourier Transform (QFT) to the given qubits.
+
+    The QFT maps the computational basis state :math:`|j\rangle` to:
+
+    .. math::
+
+        \frac{1}{\sqrt{N}} \sum_{k=0}^{N-1} e^{2\pi i\, jk/N} |k\rangle
+
+    where :math:`N = 2^n` and *n* is the number of qubits.
+
+    The circuit applies, for each qubit *j* (from most-significant to
+    least-significant):
+
+    1. A Hadamard gate on qubit *j*.
+    2. Controlled phase rotations :math:`R_k` from every later qubit *k* > *j*
+       with angle :math:`\pi / 2^{k-j}`.
+
+    If *swaps* is ``True`` (the default), a layer of SWAP gates is appended
+    to reverse the qubit order so that the output follows the standard
+    big-endian convention.
+
+    To obtain the inverse QFT, use ``circuit.dagger()`` on a copy of the
+    QFT sub-circuit, or apply ``qft_circuit`` and then call
+    ``circuit.dagger()`` on the relevant gates.
+
+    Args:
+        circuit: Quantum circuit to operate on (mutated in-place).
+        qubits: Qubit indices to apply QFT on.  ``None`` means all qubits
+            of *circuit* (``list(range(circuit.n_qubits))``).
+        swaps: Whether to append SWAP gates to reverse qubit order.
+            Defaults to ``True``.
+
+    Raises:
+        ValueError: Fewer than 1 qubit is specified.
+
+    Example:
+        >>> from qpandalite.circuit_builder import Circuit
+        >>> from qpandalite.algorithmics.circuits import qft_circuit
+        >>> c = Circuit(3)
+        >>> qft_circuit(c, qubits=[0, 1, 2])
+    """
+    if qubits is None:
+        qubits = list(range(circuit.n_qubits))
+
+    n = len(qubits)
+    if n < 1:
+        raise ValueError("qft_circuit requires at least 1 qubit")
+
+    for j in range(n):
+        # Hadamard on qubit j
+        circuit.h(qubits[j])
+        # Controlled phase rotations from qubits k > j
+        for k in range(j + 1, n):
+            angle = math.pi / (2 ** (k - j))
+            # Controlled-Rz using CNOT decomposition:
+            # CRz(θ) = Rz(θ/2) on target, CNOT, Rz(-θ/2) on target, CNOT
+            # Equivalently, we can use controlled-phase via CNOT + Rz
+            circuit.rz(angle / 2, qubits[k])
+            circuit.cnot(qubits[j], qubits[k])
+            circuit.rz(-angle / 2, qubits[k])
+            circuit.cnot(qubits[j], qubits[k])
+
+    if swaps:
+        for i in range(n // 2):
+            circuit.swap(qubits[i], qubits[n - 1 - i])

--- a/qpandalite/algorithmics/circuits/thermal_state.py
+++ b/qpandalite/algorithmics/circuits/thermal_state.py
@@ -1,0 +1,69 @@
+"""Thermal state preparation circuit."""
+
+__all__ = ["thermal_state_circuit"]
+
+from typing import List, Optional
+import math
+
+from qpandalite.circuit_builder import Circuit
+
+
+def thermal_state_circuit(
+    circuit: Circuit,
+    beta: float,
+    qubits: Optional[List[int]] = None,
+) -> None:
+    r"""Prepare a thermal state via single-qubit rotations.
+
+    For the transverse-field-free Hamiltonian :math:`H = \sum_i Z_i`, the
+    thermal (Gibbs) state at inverse temperature :math:`\beta` factorises
+    into a product of single-qubit states.  Each qubit is prepared in
+
+    .. math::
+
+        \sqrt{p_0}\,|0\rangle + \sqrt{p_1}\,|1\rangle
+
+    where
+
+    .. math::
+
+        p_0 = \frac{e^{\beta}}{e^{\beta}+e^{-\beta}}, \qquad
+        p_1 = 1 - p_0.
+
+    This is achieved by applying :math:`R_y(\theta)` with
+    :math:`\theta = 2\arccos(\sqrt{p_0})` to every qubit independently.
+
+    This is a lightweight, circuit-only counterpart of
+    ``state_preparation.thermal_state`` for the default Hamiltonian case.
+
+    Args:
+        circuit: Quantum circuit to operate on (mutated in-place).
+        beta: Inverse temperature (:math:`\beta > 0`).  Larger values
+            bias the state towards :math:`|0\rangle`.
+        qubits: Qubit indices to use.  ``None`` means all qubits of
+            *circuit* (``list(range(circuit.n_qubits))``).
+
+    Raises:
+        ValueError: *beta* is negative.
+
+    Example:
+        >>> from qpandalite.circuit_builder import Circuit
+        >>> from qpandalite.algorithmics.circuits import thermal_state_circuit
+        >>> c = Circuit(3)
+        >>> thermal_state_circuit(c, beta=1.0)
+    """
+    if beta < 0:
+        raise ValueError(f"beta must be non-negative, got {beta}")
+
+    if qubits is None:
+        qubits = list(range(circuit.n_qubits))
+
+    # Compute rotation angle: theta = 2 * arccos(sqrt(p0))
+    # p0 = e^beta / (e^beta + e^{-beta})
+    exp_beta = math.exp(beta)
+    exp_neg_beta = math.exp(-beta)
+    p0 = exp_beta / (exp_beta + exp_neg_beta)
+    theta = 2.0 * math.acos(math.sqrt(p0))
+
+    for q in qubits:
+        circuit.ry(theta, q)


### PR DESCRIPTION
## Summary

Closes #116

建设 `qpandalite.algorithmics.circuits` 组件库第三批。

### 新增组件（5 个）

| 组件 | 函数 | 说明 |
|------|------|------|
| QFT | `qft_circuit()` | 量子傅里叶变换电路 |
| Deutsch-Jozsa | `deutsch_jozsa_circuit()`, `deutsch_jozsa_oracle()` | DJ 算法 + oracle 生成 |
| 热态制备 | `thermal_state_circuit()` | Boltzmann 分布电路制备 |
| Dicke 态 | `dicke_state_circuit()` | SCUC 算法纯门操作 |
| Grover Oracle | `grover_oracle()`, `grover_diffusion()` | Oracle 构造 + 扩散算子 |

### 文件清单（19 个文件）

**实现代码（7）**
- `qpandalite/algorithmics/circuits/__init__.py`
- `qpandalite/algorithmics/circuits/qft.py`
- `qpandalite/algorithmics/circuits/deutsch_jozsa.py`
- `qpandalite/algorithmics/circuits/thermal_state.py`
- `qpandalite/algorithmics/circuits/dicke_state.py`
- `qpandalite/algorithmics/circuits/grover_oracle.py`
- `qpandalite/algorithmics/__init__.py`（更新）

**示例（6）**
- `examples/circuits/qft.py`
- `examples/circuits/deutsch-jozsa.py`
- `examples/circuits/thermal_state.py`
- `examples/circuits/dicke_state.py`
- `examples/circuits/grover_oracle.py`
- `examples/circuits/README.md`

**文档（6）**
- `docs/source/algorithm/qft.md`
- `docs/source/algorithm/deutsch-jozsa.md`
- `docs/source/algorithm/thermal_state.md`
- `docs/source/algorithm/dicke_state.md`
- `docs/source/algorithm/grover_oracle.md`
- `docs/source/algorithm.rst`（更新）
