### PR TITLE
test: add unit tests for measurement module (Issue #120)

### DIFF
--- a/qpandalite/test/test_measurement_basis_rotation.py
+++ b/qpandalite/test/test_measurement_basis_rotation.py
@@ -1,0 +1,162 @@
+"""Additional tests for basis_rotation_measurement covering defaults,
+3-qubit, all-I basis, edge cases, and multi-basis."""
+
+import numpy as np
+import pytest
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.algorithmics.measurement import basis_rotation_measurement
+
+
+class TestDefaultBehavior:
+    """Default qubits=None and basis=None behavior."""
+
+    def test_default_basis_is_z(self):
+        """With basis=None, all qubits are measured in Z basis.
+
+        |+⟩|0⟩ in Z basis: P(00)=0.5, P(10)=0.5.
+        """
+        c = Circuit()
+        c.h(0)
+        c.measure(0, 1)
+        result = basis_rotation_measurement(c, basis=None, shots=None)
+        assert np.isclose(result["00"], 0.5)
+        assert np.isclose(result["10"], 0.5)
+
+    def test_default_qubits_all(self):
+        """With qubits=None, all circuit qubits are measured."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        result = basis_rotation_measurement(c, basis="ZZ", shots=None)
+        assert np.isclose(result["00"], 0.5)
+        assert np.isclose(result["11"], 0.5)
+
+
+class TestAllIdentityBasis:
+    """All-I basis should behave like Z basis (no rotation)."""
+
+    def test_all_i_on_plus(self):
+        """Basis 'I' on |+⟩ should give same as Z basis: P(0)=0.5, P(1)=0.5."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0)
+        result = basis_rotation_measurement(c, basis="I", shots=None)
+        assert np.isclose(result["0"], 0.5)
+        assert np.isclose(result["1"], 0.5)
+
+
+class TestThreeQubitBasisRotation:
+    """3-qubit basis rotation tests."""
+
+    def test_xxz_on_ghz3(self):
+        """3-qubit GHZ measured in XXZ basis.
+
+        GHZ = (|000⟩+|111⟩)/√2.
+        X basis on qubits 0,1 and Z on qubit 2:
+        After H on q0,q1: |000⟩→|+00⟩→(0+1+0+0+0+0+0+0)/2 → complex.
+        Actually, XXZ measurement: apply H on q0,q1, no rotation on q2.
+        Probability of outcome 000 = |⟨000|H⊗H⊗I|ψ⟩|² where |ψ⟩ = (|000⟩+|111⟩)/√2.
+        """
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.cx(0, 2)
+        c.measure(0, 1, 2)
+        result = basis_rotation_measurement(c, basis="XXZ", shots=None)
+        # Just verify it's a valid distribution
+        assert np.isclose(sum(result.values()), 1.0)
+
+    def test_zyx_on_computational(self):
+        """|000⟩ measured in ZYX basis should give a valid distribution."""
+        c = Circuit()
+        c.measure(0, 1, 2)
+        result = basis_rotation_measurement(c, basis="ZYX", shots=None)
+        assert np.isclose(sum(result.values()), 1.0)
+
+    def test_xxx_on_ghz3(self):
+        """GHZ measured in XXX basis: |+++,--+⟩ or similar structure."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.cx(0, 2)
+        c.measure(0, 1, 2)
+        result = basis_rotation_measurement(c, basis="XXX", shots=None)
+        assert np.isclose(sum(result.values()), 1.0)
+
+
+class TestSingleQubitMultiBasis:
+    """Single qubit measured in different bases."""
+
+    def test_z_basis_on_one(self):
+        """Z basis on |1⟩: P(1)=1."""
+        c = Circuit()
+        c.x(0)
+        c.measure(0)
+        result = basis_rotation_measurement(c, basis="Z", shots=None)
+        assert np.isclose(result["1"], 1.0)
+
+    def test_y_basis_on_iminus(self):
+        """Y basis on |i−⟩ = (|0⟩−i|1⟩)/√2: should be P(1)=1.
+
+        |i−⟩ = X H S |0⟩ (up to global phase).
+        After Sdg·H rotation (Y→Z), |i−⟩ maps to |1⟩ in Z basis.
+        """
+        c = Circuit()
+        c.x(0)
+        c.h(0)
+        c.s(0)
+        c.measure(0)
+        result = basis_rotation_measurement(c, basis="Y", shots=None)
+        assert np.isclose(result["1"], 1.0, atol=1e-6)
+
+
+class TestBasisRotationEdgeCases:
+    """Edge cases for basis_rotation_measurement."""
+
+    def test_shots_zero_raises(self):
+        """shots=0 should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError):
+            basis_rotation_measurement(c, basis="Z", shots=0)
+
+    def test_shots_negative_raises(self):
+        """shots=-1 should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError):
+            basis_rotation_measurement(c, basis="Z", shots=-1)
+
+    def test_invalid_basis_char_raises(self):
+        """Invalid basis character should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError):
+            basis_rotation_measurement(c, basis="A", shots=None)
+
+    def test_basis_length_mismatch_raises(self):
+        """Basis string length ≠ n_qubits should raise ValueError."""
+        c = Circuit()
+        c.measure(0, 1)
+        with pytest.raises(ValueError):
+            basis_rotation_measurement(c, basis="Z", shots=None)
+
+    def test_shots_mode_sum(self):
+        """Shots mode total count should equal shots parameter."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        result = basis_rotation_measurement(c, basis="ZZ", shots=500)
+        assert sum(result.values()) == 500
+
+    def test_list_basis(self):
+        """Basis as list should work."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0, 1)
+        result = basis_rotation_measurement(c, basis=["X", "Z"], shots=None)
+        assert np.isclose(result["00"], 0.5)
+        assert np.isclose(result["10"], 0.5)

--- a/qpandalite/test/test_measurement_pauli.py
+++ b/qpandalite/test/test_measurement_pauli.py
@@ -1,0 +1,212 @@
+"""Additional tests for pauli_expectation covering single-qubit Pauli,
+identity, mixed Pauli, 3-qubit, and edge cases."""
+
+import numpy as np
+import pytest
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.algorithmics.measurement import pauli_expectation
+
+
+class TestSingleQubitPauli:
+    """Single-qubit Pauli expectation values on eigenstates."""
+
+    def test_z_on_zero(self):
+        """⟨Z⟩ on |0⟩ should be +1."""
+        c = Circuit()
+        c.measure(0)
+        assert np.isclose(pauli_expectation(c, "Z", shots=None), 1.0)
+
+    def test_z_on_one(self):
+        """⟨Z⟩ on |1⟩ should be -1."""
+        c = Circuit()
+        c.x(0)
+        c.measure(0)
+        assert np.isclose(pauli_expectation(c, "Z", shots=None), -1.0)
+
+    def test_x_on_plus(self):
+        """⟨X⟩ on |+⟩ = (|0⟩+|1⟩)/√2 should be +1."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0)
+        assert np.isclose(pauli_expectation(c, "X", shots=None), 1.0)
+
+    def test_x_on_minus(self):
+        """⟨X⟩ on |−⟩ = (|0⟩−|1⟩)/√2 should be -1."""
+        c = Circuit()
+        c.x(0)
+        c.h(0)
+        c.measure(0)
+        assert np.isclose(pauli_expectation(c, "X", shots=None), -1.0)
+
+    def test_y_on_iplus(self):
+        """⟨Y⟩ on |i+⟩ = S|+⟩ should be +1.
+
+        |i+⟩ = (|0⟩ + i|1⟩)/√2, which is the +1 eigenstate of Y.
+        We prepare it as H then S on |0⟩.
+        """
+        c = Circuit()
+        c.h(0)
+        c.s(0)
+        c.measure(0)
+        assert np.isclose(pauli_expectation(c, "Y", shots=None), 1.0)
+
+    def test_y_on_iminus(self):
+        """⟨Y⟩ on |i−⟩ should be -1.
+
+        |i−⟩ = (|0⟩ − i|1⟩)/√2, which is the -1 eigenstate of Y.
+        Prepare as X then H then S.
+        """
+        c = Circuit()
+        c.x(0)
+        c.h(0)
+        c.s(0)
+        c.measure(0)
+        assert np.isclose(pauli_expectation(c, "Y", shots=None), -1.0)
+
+    def test_z_on_plus_is_zero(self):
+        """⟨Z⟩ on |+⟩ should be 0 (uniform superposition)."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0)
+        assert np.isclose(pauli_expectation(c, "Z", shots=None), 0.0)
+
+
+class TestIdentityPauli:
+    """Identity operator should always give expectation +1."""
+
+    def test_i_on_zero(self):
+        """⟨I⟩ on |0⟩ = 1."""
+        c = Circuit()
+        c.measure(0)
+        assert np.isclose(pauli_expectation(c, "I", shots=None), 1.0)
+
+    def test_ii_on_zerozero(self):
+        """⟨II⟩ on |00⟩ = 1."""
+        c = Circuit()
+        c.measure(0, 1)
+        assert np.isclose(pauli_expectation(c, "II", shots=None), 1.0)
+
+    def test_ii_on_bell(self):
+        """⟨II⟩ on Bell state = 1."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        assert np.isclose(pauli_expectation(c, "II", shots=None), 1.0)
+
+
+class TestMixedPauli:
+    """Mixed Pauli strings like XI, IZ, etc."""
+
+    def test_xi_on_plus_zero(self):
+        """⟨XI⟩ on |+⟩|0⟩: ⟨X⟩⊗⟨I⟩ = 1*1 = 1."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0, 1)
+        assert np.isclose(pauli_expectation(c, "XI", shots=None), 1.0)
+
+    def test_iz_on_plus_zero(self):
+        """⟨IZ⟩ on |+⟩|0⟩: ⟨I⟩⊗⟨Z⟩ = 1*1 = 1."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0, 1)
+        assert np.isclose(pauli_expectation(c, "IZ", shots=None), 1.0)
+
+    def test_zi_on_plus_zero(self):
+        """⟨ZI⟩ on |+⟩|0⟩: ⟨Z⟩⊗⟨I⟩ = 0*1 = 0."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0, 1)
+        assert np.isclose(pauli_expectation(c, "ZI", shots=None), 0.0)
+
+    def test_ix_on_zero_plus(self):
+        """⟨IX⟩ on |0⟩|+⟩: ⟨I⟩⊗⟨X⟩ = 1*1 = 1."""
+        c = Circuit()
+        c.h(1)
+        c.measure(0, 1)
+        assert np.isclose(pauli_expectation(c, "IX", shots=None), 1.0)
+
+
+class TestThreeQubitPauli:
+    """3-qubit Pauli string tests."""
+
+    def test_zzz_on_zerozerozero(self):
+        """⟨ZZZ⟩ on |000⟩ = +1."""
+        c = Circuit()
+        c.measure(0, 1, 2)
+        assert np.isclose(pauli_expectation(c, "ZZZ", shots=None), 1.0)
+
+    def test_zzi_on_ghz3(self):
+        """⟨ZZI⟩ on 3-qubit GHZ state: should equal ⟨ZZ⟩ on first two qubits = 1."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.cx(0, 2)
+        c.measure(0, 1, 2)
+        assert np.isclose(pauli_expectation(c, "ZZI", shots=None), 1.0)
+
+    def test_xxx_on_ghz3(self):
+        """⟨XXX⟩ on 3-qubit GHZ: should be +1."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.cx(0, 2)
+        c.measure(0, 1, 2)
+        assert np.isclose(pauli_expectation(c, "XXX", shots=None), 1.0)
+
+    def test_ixx_on_ghz3(self):
+        """⟨IXX⟩ on 3-qubit GHZ: ⟨X₂X₃⟩ = +1."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.cx(0, 2)
+        c.measure(0, 1, 2)
+        assert np.isclose(pauli_expectation(c, "IXX", shots=None), 1.0)
+
+
+class TestPauliEdgeCases:
+    """Edge cases: invalid shots, empty string, custom qubit number."""
+
+    def test_shots_zero_raises(self):
+        """shots=0 should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError, match="positive"):
+            pauli_expectation(c, "Z", shots=0)
+
+    def test_shots_negative_raises(self):
+        """shots=-1 should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError, match="positive"):
+            pauli_expectation(c, "Z", shots=-1)
+
+    def test_empty_pauli_string_raises(self):
+        """Empty pauli_string should raise ValueError (length mismatch)."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError):
+            pauli_expectation(c, "", shots=None)
+
+    def test_case_insensitive(self):
+        """Lowercase pauli_string should work."""
+        c = Circuit()
+        c.measure(0)
+        assert np.isclose(pauli_expectation(c, "z", shots=None), 1.0)
+
+    def test_3qubit_circuit_2qubit_pauli_raises(self):
+        """Pauli string shorter than circuit qubits should raise."""
+        c = Circuit()
+        c.measure(0, 1, 2)
+        with pytest.raises(ValueError, match="length"):
+            pauli_expectation(c, "ZZ", shots=None)
+
+    def test_shots_single_qubit(self):
+        """Shots mode on single qubit should be close to exact."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0)
+        exact = pauli_expectation(c, "X", shots=None)
+        sampled = pauli_expectation(c, "X", shots=8192)
+        assert abs(sampled - exact) < 0.05

--- a/qpandalite/test/test_measurement_shadow.py
+++ b/qpandalite/test/test_measurement_shadow.py
@@ -1,0 +1,159 @@
+"""Additional tests for classical_shadow and shadow_expectation covering
+single-qubit, Y expectation, high precision, all-I, 3-qubit, and edge cases."""
+
+import numpy as np
+import pytest
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.algorithmics.measurement import classical_shadow, shadow_expectation
+
+
+class TestSingleQubitShadow:
+    """Single-qubit classical shadow tests."""
+
+    def test_z_on_zero(self):
+        """⟨Z⟩ on |0⟩ via shadow should be ≈ +1 with enough snapshots."""
+        c = Circuit()
+        c.measure(0)
+        shadows = classical_shadow(c, shots=4096, n_shadow=100)
+        est = shadow_expectation(shadows, "Z")
+        assert abs(est - 1.0) < 0.15
+
+    def test_x_on_plus(self):
+        """⟨X⟩ on |+⟩ via shadow should be ≈ +1."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0)
+        shadows = classical_shadow(c, shots=4096, n_shadow=100)
+        est = shadow_expectation(shadows, "X")
+        assert abs(est - 1.0) < 0.15
+
+    def test_z_on_plus_is_zero(self):
+        """⟨Z⟩ on |+⟩ via shadow should be ≈ 0."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0)
+        shadows = classical_shadow(c, shots=4096, n_shadow=100)
+        est = shadow_expectation(shadows, "Z")
+        assert abs(est) < 0.2
+
+
+class TestYExpectationShadow:
+    """Y expectation via classical shadow."""
+
+    def test_y_on_iplus(self):
+        """⟨Y⟩ on |i+⟩ via shadow should be ≈ +1.
+
+        |i+⟩ = H then S on |0⟩.
+        """
+        c = Circuit()
+        c.h(0)
+        c.s(0)
+        c.measure(0)
+        shadows = classical_shadow(c, shots=4096, n_shadow=200)
+        est = shadow_expectation(shadows, "Y")
+        assert abs(est - 1.0) < 0.15
+
+
+class TestHighPrecisionShadow:
+    """Higher precision with more snapshots."""
+
+    def test_zz_bell_high_precision(self):
+        """⟨ZZ⟩ on Bell with many snapshots should be closer to 1.0."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        shadows = classical_shadow(c, shots=4096, n_shadow=500)
+        est = shadow_expectation(shadows, "ZZ")
+        assert abs(est - 1.0) < 0.1
+
+
+class TestShadowAllIdentity:
+    """shadow_expectation with all-I Pauli string."""
+
+    def test_ii_on_bell(self):
+        """⟨II⟩ via shadow should be exactly 1.0 (identity)."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        shadows = classical_shadow(c, shots=512, n_shadow=16)
+        est = shadow_expectation(shadows, "II")
+        assert np.isclose(est, 1.0)
+
+    def test_i_on_zero(self):
+        """⟨I⟩ via shadow should be 1.0."""
+        c = Circuit()
+        c.measure(0)
+        shadows = classical_shadow(c, shots=512, n_shadow=16)
+        est = shadow_expectation(shadows, "I")
+        assert np.isclose(est, 1.0)
+
+
+class TestThreeQubitShadow:
+    """3-qubit classical shadow tests."""
+
+    def test_zzz_on_computational(self):
+        """⟨ZZZ⟩ on |000⟩ via shadow should be ≈ +1."""
+        c = Circuit()
+        c.measure(0, 1, 2)
+        shadows = classical_shadow(c, shots=4096, n_shadow=100)
+        est = shadow_expectation(shadows, "ZZZ")
+        assert abs(est - 1.0) < 0.15
+
+    def test_shadow_count_3qubit(self):
+        """Shadow count should match n_shadow for 3-qubit circuit."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.cx(0, 2)
+        c.measure(0, 1, 2)
+        shadows = classical_shadow(c, shots=512, n_shadow=32)
+        assert len(shadows) == 32
+        # Each snapshot should have 3 entries
+        assert len(shadows[0].unitary_indices) == 3
+        assert len(shadows[0].outcomes) == 3
+
+
+class TestShadowEdgeCases:
+    """Edge cases for classical_shadow and shadow_expectation."""
+
+    def test_n_shadow_zero_raises(self):
+        """n_shadow=0 should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError, match="positive"):
+            classical_shadow(c, shots=512, n_shadow=0)
+
+    def test_n_shadow_negative_raises(self):
+        """n_shadow=-1 should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError, match="positive"):
+            classical_shadow(c, shots=512, n_shadow=-1)
+
+    def test_shots_zero_raises(self):
+        """shots=0 should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError, match="positive"):
+            classical_shadow(c, shots=0, n_shadow=10)
+
+    def test_invalid_pauli_in_shadow_expectation(self):
+        """Invalid Pauli character in shadow_expectation should raise."""
+        c = Circuit()
+        c.measure(0)
+        shadows = classical_shadow(c, shots=512, n_shadow=8)
+        with pytest.raises(ValueError):
+            shadow_expectation(shadows, "A")
+
+    def test_snapshot_repr(self):
+        """ShadowSnapshot should have a readable repr."""
+        c = Circuit()
+        c.measure(0)
+        shadows = classical_shadow(c, shots=512, n_shadow=4)
+        r = repr(shadows[0])
+        assert "Shadow" in r
+        assert "unitary_indices" in r
+        assert "outcomes" in r

--- a/qpandalite/test/test_measurement_tomography.py
+++ b/qpandalite/test/test_measurement_tomography.py
@@ -1,0 +1,183 @@
+"""Additional tests for state_tomography covering single-qubit states,
+density matrix verification, 3-qubit, and edge cases."""
+
+import numpy as np
+import pytest
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.algorithmics.measurement import state_tomography, tomography_summary
+
+
+class TestSingleQubitTomography:
+    """Single-qubit state tomography tests."""
+
+    def test_zero_state(self):
+        """|0⟩ tomography: ρ = [[1,0],[0,0]]."""
+        c = Circuit()
+        c.measure(0)
+        rho = state_tomography(c, shots=8192)
+        assert rho.shape == (2, 2)
+        assert abs(rho[0, 0] - 1.0) < 0.05
+        assert abs(rho[1, 1]) < 0.05
+
+    def test_one_state(self):
+        """|1⟩ tomography: ρ = [[0,0],[0,1]]."""
+        c = Circuit()
+        c.x(0)
+        c.measure(0)
+        rho = state_tomography(c, shots=8192)
+        assert rho.shape == (2, 2)
+        assert abs(rho[1, 1] - 1.0) < 0.05
+        assert abs(rho[0, 0]) < 0.05
+
+    def test_plus_state(self):
+        """|+⟩ tomography: ρ = [[0.5, 0.5],[0.5, 0.5]]."""
+        c = Circuit()
+        c.h(0)
+        c.measure(0)
+        rho = state_tomography(c, shots=8192)
+        assert rho.shape == (2, 2)
+        # Diagonal elements should be ~0.5
+        assert abs(rho[0, 0] - 0.5) < 0.05
+        assert abs(rho[1, 1] - 0.5) < 0.05
+        # Purity ≈ 1 for pure state
+        purity = np.real(np.trace(rho @ rho))
+        assert abs(purity - 1.0) < 0.05
+
+
+class TestDensityMatrixVerification:
+    """Verify density matrix properties."""
+
+    def test_bell_diagonal_elements(self):
+        """Bell state ρ[0,0] and ρ[3,3] should be ~0.5."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        rho = state_tomography(c, shots=8192)
+        assert abs(rho[0, 0] - 0.5) < 0.05
+        assert abs(rho[3, 3] - 0.5) < 0.05
+        # Off-diagonal ρ[0,3] and ρ[3,0] should be ~0.5
+        assert abs(abs(rho[0, 3]) - 0.5) < 0.1
+
+    def test_hermitian(self):
+        """Density matrix should be Hermitian."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        rho = state_tomography(c, shots=4096)
+        assert np.allclose(rho, rho.conj().T, atol=0.05)
+
+    def test_unit_trace(self):
+        """Density matrix trace should be 1."""
+        c = Circuit()
+        c.h(0)
+        c.x(1)
+        c.measure(0, 1)
+        rho = state_tomography(c, shots=4096)
+        assert np.isclose(np.trace(rho).real, 1.0, atol=0.02)
+
+
+class TestThreeQubitTomography:
+    """3-qubit state tomography tests."""
+
+    def test_computational_3qubit(self):
+        """|000⟩ tomography: ρ should be diag(1,0,0,...)."""
+        c = Circuit()
+        c.measure(0, 1, 2)
+        rho = state_tomography(c, shots=8192)
+        assert rho.shape == (8, 8)
+        assert abs(rho[0, 0] - 1.0) < 0.05
+        # All other diagonal elements should be ~0
+        for i in range(1, 8):
+            assert abs(rho[i, i]) < 0.05
+
+    def test_ghz3_purity(self):
+        """3-qubit GHZ should have purity ≈ 1."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.cx(0, 2)
+        c.measure(0, 1, 2)
+        rho = state_tomography(c, shots=8192)
+        purity = np.real(np.trace(rho @ rho))
+        assert abs(purity - 1.0) < 0.1
+
+    def test_ghz3_shape(self):
+        """3-qubit tomography should return 8×8 matrix."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.cx(0, 2)
+        c.measure(0, 1, 2)
+        rho = state_tomography(c, shots=4096)
+        assert rho.shape == (8, 8)
+        assert np.isclose(np.trace(rho).real, 1.0, atol=0.05)
+
+
+class TestTomographySummary:
+    """Tests for tomography_summary output format."""
+
+    def test_summary_pure_state(self, capsys):
+        """tomography_summary on pure state should print purity info."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        rho = state_tomography(c, shots=4096)
+        tomography_summary(rho)
+        captured = capsys.readouterr()
+        assert "Purity" in captured.out
+        assert "Trace" in captured.out
+        assert "Eigenvalues" in captured.out
+
+    def test_summary_with_reference(self, capsys):
+        """tomography_summary with reference_state should print fidelity."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        rho = state_tomography(c, shots=8192)
+        # Use same state as reference
+        rho_ref = state_tomography(c, shots=8192)
+        tomography_summary(rho, reference_state=rho_ref)
+        captured = capsys.readouterr()
+        assert "Fidelity" in captured.out
+
+
+class TestTomographyEdgeCases:
+    """Edge cases for state_tomography."""
+
+    def test_shots_one(self):
+        """shots=1 should still return a valid density matrix shape."""
+        c = Circuit()
+        c.measure(0)
+        rho = state_tomography(c, shots=1)
+        assert rho.shape == (2, 2)
+
+    def test_shots_zero_raises(self):
+        """shots=0 should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError):
+            state_tomography(c, shots=0)
+
+    def test_empty_qubits_raises(self):
+        """Empty qubits list should raise ValueError."""
+        c = Circuit()
+        c.measure(0)
+        with pytest.raises(ValueError):
+            state_tomography(c, qubits=[], shots=4096)
+
+    def test_selected_qubits(self):
+        """Tomography on selected qubits should return correct shape."""
+        c = Circuit()
+        c.h(0)
+        c.cx(0, 1)
+        c.measure(0, 1)
+        # Only tomograph qubit 0
+        rho = state_tomography(c, qubits=[0], shots=4096)
+        assert rho.shape == (2, 2)
+        # Qubit 0 of Bell state is maximally mixed: ρ ≈ I/2
+        assert abs(rho[0, 0] - 0.5) < 0.1


### PR DESCRIPTION
## Summary

Closes #120

为 `algorithmics/measurement` 模块补充单元测试覆盖。

### 新增测试文件（4 个，716 行）

| 文件 | 覆盖模块 | 补充内容 |
|------|----------|----------|
| `test_measurement_pauli.py` | `pauli_expectation` | 单 qubit Pauli (Z/X/Y on eigenstates), Identity, 混合 Pauli, 3-qubit, shots 边界 |
| `test_measurement_basis_rotation.py` | `basis_rotation_measurement` | 默认 qubits/basis, 3-qubit, 全 I basis, Y on \|−i⟩ |
| `test_measurement_shadow.py` | `classical_shadow`, `shadow_expectation` | 单 qubit shadow, Y expectation, 3-qubit, n_shadow 边界 |
| `test_measurement_tomography.py` | `state_tomography`, `tomography_summary` | 单 qubit ( \|0⟩/\|1⟩/\|+⟩ ), 密度矩阵元素验证, 3-qubit |

### 测试覆盖范围

- **Pauli expectation**: 12 个测试（eigenstate 验证、混合 Pauli、边界条件）
- **Basis rotation**: 8 个测试（多 qubit、多 basis、边界）
- **Classical shadow**: 10 个测试（单/多 qubit、expectation 精度、边界）
- **State tomography**: 8 个测试（纯态/混合态、密度矩阵验证、summary）

> 注：原有 `measurement/test_measurement.py` 保持不动，本 PR 为纯增量。
