### PR TITLE
test: add unit tests for analyzer module (Issue #122)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 testpaths = qpandalite/test
 python_files = test_*.py
-python_functions = run_test_*
+python_functions = test_* run_test_*
 addopts = -v

--- a/qpandalite/test/test_analyzer_draw.py
+++ b/qpandalite/test/test_analyzer_draw.py
@@ -1,0 +1,358 @@
+"""Tests for qpandalite/analyzer/draw.py"""
+
+import pytest
+
+from qpandalite.analyzer.draw import (
+    _parse_measured_result,
+    plot_histogram,
+    plot_distribution,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock axes – provides all methods called by plot_histogram / plot_distribution
+# ---------------------------------------------------------------------------
+
+class _MockAxes:
+    """Minimal mock for matplotlib Axes."""
+
+    def __init__(self):
+        self.calls = []
+
+    def bar(self, x, values, **kwargs):
+        self.calls.append(("bar", x, values, kwargs))
+        return self
+
+    def axhline(self, y, **kwargs):
+        self.calls.append(("axhline", y, kwargs))
+        return self
+
+    def set_xticks(self, ticks):
+        self.calls.append(("set_xticks", ticks))
+
+    def set_xticklabels(self, labels, rotation=None, ha=None):
+        self.calls.append(("set_xticklabels", labels, rotation, ha))
+
+    def set_xlabel(self, label):
+        self.calls.append(("set_xlabel", label))
+
+    def set_ylabel(self, label):
+        self.calls.append(("set_ylabel", label))
+
+    def set_title(self, title):
+        self.calls.append(("set_title", title))
+
+    def set_ylim(self, bottom, top=None):
+        self.calls.append(("set_ylim", bottom, top))
+
+    def grid(self, axis=None, linestyle=None, alpha=None):
+        self.calls.append(("grid", axis, linestyle, alpha))
+
+    def legend(self, loc=None):
+        self.calls.append(("legend", loc))
+
+
+class _MockFigure:
+    """Minimal mock for matplotlib Figure."""
+
+    def __init__(self):
+        self.calls = []
+
+    def tight_layout(self):
+        self.calls.append(("tight_layout",))
+
+    def show(self):
+        self.calls.append(("show",))
+
+
+# ---------------------------------------------------------------------------
+# Monkeypatch fixture – prevent plt.show() / plt.subplots() from opening windows
+#
+# We patch matplotlib.pyplot.subplots directly (not via a string path) because
+# pytest's monkeypatch.resolve() cannot traverse through a non-package module
+# file like qpandalite/analyzer/draw.py to find submodules.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _patch_matplotlib(monkeypatch):
+    """Patches plt.show and plt.subplots to return mock objects."""
+    import matplotlib.pyplot as plt
+
+    # Keep a reference to the real plt so we can patch it
+    _real_pyplot = plt
+
+    def _mock_subplots(**kwargs):
+        fig = _MockFigure()
+        ax = _MockAxes()
+        return fig, ax
+
+    # Patch in-place on the module object
+    monkeypatch.setattr(_real_pyplot, "show", lambda: None)
+    monkeypatch.setattr(_real_pyplot, "subplots", _mock_subplots)
+
+
+# ---------------------------------------------------------------------------
+# _parse_measured_result – dict format
+# ---------------------------------------------------------------------------
+
+class TestParseDictFormat:
+    """Tests for dict input to _parse_measured_result."""
+
+    def test_valid_dict_two_qubits(self):
+        result = {"00": 0.5, "11": 0.5}
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert labels == ["00", "11"]
+        assert values == [0.5, 0.5]
+        assert nqubit == 2
+        assert adj_figsize == (10, 6)
+        assert rot == 0  # nqubit < 7
+
+    def test_valid_dict_three_qubits(self):
+        result = {"000": 0.125, "011": 0.25, "101": 0.375, "111": 0.25}
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert len(labels) == 4
+        assert nqubit == 3
+        assert rot == 0
+
+    def test_empty_dict(self):
+        result = {}
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert labels == []
+        assert values == []
+        assert nqubit == 0
+        assert adj_figsize == (10, 6)
+        assert rot == 0
+
+
+# ---------------------------------------------------------------------------
+# _parse_measured_result – list format
+# ---------------------------------------------------------------------------
+
+class TestParseListFormat:
+    """Tests for list input to _parse_measured_result."""
+
+    def test_valid_list_1qubit(self):
+        result = [0.6, 0.4]
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert labels == ["0", "1"]
+        assert values == [0.6, 0.4]
+        assert nqubit == 1
+        assert adj_figsize == (10, 6)
+        assert rot == 0  # nqubit < 7 → no rotation
+
+    def test_valid_list_2qubits(self):
+        result = [0.5, 0.0, 0.0, 0.5]
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert labels == ["00", "01", "10", "11"]
+        assert nqubit == 2
+        assert rot == 0
+
+    def test_valid_list_7qubits(self):
+        # 7 qubits → 128 outcomes
+        n = 128
+        result = [1.0 / n] * n
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert nqubit == 7
+        assert rot == 30
+        # figsize: max(10, 7 * 0.6) = max(10, 4.2) = 10
+        assert adj_figsize == (10, 6)
+
+    def test_valid_list_10qubits(self):
+        # 10 qubits → 1024 outcomes
+        n = 1024
+        result = [1.0 / n] * n
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert nqubit == 10
+        assert rot == 45
+        # figsize: max(10, 10 * 0.4) = max(10, 4) = 10
+        assert adj_figsize == (10, 6)
+
+    def test_valid_list_12qubits_figsize_adjusted(self):
+        # 12 qubits → figsize
+        n = 4096
+        result = [1.0 / n] * n
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert nqubit == 12
+        assert rot == 45
+        assert adj_figsize == (10, 6)
+
+    def test_valid_list_20qubits_figsize_expanded(self):
+        # 20 qubits → figsize: max(10, 20*0.4) = max(10, 8) = 10
+        n = 1 << 20  # 1048576
+        result = [1.0 / n] * n
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert nqubit == 20
+        assert rot == 45
+        assert adj_figsize == (10, 6)
+
+    @pytest.mark.parametrize("non_power_of_two", [3, 5, 6, 7, 9, 10, 100])
+    def test_list_not_power_of_two_raises(self, non_power_of_two):
+        with pytest.raises(ValueError, match="not a power of 2"):
+            _parse_measured_result([0.1] * non_power_of_two, (10, 6))
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="not a power of 2"):
+            _parse_measured_result([], (10, 6))
+
+    def test_single_element_list_is_valid(self):
+        # n=1 (2^0) is a power of 2: 1 & 0 == 0
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result([1.0], (10, 6))
+        assert labels == ["0"]
+        assert nqubit == 0
+        assert rot == 0
+
+
+# ---------------------------------------------------------------------------
+# _parse_measured_result – wrong type
+# ---------------------------------------------------------------------------
+
+class TestParseWrongType:
+    """Tests for invalid type input to _parse_measured_result."""
+
+    @pytest.mark.parametrize("wrong_type", [42, 3.14, "00", set([1, 2]), None])
+    def test_wrong_type_raises(self, wrong_type):
+        with pytest.raises(TypeError, match="must be a dict or a list"):
+            _parse_measured_result(wrong_type, (10, 6))
+
+
+# ---------------------------------------------------------------------------
+# _parse_measured_result – rotation angle and figsize adjustment
+# ---------------------------------------------------------------------------
+
+class TestParseRotationAndFigsize:
+    """Tests for rotation angle and figsize adjustment logic."""
+
+    def test_nqubit_1_no_rotation(self):
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(
+            {"0": 1.0}, (10, 6)
+        )
+        assert nqubit == 1
+        assert rot == 0
+
+    def test_nqubit_7_rotation_30(self):
+        # 7 qubits → 128 outcomes
+        n = 128
+        result = {f"{i:07b}": 1.0 / n for i in range(n)}
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert nqubit == 7
+        assert rot == 30
+
+    def test_nqubit_10_rotation_45(self):
+        # 10 qubits → 1024 outcomes
+        n = 1024
+        result = {f"{i:010b}": 1.0 / n for i in range(n)}
+        labels, values, nqubit, adj_figsize, rot = _parse_measured_result(result, (10, 6))
+        assert nqubit == 10
+        assert rot == 45
+
+    def test_nqubit_7_figsize_adjusted(self):
+        n = 128
+        result = {f"{i:07b}": 1.0 / n for i in range(n)}
+        _, _, _, adj_figsize, _ = _parse_measured_result(result, (8, 5))
+        # max(8, 7 * 0.6) = max(8, 4.2) = 8
+        assert adj_figsize == (8, 5)
+
+    def test_nqubit_10_figsize_adjusted(self):
+        n = 1024
+        result = {f"{i:010b}": 1.0 / n for i in range(n)}
+        _, _, _, adj_figsize, _ = _parse_measured_result(result, (8, 5))
+        # max(8, 10 * 0.4) = max(8, 4) = 8
+        assert adj_figsize == (8, 5)
+
+
+# ---------------------------------------------------------------------------
+# _parse_measured_result – label format
+# ---------------------------------------------------------------------------
+
+class TestParseLabelsFormat:
+    """Tests for the format of generated labels."""
+
+    def test_labels_are_binary_strings(self):
+        result = [0.25] * 4
+        labels, _, _, _, _ = _parse_measured_result(result, (10, 6))
+        assert labels == ["00", "01", "10", "11"]
+        for label in labels:
+            assert all(c in "01" for c in label)
+
+    def test_labels_padded_to_nqubit(self):
+        result = [0.125] * 8
+        labels, _, _, _, _ = _parse_measured_result(result, (10, 6))
+        assert labels == ["000", "001", "010", "011", "100", "101", "110", "111"]
+        for label in labels:
+            assert len(label) == 3  # 3 qubits
+
+
+# ---------------------------------------------------------------------------
+# plot_histogram – valid inputs (no errors raised)
+# ---------------------------------------------------------------------------
+
+class TestPlotHistogramValid:
+    """Tests that plot_histogram accepts valid inputs without raising."""
+
+    def test_dict_input(self):
+        plot_histogram({"00": 0.5, "11": 0.5}, title="Bell State")
+
+    def test_list_input(self):
+        plot_histogram([0.5, 0.0, 0.0, 0.5], title="Bell State")
+
+    def test_custom_figsize(self):
+        plot_histogram([0.5, 0.5], title="Custom", figsize=(12, 8))
+
+
+# ---------------------------------------------------------------------------
+# plot_histogram – invalid inputs raise
+# ---------------------------------------------------------------------------
+
+class TestPlotHistogramInvalid:
+    """Tests that plot_histogram raises on invalid inputs."""
+
+    @pytest.mark.parametrize("non_power_of_two", [3, 5, 7])
+    def test_list_not_power_of_two_raises(self, non_power_of_two):
+        with pytest.raises(ValueError, match="not a power of 2"):
+            plot_histogram([0.1] * non_power_of_two)
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="not a power of 2"):
+            plot_histogram([])
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(TypeError, match="must be a dict or a list"):
+            plot_histogram(42)
+
+
+# ---------------------------------------------------------------------------
+# plot_distribution – valid inputs (no errors raised)
+# ---------------------------------------------------------------------------
+
+class TestPlotDistributionValid:
+    """Tests that plot_distribution accepts valid inputs without raising."""
+
+    def test_dict_input(self):
+        plot_distribution({"00": 0.5, "11": 0.5}, title="Bell State")
+
+    def test_list_input(self):
+        plot_distribution([0.5, 0.0, 0.0, 0.5], title="Bell State")
+
+    def test_custom_figsize(self):
+        plot_distribution([0.5, 0.5], title="Custom", figsize=(12, 8))
+
+
+# ---------------------------------------------------------------------------
+# plot_distribution – invalid inputs raise
+# ---------------------------------------------------------------------------
+
+class TestPlotDistributionInvalid:
+    """Tests that plot_distribution raises on invalid inputs."""
+
+    @pytest.mark.parametrize("non_power_of_two", [3, 5, 7])
+    def test_list_not_power_of_two_raises(self, non_power_of_two):
+        with pytest.raises(ValueError, match="not a power of 2"):
+            plot_distribution([0.1] * non_power_of_two)
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="not a power of 2"):
+            plot_distribution([])
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(TypeError, match="must be a dict or a list"):
+            plot_distribution(42)

--- a/qpandalite/test/test_analyzer_expectation.py
+++ b/qpandalite/test/test_analyzer_expectation.py
@@ -1,0 +1,705 @@
+"""Comprehensive unit tests for qpandalite.analyzer.expectation."""
+
+import numpy as np
+import pytest
+
+from qpandalite.analyzer.expectation import (
+    calculate_expectation,
+    calculate_exp_X,
+    calculate_exp_Y,
+    calculate_multi_basis_expectation,
+)
+
+
+# =============================================================================
+# TestCalculateExpectation
+# =============================================================================
+class TestCalculateExpectation:
+    """Tests for calculate_expectation."""
+
+    # -------------------------------------------------------------------------
+    # Parameter validation
+    # -------------------------------------------------------------------------
+    def test_invalid_hamiltonian_char(self):
+        """Hamiltonian with invalid characters raises ValueError."""
+        result = {"00": 1.0}
+        with pytest.raises(ValueError, match="only containing Z or I"):
+            calculate_expectation(result, "XZ")
+
+    def test_empty_hamiltonian_no_raise(self):
+        """Empty string Hamiltonian is valid for empty result (nqubit=0)."""
+        # Empty string hamiltonian means nqubit=0, matches empty-dict result
+        result = {"": 1.0}
+        assert np.isclose(calculate_expectation(result, ""), 1.0)
+
+    def test_hamiltonian_length_mismatch_dict(self):
+        """Hamiltonian length != number of qubits raises ValueError."""
+        result = {"000": 1.0}  # 3 qubits
+        with pytest.raises(ValueError, match="same size"):
+            calculate_expectation(result, "ZZ")  # 2-qubit Hamiltonian
+
+    def test_hamiltonian_length_mismatch_list(self):
+        """List result length mismatch with Hamiltonian raises ValueError."""
+        result = [1.0, 0.0]  # 2**1 = 2 entries = 1 qubit
+        with pytest.raises(ValueError, match="same size"):
+            calculate_expectation(result, "ZZ")  # 2-qubit Hamiltonian
+
+    def test_wrong_input_type(self):
+        """Non-dict/non-list measured_result raises ValueError."""
+        with pytest.raises(ValueError, match="Dict or a List"):
+            calculate_expectation("invalid", "Z")
+
+    def test_hamiltonian_not_string_or_list(self):
+        """Hamiltonian that is neither str nor list raises ValueError."""
+        result = {"0": 1.0}
+        with pytest.raises(ValueError, match="must be a str"):
+            calculate_expectation(result, 42)
+
+    # -------------------------------------------------------------------------
+    # Numerical correctness - eigenstates
+    # -------------------------------------------------------------------------
+    def test_z_on_zero_state(self):
+        """Z on |0> = +1."""
+        result = {"0": 1.0}
+        assert np.isclose(calculate_expectation(result, "Z"), 1.0)
+
+    def test_z_on_one_state(self):
+        """Z on |1> = -1."""
+        result = {"1": 1.0}
+        assert np.isclose(calculate_expectation(result, "Z"), -1.0)
+
+    def test_z_on_plus_state(self):
+        """Z on |+> = 0 (equal superposition)."""
+        result = {"0": 0.5, "1": 0.5}
+        assert np.isclose(calculate_expectation(result, "Z"), 0.0)
+
+    def test_z_on_minus_state(self):
+        """Z on |-> = 0 (equal superposition)."""
+        result = {"0": 0.5, "1": 0.5}
+        assert np.isclose(calculate_expectation(result, "Z"), 0.0)
+
+    def test_zz_on_bell_state_00_11(self):
+        """ZZ on Bell state |Phi+> = (|00>+|11>)/sqrt(2) = +1."""
+        result = {"00": 0.5, "11": 0.5}
+        assert np.isclose(calculate_expectation(result, "ZZ"), 1.0)
+
+    def test_zi_on_bell_state(self):
+        """ZI on Bell state |Phi+> = 0 (reduced density matrix maximally mixed)."""
+        result = {"00": 0.5, "11": 0.5}
+        assert np.isclose(calculate_expectation(result, "ZI"), 0.0)
+
+    def test_iz_on_bell_state(self):
+        """IZ on Bell state |Phi+> = 0."""
+        result = {"00": 0.5, "11": 0.5}
+        assert np.isclose(calculate_expectation(result, "IZ"), 0.0)
+
+    def test_zz_on_product_state_00(self):
+        """ZZ on |00> = +1."""
+        result = {"00": 1.0}
+        assert np.isclose(calculate_expectation(result, "ZZ"), 1.0)
+
+    def test_zz_on_product_state_11(self):
+        """ZZ on |11> = +1 (two Z flips = positive)."""
+        result = {"11": 1.0}
+        assert np.isclose(calculate_expectation(result, "ZZ"), 1.0)
+
+    def test_zz_on_product_state_01(self):
+        """ZZ on |01> = -1 (one Z flip)."""
+        result = {"01": 1.0}
+        assert np.isclose(calculate_expectation(result, "ZZ"), -1.0)
+
+    def test_zz_on_product_state_10(self):
+        """ZZ on |10> = -1 (one Z flip)."""
+        result = {"10": 1.0}
+        assert np.isclose(calculate_expectation(result, "ZZ"), -1.0)
+
+    def test_i_identity_term(self):
+        """I on any state = 1 (identity does nothing)."""
+        assert np.isclose(calculate_expectation({"0": 1.0}, "I"), 1.0)
+        assert np.isclose(calculate_expectation({"00": 1.0}, "II"), 1.0)
+        assert np.isclose(calculate_expectation({"0": 0.5, "1": 0.5}, "I"), 1.0)
+
+    def test_zi_identity_mix(self):
+        """ZI on |00> = +1 (Z on qubit 0 which is 0, I on qubit 1)."""
+        result = {"00": 1.0}
+        assert np.isclose(calculate_expectation(result, "ZI"), 1.0)
+
+    def test_iz_identity_mix(self):
+        """IZ on |00> = +1."""
+        result = {"00": 1.0}
+        assert np.isclose(calculate_expectation(result, "IZ"), 1.0)
+
+    def test_iz_on_01(self):
+        """IZ on |01> = -1 (Z on qubit 1 which is 1)."""
+        result = {"01": 1.0}
+        assert np.isclose(calculate_expectation(result, "IZ"), -1.0)
+
+    # -------------------------------------------------------------------------
+    # List input format
+    # -------------------------------------------------------------------------
+    def test_z_on_zero_state_list(self):
+        """Z on |0> = +1 (list format [P(0), P(1)])."""
+        result = [1.0, 0.0]
+        assert np.isclose(calculate_expectation(result, "Z"), 1.0)
+
+    def test_z_on_one_state_list(self):
+        """Z on |1> = -1 (list format)."""
+        result = [0.0, 1.0]
+        assert np.isclose(calculate_expectation(result, "Z"), -1.0)
+
+    def test_zz_on_bell_state_list(self):
+        """ZZ on Bell state = +1 (list format: [P(00), P(01), P(10), P(11)])."""
+        result = [0.5, 0.0, 0.0, 0.5]
+        assert np.isclose(calculate_expectation(result, "ZZ"), 1.0)
+
+    def test_zi_on_bell_state_list(self):
+        """ZI on Bell state = 0 (list format)."""
+        result = [0.5, 0.0, 0.0, 0.5]
+        assert np.isclose(calculate_expectation(result, "ZI"), 0.0)
+
+    def test_zz_on_product_state_00_list(self):
+        """ZZ on |00> = +1 (list format)."""
+        result = [1.0, 0.0, 0.0, 0.0]
+        assert np.isclose(calculate_expectation(result, "ZZ"), 1.0)
+
+    def test_zz_on_product_state_01_list(self):
+        """ZZ on |01> = -1 (list format)."""
+        result = [0.0, 1.0, 0.0, 0.0]
+        assert np.isclose(calculate_expectation(result, "ZZ"), -1.0)
+
+    # -------------------------------------------------------------------------
+    # Lowercase z/i
+    # -------------------------------------------------------------------------
+    def test_lowercase_z(self):
+        """Lowercase 'z' is treated same as 'Z'."""
+        result = {"0": 1.0}
+        assert np.isclose(calculate_expectation(result, "z"), 1.0)
+
+    def test_lowercase_z_on_one(self):
+        """Lowercase 'z' on |1> = -1."""
+        result = {"1": 1.0}
+        assert np.isclose(calculate_expectation(result, "z"), -1.0)
+
+    def test_mixed_case_zZ(self):
+        """Mixed 'zZ' on |0> = +1 (z on q0=0, Z on q1=0)."""
+        result = {"00": 1.0}
+        assert np.isclose(calculate_expectation(result, "zZ"), 1.0)
+
+    # -------------------------------------------------------------------------
+    # List of hamiltonians
+    # -------------------------------------------------------------------------
+    def test_list_of_hamiltonians(self):
+        """Passing a list of Hamiltonians returns a list of results."""
+        result = {"00": 0.5, "11": 0.5}
+        out = calculate_expectation(result, ["ZZ", "ZI", "IZ", "II"])
+        assert isinstance(out, list)
+        assert len(out) == 4
+        assert np.isclose(out[0], 1.0)
+        assert np.isclose(out[1], 0.0)
+        assert np.isclose(out[2], 0.0)
+        assert np.isclose(out[3], 1.0)
+
+    def test_list_of_hamiltonians_empty(self):
+        """Empty list of Hamiltonians returns empty list."""
+        result = {"0": 1.0}
+        out = calculate_expectation(result, [])
+        assert out == []
+
+    def test_list_of_hamiltonians_mixed_case(self):
+        """List of Hamiltonians with mixed case works."""
+        result = {"0": 1.0}
+        out = calculate_expectation(result, ["Z", "z", "I"])
+        assert np.isclose(out[0], 1.0)
+        assert np.isclose(out[1], 1.0)
+        assert np.isclose(out[2], 1.0)
+
+    # -------------------------------------------------------------------------
+    # Boundary: single qubit
+    # -------------------------------------------------------------------------
+    def test_single_qubit_various_states(self):
+        """Single qubit: test |0>, |1>, |+>, |->."""
+        assert np.isclose(calculate_expectation({"0": 1.0}, "Z"), 1.0)
+        assert np.isclose(calculate_expectation({"1": 1.0}, "Z"), -1.0)
+        assert np.isclose(calculate_expectation({"0": 0.5, "1": 0.5}, "Z"), 0.0)
+
+    # -------------------------------------------------------------------------
+    # Boundary: 3+ qubits
+    # -------------------------------------------------------------------------
+    def test_three_qubit_zzz_on_000(self):
+        """ZZZ on |000> = +1."""
+        result = {"000": 1.0}
+        assert np.isclose(calculate_expectation(result, "ZZZ"), 1.0)
+
+    def test_three_qubit_zzz_on_001(self):
+        """ZZZ on |001> = -1 (one qubit flipped)."""
+        result = {"001": 1.0}
+        assert np.isclose(calculate_expectation(result, "ZZZ"), -1.0)
+
+    def test_three_qubit_zzz_on_011(self):
+        """ZZZ on |011> = +1 (two qubits flipped: (+)(+)(-)=+)."""
+        result = {"011": 1.0}
+        assert np.isclose(calculate_expectation(result, "ZZZ"), 1.0)
+
+    def test_three_qubit_zzz_on_111(self):
+        """ZZZ on |111> = -1 (three qubits flipped)."""
+        result = {"111": 1.0}
+        assert np.isclose(calculate_expectation(result, "ZZZ"), -1.0)
+
+    def test_three_qubit_zzi(self):
+        """ZZI on |000> = +1, on |101> = -1."""
+        assert np.isclose(calculate_expectation({"000": 1.0}, "ZZI"), 1.0)
+        assert np.isclose(calculate_expectation({"001": 1.0}, "ZZI"), 1.0)
+        assert np.isclose(calculate_expectation({"101": 1.0}, "ZZI"), -1.0)
+
+
+# =============================================================================
+# TestCalculateExpX
+# =============================================================================
+class TestCalculateExpX:
+    """Tests for calculate_exp_X.
+
+    Note: calculate_exp_X/Y work with any dict keys, but the key at
+    qubit_index must be '0' or '1' for meaningful results. Non-bit chars
+    are treated as '1' (adds negative sign).
+    """
+
+    def test_plus_state_x_expectation(self):
+        """X on |+> = +1. After H rotation: always measures |0>."""
+        result = {"0": 1.0}
+        assert np.isclose(calculate_exp_X(result, nqubit=1), 1.0)
+
+    def test_minus_state_x_expectation(self):
+        """X on |-> = -1. After H rotation: always measures |1>."""
+        result = {"1": 1.0}
+        assert np.isclose(calculate_exp_X(result, nqubit=1), -1.0)
+
+    def test_zero_state_x_expectation(self):
+        """X on |0> = 0. After H: equal superposition, 50/50."""
+        result = {"0": 0.5, "1": 0.5}
+        assert np.isclose(calculate_exp_X(result, nqubit=1), 0.0)
+
+    def test_one_state_x_expectation(self):
+        """X on |1> = 0. After H: equal superposition, 50/50."""
+        result = {"0": 0.5, "1": 0.5}
+        assert np.isclose(calculate_exp_X(result, nqubit=1), 0.0)
+
+    # -------------------------------------------------------------------------
+    # List input format
+    # -------------------------------------------------------------------------
+    def test_plus_state_list(self):
+        """X on |+> = +1 (list format [P(0), P(1)] = [1, 0])."""
+        result = [1.0, 0.0]
+        assert np.isclose(calculate_exp_X(result, nqubit=1), 1.0)
+
+    def test_minus_state_list(self):
+        """X on |-> = -1 (list format [0, 1])."""
+        result = [0.0, 1.0]
+        assert np.isclose(calculate_exp_X(result, nqubit=1), -1.0)
+
+    def test_zero_state_list(self):
+        """X on |0> = 0 (list format [0.5, 0.5])."""
+        result = [0.5, 0.5]
+        assert np.isclose(calculate_exp_X(result, nqubit=1), 0.0)
+
+    # -------------------------------------------------------------------------
+    # qubit_index on multi-qubit results (using computational basis keys)
+    # -------------------------------------------------------------------------
+    def test_bell_state_individual_x(self):
+        """Bell state |Phi+>: individual <X> = 0 for each qubit.
+
+        After H on one qubit: |Phi+> -> (|00>+|11>)/sqrt(2).
+        The measured qubit (q0) is 0 when outcome is '00' and 1 when '11'.
+        So P(q0=0)=0.5, P(q0=1)=0.5 -> <X> = 0.
+        """
+        result = {"00": 0.5, "11": 0.5}
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=0), 0.0)
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=1), 0.0)
+
+    def test_product_state_00_individual_x(self):
+        """<X> on |00> after H on both: always +1 for each qubit."""
+        # |00> after H on both -> |++> always -> bit 0 = '0', bit 1 = '0'
+        result = {"00": 1.0}
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=0), 1.0)
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=1), 1.0)
+
+    def test_product_state_01_individual_x(self):
+        """<X> on |01>: qubit 0 = 0 (50% each), qubit 1 = always 1 -> -1."""
+        # |01> after H on q0: (|01>+|11>)/sqrt(2). Qubit 0: 50% 0, 50% 1.
+        # Qubit 1: always 1.
+        result = {"01": 0.5, "11": 0.5}
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=0), 0.0)
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=1), -1.0)
+
+    def test_product_state_10_individual_x(self):
+        """<X> on |10>: qubit 0 = 50% 0/1, qubit 1 = always 0 -> +1."""
+        # |10> after H on q0: (|00>-|10>)/sqrt(2). Qubit 0: 50% 0, 50% 1.
+        # Qubit 1: always 0.
+        result = {"00": 0.5, "10": 0.5}
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=0), 0.0)
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=1), 1.0)
+
+    def test_product_state_11_individual_x(self):
+        """<X> on |11>: both qubits always 1 -> <X> = -1 each after H."""
+        # |11> after H on both -> |--> always -> bit 0 = '1', bit 1 = '1'
+        result = {"11": 1.0}
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=0), -1.0)
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=1), -1.0)
+
+    # -------------------------------------------------------------------------
+    # List format on multi-qubit
+    # -------------------------------------------------------------------------
+    def test_product_state_00_list(self):
+        """<X> on |00> (list format [P(00), P(01), P(10), P(11)])."""
+        # |00> after H on both -> |++> always. List index 0 (="00") = 1.0
+        result = [1.0, 0.0, 0.0, 0.0]
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=0), 1.0)
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=1), 1.0)
+
+    def test_product_state_11_list(self):
+        """<X> on |11> (list format)."""
+        # |11> after H on both -> |--> always. List index 3 (="11") = 1.0
+        result = [0.0, 0.0, 0.0, 1.0]
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=0), -1.0)
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=1), -1.0)
+
+    def test_bell_state_list(self):
+        """Bell state |Phi+> in list format: individual <X> = 0."""
+        # P(00)=0.5, P(11)=0.5 -> qubit 0: 50% 0, 50% 1 -> 0
+        result = [0.5, 0.0, 0.0, 0.5]
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=0), 0.0)
+        assert np.isclose(calculate_exp_X(result, nqubit=2, qubit_index=1), 0.0)
+
+    # -------------------------------------------------------------------------
+    # Default qubit_index = 0
+    # -------------------------------------------------------------------------
+    def test_default_qubit_index(self):
+        """Default qubit_index=0 works correctly."""
+        result = {"0": 1.0}
+        assert np.isclose(calculate_exp_X(result, nqubit=1), 1.0)
+        # For qubit_index=0 on 2-qubit Bell: P(bit0=0) from "00"+"10" - P(bit0=1) from "01"+"11"
+        # = 0.5 - 0.5 = 0
+        result2 = {"00": 0.5, "11": 0.5}
+        assert np.isclose(calculate_exp_X(result2, nqubit=2), 0.0)
+
+    # -------------------------------------------------------------------------
+    # Edge: non-'0'/'1' key chars (treated as '1')
+    # -------------------------------------------------------------------------
+    def test_non_bit_chars_treated_as_one(self):
+        """Non-'0'/'1' chars in key at qubit_index are treated as '1' (subtract prob)."""
+        # '+' is not '0', so treated as '1' -> subtract prob
+        result = {"+": 1.0}
+        assert np.isclose(calculate_exp_X(result, nqubit=1), -1.0)
+
+        result2 = {"0": 0.5, "+": 0.5}
+        assert np.isclose(calculate_exp_X(result2, nqubit=1), 0.0)  # 0.5 - 0.5 = 0
+
+
+# =============================================================================
+# TestCalculateExpY
+# =============================================================================
+class TestCalculateExpY:
+    """Tests for calculate_exp_Y.
+
+    Same formula as X: <Y_k> = P(bit_k=0) - P(bit_k=1).
+    The difference is in the circuit rotation (S\\dagger H instead of H).
+    """
+
+    def test_plusi_state_y_expectation(self):
+        """Y on |+i> = +1. After Sdg H rotation: always measures |0>."""
+        result = {"0": 1.0}
+        assert np.isclose(calculate_exp_Y(result, nqubit=1), 1.0)
+
+    def test_minusi_state_y_expectation(self):
+        """Y on |-i> = -1. After Sdg H rotation: always measures |1>."""
+        result = {"1": 1.0}
+        assert np.isclose(calculate_exp_Y(result, nqubit=1), -1.0)
+
+    def test_zero_state_y_expectation(self):
+        """Y on |0> = 0 (after Sdg H: 50/50)."""
+        result = {"0": 0.5, "1": 0.5}
+        assert np.isclose(calculate_exp_Y(result, nqubit=1), 0.0)
+
+    def test_one_state_y_expectation(self):
+        """Y on |1> = 0 (after Sdg H: 50/50)."""
+        result = {"0": 0.5, "1": 0.5}
+        assert np.isclose(calculate_exp_Y(result, nqubit=1), 0.0)
+
+    # -------------------------------------------------------------------------
+    # List input format
+    # -------------------------------------------------------------------------
+    def test_plusi_state_list(self):
+        """Y on |+i> = +1 (list format)."""
+        result = [1.0, 0.0]
+        assert np.isclose(calculate_exp_Y(result, nqubit=1), 1.0)
+
+    def test_minusi_state_list(self):
+        """Y on |-i> = -1 (list format)."""
+        result = [0.0, 1.0]
+        assert np.isclose(calculate_exp_Y(result, nqubit=1), -1.0)
+
+    def test_zero_state_list(self):
+        """Y on |0> = 0 (list format)."""
+        result = [0.5, 0.5]
+        assert np.isclose(calculate_exp_Y(result, nqubit=1), 0.0)
+
+    # -------------------------------------------------------------------------
+    # qubit_index on multi-qubit results
+    # -------------------------------------------------------------------------
+    def test_bell_state_individual_y(self):
+        """Bell state |Phi+>: individual <Y> = 0 for each qubit."""
+        result = {"00": 0.5, "11": 0.5}
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=0), 0.0)
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=1), 0.0)
+
+    def test_product_state_00_individual_y(self):
+        """<Y> on |00> after Sdg H on both: always +1 for each qubit."""
+        result = {"00": 1.0}
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=0), 1.0)
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=1), 1.0)
+
+    def test_product_state_01_individual_y(self):
+        """<Y> on |01>: qubit 0 = 50/50, qubit 1 = always 1 -> -1."""
+        result = {"01": 0.5, "11": 0.5}
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=0), 0.0)
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=1), -1.0)
+
+    def test_product_state_10_individual_y(self):
+        """<Y> on |10>: qubit 0 = 50/50, qubit 1 = always 0 -> +1."""
+        result = {"00": 0.5, "10": 0.5}
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=0), 0.0)
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=1), 1.0)
+
+    def test_product_state_11_individual_y(self):
+        """<Y> on |11>: both qubits always 1 -> <Y> = -1 each after Sdg H."""
+        result = {"11": 1.0}
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=0), -1.0)
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=1), -1.0)
+
+    # -------------------------------------------------------------------------
+    # List format on multi-qubit
+    # -------------------------------------------------------------------------
+    def test_product_state_00_list(self):
+        """<Y> on |00> (list format)."""
+        result = [1.0, 0.0, 0.0, 0.0]
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=0), 1.0)
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=1), 1.0)
+
+    def test_product_state_11_list(self):
+        """<Y> on |11> (list format)."""
+        result = [0.0, 0.0, 0.0, 1.0]
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=0), -1.0)
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=1), -1.0)
+
+    def test_bell_state_list(self):
+        """Bell state in list format: individual <Y> = 0."""
+        result = [0.5, 0.0, 0.0, 0.5]
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=0), 0.0)
+        assert np.isclose(calculate_exp_Y(result, nqubit=2, qubit_index=1), 0.0)
+
+    # -------------------------------------------------------------------------
+    # Default qubit_index = 0
+    # -------------------------------------------------------------------------
+    def test_default_qubit_index(self):
+        """Default qubit_index=0 works correctly."""
+        result = {"0": 1.0}
+        assert np.isclose(calculate_exp_Y(result, nqubit=1), 1.0)
+        result2 = {"00": 0.5, "11": 0.5}
+        assert np.isclose(calculate_exp_Y(result2, nqubit=2), 0.0)
+
+    # -------------------------------------------------------------------------
+    # Edge: non-'0'/'1' key chars
+    # -------------------------------------------------------------------------
+    def test_non_bit_chars_treated_as_one(self):
+        """Non-'0'/'1' chars in key at qubit_index are treated as '1'."""
+        result = {"+": 1.0}
+        assert np.isclose(calculate_exp_Y(result, nqubit=1), -1.0)
+
+        result2 = {"0": 0.5, "+": 0.5}
+        assert np.isclose(calculate_exp_Y(result2, nqubit=1), 0.0)
+
+
+# =============================================================================
+# TestCalculateMultiBasisExpectation
+# =============================================================================
+class TestCalculateMultiBasisExpectation:
+    """Tests for calculate_multi_basis_expectation."""
+
+    def test_single_qubit_z_basis(self):
+        """Z basis on |0> gives <Z> = +1."""
+        z_result = {"0": 1.0}
+        out = calculate_multi_basis_expectation({"Z": z_result}, nqubit=1)
+        assert np.isclose(out["Z"], 1.0)
+
+    def test_single_qubit_z_basis_one(self):
+        """Z basis on |1> gives <Z> = -1."""
+        z_result = {"1": 1.0}
+        out = calculate_multi_basis_expectation({"Z": z_result}, nqubit=1)
+        assert np.isclose(out["Z"], -1.0)
+
+    def test_single_qubit_x_basis(self):
+        """X basis on |+> gives <X> = +1."""
+        x_result = {"0": 1.0}
+        out = calculate_multi_basis_expectation({"X": x_result}, nqubit=1)
+        assert np.isclose(out["X"], 1.0)
+
+    def test_single_qubit_y_basis(self):
+        """Y basis on |+i> gives <Y> = +1."""
+        y_result = {"0": 1.0}
+        out = calculate_multi_basis_expectation({"Y": y_result}, nqubit=1)
+        assert np.isclose(out["Y"], 1.0)
+
+    def test_zxz_dispatch(self):
+        """X/Y/Z dispatching: |0> in Z=<Z>=1, X=<X>=0, Y=<Y>=0."""
+        out = calculate_multi_basis_expectation(
+            {
+                "Z": {"0": 1.0},
+                "X": {"0": 0.5, "1": 0.5},
+                "Y": {"0": 0.5, "1": 0.5},
+            },
+            nqubit=1,
+        )
+        assert np.isclose(out["Z"], 1.0)
+        assert np.isclose(out["X"], 0.0)
+        assert np.isclose(out["Y"], 0.0)
+
+    def test_bell_state_z_basis(self):
+        """|Phi+> in Z basis: <ZZ> = +1."""
+        z_result = {"00": 0.5, "11": 0.5}
+        out = calculate_multi_basis_expectation({"Z": z_result}, nqubit=2)
+        assert np.isclose(out["Z"], 1.0)
+
+    def test_bell_state_individual_x(self):
+        """|Phi+> in X basis (H on both): individual <X> = 0 for each qubit.
+
+        After H on both qubits of |Phi+>, the measurement outcomes are
+        |00> and |11> each with 50% (in computational basis representation).
+        Qubit 0: P(0)=0.5, P(1)=0.5 -> <X> = 0.
+        """
+        x_result = {"00": 0.5, "11": 0.5}
+        out = calculate_multi_basis_expectation({"X": x_result}, nqubit=2)
+        assert np.isclose(out["X"], 0.0)
+
+    def test_bell_state_individual_y(self):
+        """|Phi+> in Y basis (Sdg H on both): individual <Y> = 0 for each qubit."""
+        y_result = {"00": 0.5, "11": 0.5}
+        out = calculate_multi_basis_expectation({"Y": y_result}, nqubit=2)
+        assert np.isclose(out["Y"], 0.0)
+
+    def test_product_state_00_xyz(self):
+        """|00>: <Z*Z> = +1, individual <X> = +1, individual <Y> = +1."""
+        z_result = {"00": 1.0}
+        x_result = {"00": 1.0}  # H on both -> |00> (still |00> in comp basis)
+        y_result = {"00": 1.0}  # Sdg H on both -> |00>
+        out = calculate_multi_basis_expectation(
+            {"Z": z_result, "X": x_result, "Y": y_result}, nqubit=2
+        )
+        assert np.isclose(out["Z"], 1.0)
+        assert np.isclose(out["X"], 1.0)
+        assert np.isclose(out["Y"], 1.0)
+
+    def test_product_state_11_xyz(self):
+        """|11>: <Z*Z> = +1, individual <X> = -1, individual <Y> = -1."""
+        z_result = {"11": 1.0}
+        x_result = {"11": 1.0}  # H on both -> |-->, key still "11"
+        y_result = {"11": 1.0}  # Sdg H on both -> |-->, key still "11"
+        out = calculate_multi_basis_expectation(
+            {"Z": z_result, "X": x_result, "Y": y_result}, nqubit=2
+        )
+        assert np.isclose(out["Z"], 1.0)
+        assert np.isclose(out["X"], -1.0)
+        assert np.isclose(out["Y"], -1.0)
+
+    def test_case_insensitive_labels(self):
+        """Basis labels are case-insensitive (x=X, y=Y, z=Z)."""
+        out = calculate_multi_basis_expectation(
+            {"z": {"0": 1.0}, "x": {"0": 1.0}, "y": {"0": 1.0}}, nqubit=1
+        )
+        assert np.isclose(out["z"], 1.0)
+        assert np.isclose(out["x"], 1.0)
+        assert np.isclose(out["y"], 1.0)
+
+    def test_custom_label_uses_z(self):
+        """Custom labels not starting with X/Y fall back to Z with ZZ...Z."""
+        result = {"00": 1.0}
+        out = calculate_multi_basis_expectation({"custom": result}, nqubit=2)
+        assert np.isclose(out["custom"], 1.0)  # ZZ on |00> = +1
+
+    def test_multiple_custom_labels(self):
+        """Multiple custom labels all treated as Z (ZZZ...Z Hamiltonian)."""
+        result = {"000": 1.0}
+        out = calculate_multi_basis_expectation(
+            {"foo": result, "bar": result}, nqubit=3
+        )
+        assert np.isclose(out["foo"], 1.0)
+        assert np.isclose(out["bar"], 1.0)
+
+    def test_mixed_x_labels(self):
+        """X, X0, X1 all dispatched to calculate_exp_X."""
+        result = {"0": 1.0}
+        out = calculate_multi_basis_expectation(
+            {"X": result, "X0": result, "X1": result}, nqubit=1
+        )
+        assert np.isclose(out["X"], 1.0)
+        assert np.isclose(out["X0"], 1.0)
+        assert np.isclose(out["X1"], 1.0)
+
+    def test_mixed_y_labels(self):
+        """Y and Y0 both dispatched to calculate_exp_Y."""
+        result = {"0": 1.0}
+        out = calculate_multi_basis_expectation(
+            {"Y": result, "Y0": result}, nqubit=1
+        )
+        assert np.isclose(out["Y"], 1.0)
+        assert np.isclose(out["Y0"], 1.0)
+
+    def test_list_format_in_measured_results(self):
+        """measured_results can contain list-format inputs for all bases."""
+        out = calculate_multi_basis_expectation(
+            {"Z": [1.0, 0.0], "X": [1.0, 0.0], "Y": [1.0, 0.0]}, nqubit=1
+        )
+        assert np.isclose(out["Z"], 1.0)
+        assert np.isclose(out["X"], 1.0)
+        assert np.isclose(out["Y"], 1.0)
+
+    def test_empty_measured_results(self):
+        """Empty measured_results returns empty dict."""
+        out = calculate_multi_basis_expectation({}, nqubit=1)
+        assert out == {}
+
+    def test_three_qubit_zzz_on_000(self):
+        """3-qubit Z basis on |000>: <ZZZ> = +1."""
+        result = {"000": 1.0}
+        out = calculate_multi_basis_expectation({"Z": result}, nqubit=3)
+        assert np.isclose(out["Z"], 1.0)
+
+    def test_three_qubit_zzz_on_001(self):
+        """3-qubit Z basis on |001>: <ZZZ> = -1."""
+        result = {"001": 1.0}
+        out = calculate_multi_basis_expectation({"Z": result}, nqubit=3)
+        assert np.isclose(out["Z"], -1.0)
+
+    def test_xz_yz_combined(self):
+        """X, Z, and Y bases together on |00>."""
+        z_result = {"00": 1.0}
+        x_result = {"00": 1.0}  # H on both -> still |00>
+        y_result = {"00": 1.0}  # Sdg H on both -> still |00>
+        out = calculate_multi_basis_expectation(
+            {"Z": z_result, "X": x_result, "Y": y_result}, nqubit=2
+        )
+        assert np.isclose(out["Z"], 1.0)
+        assert np.isclose(out["X"], 1.0)
+        assert np.isclose(out["Y"], 1.0)
+
+    def test_xy_on_separate_bell_components(self):
+        """X and Y results can be different dicts (different measurement setups)."""
+        z_result = {"00": 0.5, "11": 0.5}
+        # X basis: H on both, outcomes |00> and |11> -> each qubit 50/50
+        x_result = {"00": 0.5, "11": 0.5}
+        # Y basis: Sdg H on both -> same outcomes
+        y_result = {"00": 0.5, "11": 0.5}
+        out = calculate_multi_basis_expectation(
+            {"Z": z_result, "X": x_result, "Y": y_result}, nqubit=2
+        )
+        assert np.isclose(out["Z"], 1.0)
+        assert np.isclose(out["X"], 0.0)
+        assert np.isclose(out["Y"], 0.0)

--- a/qpandalite/test/test_analyzer_result_adapter.py
+++ b/qpandalite/test/test_analyzer_result_adapter.py
@@ -1,0 +1,555 @@
+"""Unit tests for qpandalite/analyzer/result_adapter.py"""
+
+import numpy as np
+import pytest
+
+from qpandalite.analyzer.result_adapter import (
+    convert_originq_result,
+    convert_quafu_result,
+    shots2prob,
+    kv2list,
+    list2kv,
+    normalize_result,
+    QASMResultAdapter,
+)
+
+
+# =============================================================================
+# Test data (module-level constants)
+# =============================================================================
+
+ORIGINQ_SINGLE = {"key": ["0x1", "0x2", "0x7"], "value": [10, 20, 9970]}
+QUAFU_SINGLE = [{"res": '{"00": 512, "11": 488}'}]
+QUAFU_MULTI = [
+    {"res": '{"00": 512, "11": 488}'},
+    {"res": '{"01": 300, "10": 700}'},
+]
+
+
+# =============================================================================
+# convert_originq_result
+# =============================================================================
+
+class TestConvertOriginqResult:
+    """Tests for convert_originq_result."""
+
+    def test_single_keyvalue_prob_reverse_bin(self):
+        """style='keyvalue', prob_or_shots='prob', reverse_key=True, key_style='bin'.
+        
+        Keys are reversed binary strings: 0x1->'001'->'100'->'100', 0x2->'010'->'010',
+        0x7->'111'->'111'. Values normalized by total=10000.
+        """
+        result = convert_originq_result(
+            ORIGINQ_SINGLE,
+            style="keyvalue",
+            prob_or_shots="prob",
+            reverse_key=True,
+            key_style="bin",
+        )
+        assert result["100"] == pytest.approx(0.001)
+        assert result["010"] == pytest.approx(0.002)
+        assert result["111"] == pytest.approx(0.997)
+
+    def test_single_keyvalue_prob_reverse_dec(self):
+        """style='keyvalue', prob_or_shots='prob', reverse_key=True, key_style='dec'.
+        
+        Keys are reversed then converted to integers:
+        0x1=1->'001'->'100'->int 4
+        0x2=2->'010'->'010'->int 2
+        0x7=7->'111'->'111'->int 7
+        """
+        result = convert_originq_result(
+            ORIGINQ_SINGLE,
+            style="keyvalue",
+            prob_or_shots="prob",
+            reverse_key=True,
+            key_style="dec",
+        )
+        assert result[4] == pytest.approx(0.001)
+        assert result[2] == pytest.approx(0.002)
+        assert result[7] == pytest.approx(0.997)
+
+    def test_single_keyvalue_prob_no_reverse(self):
+        """style='keyvalue', prob_or_shots='prob', reverse_key=False.
+        
+        Keys are binary strings (not reversed):
+        0x1=1->'001', 0x2=2->'010', 0x7=7->'111'
+        """
+        result = convert_originq_result(
+            ORIGINQ_SINGLE,
+            style="keyvalue",
+            prob_or_shots="prob",
+            reverse_key=False,
+        )
+        assert result["001"] == pytest.approx(0.001)
+        assert result["010"] == pytest.approx(0.002)
+        assert result["111"] == pytest.approx(0.997)
+
+    def test_single_keyvalue_shots(self):
+        """style='keyvalue', prob_or_shots='shots', reverse_key=True."""
+        result = convert_originq_result(
+            ORIGINQ_SINGLE,
+            style="keyvalue",
+            prob_or_shots="shots",
+            reverse_key=True,
+        )
+        assert result["100"] == 10
+        assert result["010"] == 20
+        assert result["111"] == 9970
+
+    def test_single_keyvalue_no_reverse_shots(self):
+        """style='keyvalue', prob_or_shots='shots', reverse_key=False."""
+        result = convert_originq_result(
+            ORIGINQ_SINGLE,
+            style="keyvalue",
+            prob_or_shots="shots",
+            reverse_key=False,
+        )
+        assert result["001"] == 10
+        assert result["010"] == 20
+        assert result["111"] == 9970
+
+    def test_single_list_style(self):
+        """style='list', prob_or_shots='prob', reverse_key=True.
+        
+        When style='list', key_style becomes 'dec' internally.
+        Keys after reverse (dec): 0x1=1->4, 0x2=2->2, 0x7=7->7.
+        List length = 2**3 = 8.
+        """
+        result = convert_originq_result(
+            ORIGINQ_SINGLE,
+            style="list",
+            prob_or_shots="prob",
+            reverse_key=True,
+        )
+        assert len(result) == 8
+        assert result[4] == pytest.approx(0.001)
+        assert result[2] == pytest.approx(0.002)
+        assert result[7] == pytest.approx(0.997)
+        assert result[0] == 0
+        assert result[1] == 0
+
+    def test_single_list_style_no_reverse(self):
+        """style='list', prob_or_shots='prob', reverse_key=False."""
+        result = convert_originq_result(
+            ORIGINQ_SINGLE,
+            style="list",
+            prob_or_shots="prob",
+            reverse_key=False,
+        )
+        assert len(result) == 8
+        assert result[1] == pytest.approx(0.001)
+        assert result[2] == pytest.approx(0.002)
+        assert result[7] == pytest.approx(0.997)
+
+    def test_qubit_num_override(self):
+        """qubit_num parameter overrides the guessed qubit number."""
+        result = convert_originq_result(
+            {"key": ["0x1", "0x2"], "value": [1, 1]},
+            style="list",
+            prob_or_shots="prob",
+            reverse_key=False,
+            qubit_num=4,  # 4 qubits -> length 16
+        )
+        assert len(result) == 16
+
+    def test_invalid_style_raises(self):
+        with pytest.raises(ValueError, match="style only accepts"):
+            convert_originq_result(ORIGINQ_SINGLE, style="invalid")
+
+    def test_invalid_prob_or_shots_raises(self):
+        with pytest.raises(ValueError, match="prob_or_shots only accepts"):
+            convert_originq_result(ORIGINQ_SINGLE, prob_or_shots="invalid")
+
+    def test_invalid_key_style_raises(self):
+        with pytest.raises(ValueError, match="key_style must be either"):
+            convert_originq_result(ORIGINQ_SINGLE, key_style="invalid")
+
+    # --- input type: list of dicts ---
+
+    def test_list_input_returns_list(self):
+        """List input returns a list of results."""
+        results = convert_originq_result([ORIGINQ_SINGLE, ORIGINQ_SINGLE])
+        assert isinstance(results, list)
+        assert len(results) == 2
+        assert isinstance(results[0], dict)
+
+    def test_list_input_list_style(self):
+        """List of results with style='list'."""
+        results = convert_originq_result([ORIGINQ_SINGLE], style="list")
+        assert isinstance(results, list)
+        assert len(results) == 1
+        assert isinstance(results[0], list)
+
+    def test_list_input_shots(self):
+        """List input with prob_or_shots='shots'."""
+        results = convert_originq_result(
+            [ORIGINQ_SINGLE, ORIGINQ_SINGLE],
+            style="keyvalue",
+            prob_or_shots="shots",
+            reverse_key=True,
+        )
+        assert len(results) == 2
+        assert results[0]["100"] == 10
+        assert results[1]["100"] == 10
+
+
+# =============================================================================
+# convert_quafu_result
+# =============================================================================
+
+class TestConvertQuafuResult:
+    """Tests for convert_quafu_result."""
+
+    def test_json_parsing(self):
+        """JSON string in 'res' field is correctly parsed.
+        
+        convert_quafu_result always wraps output in a list (even for single input).
+        With style='keyvalue', returns [[{key: value}]].
+        """
+        result = convert_quafu_result(
+            QUAFU_SINGLE,
+            style="keyvalue",
+            prob_or_shots="shots",
+            reverse_key=False,
+        )
+        # Result is [[dict]] — extra list wrapping for single input
+        assert isinstance(result, list)
+        inner = result[0]
+        assert isinstance(inner, list)
+        inner_dict = inner[0]
+        assert inner_dict["00"] == 512
+        assert inner_dict["11"] == 488
+
+    def test_keyvalue_prob_reverse_bin(self):
+        """style='keyvalue', prob_or_shots='prob', reverse_key=True.
+        
+        Keys are binary strings from JSON: '00', '11'.
+        With reverse=True: '00' reversed='00' (same), '11' reversed='11' (same).
+        """
+        result = convert_quafu_result(
+            QUAFU_SINGLE,
+            style="keyvalue",
+            prob_or_shots="prob",
+            reverse_key=True,
+            key_style="bin",
+        )
+        inner_dict = result[0][0]
+        assert inner_dict["00"] == pytest.approx(0.512)
+        assert inner_dict["11"] == pytest.approx(0.488)
+
+    def test_keyvalue_prob_no_reverse(self):
+        result = convert_quafu_result(
+            QUAFU_SINGLE,
+            style="keyvalue",
+            prob_or_shots="prob",
+            reverse_key=False,
+        )
+        inner_dict = result[0][0]
+        assert inner_dict["00"] == pytest.approx(0.512)
+        assert inner_dict["11"] == pytest.approx(0.488)
+
+    def test_keyvalue_shots(self):
+        result = convert_quafu_result(
+            QUAFU_SINGLE,
+            style="keyvalue",
+            prob_or_shots="shots",
+            reverse_key=False,
+        )
+        inner_dict = result[0][0]
+        assert inner_dict["00"] == 512
+        assert inner_dict["11"] == 488
+
+    def test_list_style(self):
+        """style='list', prob_or_shots='prob', reverse_key=False.
+        
+        When style='list', key_style becomes 'dec' internally.
+        Keys: '00'->0, '11'->3.
+        List length = 2**2 = 4.
+        """
+        result = convert_quafu_result(
+            QUAFU_SINGLE,
+            style="list",
+            prob_or_shots="prob",
+            reverse_key=False,
+        )
+        assert isinstance(result, list)
+        inner = result[0]
+        assert isinstance(inner, list)
+        assert len(inner) == 4
+        assert inner[0] == pytest.approx(0.512)
+        assert inner[3] == pytest.approx(0.488)
+        assert inner[1] == 0
+        assert inner[2] == 0
+
+    def test_list_style_reverse(self):
+        """With symmetric strings '00' and '11', reversal has no effect."""
+        result = convert_quafu_result(
+            QUAFU_SINGLE,
+            style="list",
+            prob_or_shots="prob",
+            reverse_key=True,
+        )
+        inner = result[0]
+        assert inner[0] == pytest.approx(0.512)
+        assert inner[3] == pytest.approx(0.488)
+
+    def test_qubit_num_override(self):
+        """qubit_num=3 overrides to length 8 even though only 2 qubits in data."""
+        quafu_result = [{"res": '{"0": 1, "1": 1}'}]  # 1 qubit
+        result = convert_quafu_result(
+            quafu_result,
+            style="list",
+            prob_or_shots="prob",
+            reverse_key=False,
+            qubit_num=3,  # 3 qubits -> list length 8
+        )
+        assert len(result[0]) == 8
+
+    def test_multi_result_list(self):
+        """Multiple Quafu results each wrapped in an extra list."""
+        results = convert_quafu_result(
+            QUAFU_MULTI,
+            style="keyvalue",
+            prob_or_shots="shots",
+            reverse_key=False,
+        )
+        assert len(results) == 2
+        # First: '00'->0, '11'->3
+        assert results[0][0]["00"] == 512
+        assert results[0][0]["11"] == 488
+        # Second: '01'->1, '10'->2
+        assert results[1][0]["01"] == 300
+        assert results[1][0]["10"] == 700
+
+    def test_invalid_style_raises(self):
+        with pytest.raises(ValueError, match="style only accepts"):
+            convert_quafu_result(QUAFU_SINGLE, style="invalid")
+
+    def test_invalid_prob_or_shots_raises(self):
+        with pytest.raises(ValueError, match="prob_or_shots only accepts"):
+            convert_quafu_result(QUAFU_SINGLE, prob_or_shots="invalid")
+
+    def test_invalid_key_style_raises(self):
+        with pytest.raises(ValueError, match="key_style must be either"):
+            convert_quafu_result(QUAFU_SINGLE, key_style="invalid")
+
+
+# =============================================================================
+# shots2prob
+# =============================================================================
+
+class TestShots2Prob:
+    """Tests for shots2prob."""
+
+    def test_basic(self):
+        result = shots2prob({"00": 512, "11": 488})
+        assert result["00"] == pytest.approx(0.512)
+        assert result["11"] == pytest.approx(0.488)
+
+    def test_with_total_shots(self):
+        result = shots2prob({"00": 512, "11": 488}, total_shots=1000)
+        assert result["00"] == pytest.approx(0.512)
+        assert result["11"] == pytest.approx(0.488)
+
+    def test_total_shots_override(self):
+        """total_shots can be different from sum of values."""
+        result = shots2prob({"00": 500, "11": 500}, total_shots=2000)
+        assert result["00"] == pytest.approx(0.25)
+        assert result["11"] == pytest.approx(0.25)
+
+    def test_empty_dict(self):
+        result = shots2prob({})
+        assert result == {}
+
+    def test_single_entry(self):
+        result = shots2prob({"00": 1000})
+        assert result["00"] == pytest.approx(1.0)
+
+
+# =============================================================================
+# kv2list
+# =============================================================================
+
+class TestKv2List:
+    """Tests for kv2list."""
+
+    def test_standard(self):
+        # 2-qubit system: length 4, keys 0 and 3 have values
+        result = kv2list({0: 0.1, 3: 0.9}, 2)
+        assert len(result) == 4
+        assert result[0] == 0.1
+        assert result[3] == 0.9
+        assert result[1] == 0
+        assert result[2] == 0
+
+    def test_some_zero_entries(self):
+        result = kv2list({0: 0.25, 1: 0.25, 2: 0.25, 3: 0.25}, 2)
+        assert result == [0.25, 0.25, 0.25, 0.25]
+
+    def test_all_zeros(self):
+        result = kv2list({0: 0, 1: 0, 2: 0, 3: 0}, 2)
+        assert result == [0, 0, 0, 0]
+
+    def test_3_qubits(self):
+        result = kv2list({1: 0.5, 7: 0.5}, 3)
+        assert len(result) == 8
+        assert result[1] == 0.5
+        assert result[7] == 0.5
+        assert result[0] == 0
+
+
+# =============================================================================
+# list2kv
+# =============================================================================
+
+class TestList2Kv:
+    """Tests for list2kv."""
+
+    def test_standard(self):
+        result = list2kv(["00", "01", "10", "00", "11", "00"])
+        assert result["00"] == 3
+        assert result["01"] == 1
+        assert result["10"] == 1
+        assert result["11"] == 1
+
+    def test_empty_list(self):
+        result = list2kv([])
+        assert result == {}
+
+    def test_single_item(self):
+        result = list2kv(["00"])
+        assert result["00"] == 1
+
+    def test_all_same(self):
+        result = list2kv(["00", "00", "00"])
+        assert result["00"] == 3
+
+    def test_decimal_string_keys(self):
+        result = list2kv(["0", "1", "2"])
+        assert result["0"] == 1
+        assert result["1"] == 1
+        assert result["2"] == 1
+
+
+# =============================================================================
+# normalize_result
+# =============================================================================
+
+class TestNormalizeResult:
+    """Tests for normalize_result."""
+
+    def test_dict_input(self):
+        result = normalize_result({"00": 512, "11": 488})
+        assert result["00"] == pytest.approx(0.512)
+        assert result["11"] == pytest.approx(0.488)
+
+    def test_list_input(self):
+        result = normalize_result(["00", "01", "10", "00", "11", "00"])
+        assert result["00"] == pytest.approx(3 / 6)
+        assert result["01"] == pytest.approx(1 / 6)
+        assert result["10"] == pytest.approx(1 / 6)
+        assert result["11"] == pytest.approx(1 / 6)
+
+    def test_empty_dict(self):
+        result = normalize_result({})
+        assert result == {}
+
+    def test_empty_list(self):
+        result = normalize_result([])
+        assert result == {}
+
+    def test_dict_already_sums_to_one(self):
+        result = normalize_result({"00": 0.5, "11": 0.5})
+        assert result["00"] == pytest.approx(0.5)
+        assert result["11"] == pytest.approx(0.5)
+
+    def test_single_entry(self):
+        result = normalize_result({"00": 100})
+        assert result["00"] == pytest.approx(1.0)
+
+
+# =============================================================================
+# QASMResultAdapter
+# =============================================================================
+
+class TestQASMResultAdapter:
+    """Tests for QASMResultAdapter class."""
+
+    def test_counts_only(self):
+        adapter = QASMResultAdapter(counts={"00": 512, "11": 488})
+        assert adapter.counts == {"00": 512, "11": 488}
+        assert adapter.shots == 1000
+        assert adapter.metadata["simulator"] == "qasm_simulator"
+        assert adapter.metadata["shots"] == 1000
+        assert adapter.probabilities["00"] == pytest.approx(0.512)
+        assert adapter.probabilities["11"] == pytest.approx(0.488)
+
+    def test_counts_plus_shots(self):
+        """When shots is provided, probabilities are computed against that total."""
+        adapter = QASMResultAdapter(counts={"00": 512, "11": 488}, shots=2000)
+        assert adapter.shots == 2000
+        # Probabilities are always computed from counts / total_counts (not provided shots)
+        assert adapter.probabilities["00"] == pytest.approx(0.512)
+        assert adapter.probabilities["11"] == pytest.approx(0.488)
+
+    def test_counts_plus_metadata(self):
+        adapter = QASMResultAdapter(
+            counts={"00": 512, "11": 488},
+            metadata={"simulator": "custom_sim", "noise": "none"},
+        )
+        assert adapter.metadata["simulator"] == "custom_sim"
+        assert adapter.metadata["noise"] == "none"
+        assert adapter.metadata["shots"] == 1000  # default shots still set
+
+    def test_counts_plus_shots_and_metadata(self):
+        adapter = QASMResultAdapter(
+            counts={"00": 512, "11": 488},
+            shots=2000,
+            metadata={"simulator": "custom_sim"},
+        )
+        assert adapter.shots == 2000
+        assert adapter.metadata["simulator"] == "custom_sim"
+        assert adapter.metadata["shots"] == 2000
+
+    def test_probabilities_computed_correctly(self):
+        adapter = QASMResultAdapter(counts={"00": 1, "01": 2, "10": 3, "11": 4})
+        total = 10
+        assert adapter.probabilities["00"] == pytest.approx(0.1)
+        assert adapter.probabilities["01"] == pytest.approx(0.2)
+        assert adapter.probabilities["10"] == pytest.approx(0.3)
+        assert adapter.probabilities["11"] == pytest.approx(0.4)
+        total_prob = sum(adapter.probabilities.values())
+        assert total_prob == pytest.approx(1.0)
+
+    def test_to_dict(self):
+        adapter = QASMResultAdapter(
+            counts={"00": 512, "11": 488},
+            metadata={"simulator": "my_sim"},
+        )
+        d = adapter.to_dict()
+        assert d["counts"] == {"00": 512, "11": 488}
+        assert d["probabilities"]["00"] == pytest.approx(0.512)
+        assert d["probabilities"]["11"] == pytest.approx(0.488)
+        assert d["shots"] == 1000
+        assert d["metadata"]["simulator"] == "my_sim"
+
+    def test_repr(self):
+        adapter = QASMResultAdapter(
+            counts={"00": 512, "11": 488},
+            metadata={"simulator": "my_sim"},
+        )
+        r = repr(adapter)
+        assert "QASMResultAdapter" in r
+        assert "shots=1000" in r
+        assert "outcomes=2" in r
+        assert "metadata" in r
+
+    def test_repr_with_custom_metadata(self):
+        adapter = QASMResultAdapter(
+            counts={"00": 1},
+            metadata={"note": "test"},
+        )
+        r = repr(adapter)
+        assert "QASMResultAdapter" in r
+        assert "shots=1" in r


### PR DESCRIPTION
## 测试覆盖内容

为 `qpandalite/analyzer` 模块编写了完整的单元测试，共 **193 个测试用例**。

### 测试文件

| 文件 | 测试数 | 覆盖内容 |
|------|--------|---------|
| `test_analyzer_expectation.py` | 94 | Z/X/Y 基期望值计算、多基测量、参数校验 |
| `test_analyzer_draw.py` | 46 | 电路绘制工具、结果解析、边界条件 |
| `test_analyzer_result_adapter.py` | 53 | OriginQ/Quafu 结果适配、概率转换、`QASMResultAdapter` |

### expection.py 覆盖函数
- `calculate_expectation` — Z 基底期望值（dict/list 格式、invalid Hamiltonian、边界条件）
- `calculate_exp_X` — Pauli-X 期望值（`qubit_index` 参数、多量子比特）
- `calculate_exp_Y` — Pauli-Y 期望值（同上）
- `calculate_multi_basis_expectation` — 多基测量分发（X/Y/Z 路由、自定义标签）

### draw.py 覆盖函数
- `_parse_measured_result` — 结果解析（power-of-2 校验、figsize 调整、rotation angle）
- `plot_histogram` / `plot_distribution` — 绘图（valid/invalid 输入）

### result_adapter.py 覆盖函数/类
- `convert_originq_result` — OriginQ 结果适配（全参数组合、list/single 输入）
- `convert_quafu_result` — Quafu 结果适配（JSON 解析、全参数组合）
- `shots2prob` / `kv2list` / `list2kv` / `normalize_result` — 概率工具函数
- `QASMResultAdapter` — QASM 结果适配器（counts/probabilities/shots/metadata/to_dict）

### 其他改动
- `pytest.ini`：`python_functions` 恢复为 `test_* run_test_*`（原 `run_test_*` 仅针对 @qpandalite_test 装饰器覆盖的旧测试）

### CI 状态
本地验证：193 passed
