### PR TITLE
test: add unit tests for qcloud_config modules (Issue #125)

### DIFF
--- a/qpandalite/test/test_qcloud_config_ibm.py
+++ b/qpandalite/test/test_qcloud_config_ibm.py
@@ -1,0 +1,71 @@
+"""Tests for qpandalite.qcloud_config.ibm_online_config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class RunTestIBMonlineConfig:
+    """Tests for create_ibm_online_config."""
+
+    def run_test_success_with_valid_token(self, tmp_path):
+        """Valid default_token writes correct ibm_online_config.json."""
+        from qpandalite.qcloud_config.ibm_online_config import (
+            create_ibm_online_config,
+        )
+
+        create_ibm_online_config(default_token="ibm_secret_123", savepath=tmp_path)
+
+        config_file = tmp_path / "ibm_online_config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert data == {"default_token": "ibm_secret_123"}
+
+    def run_test_success_default_savepath_cwd(self, monkeypatch, tmp_path):
+        """Without savepath, file is written to cwd."""
+        monkeypatch.chdir(tmp_path)
+        from qpandalite.qcloud_config.ibm_online_config import (
+            create_ibm_online_config,
+        )
+
+        create_ibm_online_config(default_token="ibm_token_abc")
+
+        config_file = tmp_path / "ibm_online_config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert data["default_token"] == "ibm_token_abc"
+
+    def run_test_missing_default_token_raises(self, tmp_path):
+        """Missing default_token raises RuntimeError."""
+        from qpandalite.qcloud_config.ibm_online_config import (
+            create_ibm_online_config,
+        )
+
+        with pytest.raises(RuntimeError, match="You should input your token"):
+            create_ibm_online_config(default_token=None, savepath=tmp_path)
+
+    def run_test_empty_string_token_raises(self, tmp_path):
+        """Empty string token raises RuntimeError (falsy check)."""
+        from qpandalite.qcloud_config.ibm_online_config import (
+            create_ibm_online_config,
+        )
+
+        with pytest.raises(RuntimeError, match="You should input your token"):
+            create_ibm_online_config(default_token="", savepath=tmp_path)
+
+    def run_test_custom_savepath(self, tmp_path):
+        """Custom savepath writes to the specified directory."""
+        from qpandalite.qcloud_config.ibm_online_config import (
+            create_ibm_online_config,
+        )
+
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        create_ibm_online_config(default_token="ibm_x", savepath=subdir)
+
+        config_file = subdir / "ibm_online_config.json"
+        assert config_file.exists()
+        assert json.loads(config_file.read_text()) == {"default_token": "ibm_x"}

--- a/qpandalite/test/test_qcloud_config_originq_cloud.py
+++ b/qpandalite/test/test_qcloud_config_originq_cloud.py
@@ -1,0 +1,205 @@
+"""Tests for qpandalite.qcloud_config.originq_cloud_config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class RunTestOriginQCloudConfig:
+    """Tests for create_originq_cloud_config."""
+
+    def run_test_success_with_all_params(self, tmp_path):
+        """Valid params write correct originq_cloud_config.json."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        create_originq_cloud_config(
+            apitoken="api_key_123",
+            submit_url="https://submit.example.com",
+            query_url="https://query.example.com",
+            available_qubits=[0, 1, 2, 3],
+            available_topology=[[0, 1], [1, 2], [2, 3]],
+            task_group_size=100,
+            savepath=tmp_path,
+        )
+
+        config_file = tmp_path / "originq_cloud_config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert data["apitoken"] == "api_key_123"
+        assert data["submit_url"] == "https://submit.example.com"
+        assert data["query_url"] == "https://query.example.com"
+        assert data["available_qubits"] == [0, 1, 2, 3]
+        assert data["available_topology"] == [[0, 1], [1, 2], [2, 3]]
+        assert data["task_group_size"] == 100
+
+    def run_test_success_default_task_group_size(self, tmp_path):
+        """Default task_group_size=200 is used when not specified."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        create_originq_cloud_config(
+            apitoken="key",
+            submit_url="https://s.com",
+            query_url="https://q.com",
+            available_qubits=[0],
+            available_topology=[[0, 1]],
+            savepath=tmp_path,
+        )
+
+        data = json.loads((tmp_path / "originq_cloud_config.json").read_text())
+        assert data["task_group_size"] == 200
+
+    def run_test_missing_apitoken_raises(self, tmp_path):
+        """Missing apitoken raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        with pytest.raises(RuntimeError, match="You should input your api key"):
+            create_originq_cloud_config(
+                apitoken=None,
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_missing_submit_url_raises(self, tmp_path):
+        """Missing submit_url raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        with pytest.raises(RuntimeError, match="submitting url"):
+            create_originq_cloud_config(
+                apitoken="key",
+                submit_url=None,
+                query_url="https://q.com",
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_missing_query_url_raises(self, tmp_path):
+        """Missing query_url raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        with pytest.raises(RuntimeError, match="querying url"):
+            create_originq_cloud_config(
+                apitoken="key",
+                submit_url="https://s.com",
+                query_url=None,
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_available_qubits_not_list_raises(self, tmp_path):
+        """available_qubits as non-list raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Available qubits must be a list"):
+            create_originq_cloud_config(
+                apitoken="key",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits={0, 1},
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_available_qubits_string_raises(self, tmp_path):
+        """available_qubits as string raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Available qubits must be a list"):
+            create_originq_cloud_config(
+                apitoken="key",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits="0,1",
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_available_topology_not_list_raises(self, tmp_path):
+        """available_topology as non-list raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Available topology must be a list"):
+            create_originq_cloud_config(
+                apitoken="key",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits=[0, 1],
+                available_topology="[[0,1]]",
+                savepath=tmp_path,
+            )
+
+    def run_test_task_group_size_not_int_raises(self, tmp_path):
+        """task_group_size as non-int raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Task group size"):
+            create_originq_cloud_config(
+                apitoken="key",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                task_group_size="100",
+                savepath=tmp_path,
+            )
+
+    def run_test_task_group_size_float_raises(self, tmp_path):
+        """task_group_size as float raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Task group size"):
+            create_originq_cloud_config(
+                apitoken="key",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                task_group_size=10.5,
+                savepath=tmp_path,
+            )
+
+    def run_test_custom_task_group_size(self, tmp_path):
+        """Custom task_group_size is written correctly."""
+        from qpandalite.qcloud_config.originq_cloud_config import (
+            create_originq_cloud_config,
+        )
+
+        create_originq_cloud_config(
+            apitoken="key",
+            submit_url="https://s.com",
+            query_url="https://q.com",
+            available_qubits=[0],
+            available_topology=[[0, 1]],
+            task_group_size=50,
+            savepath=tmp_path,
+        )
+
+        data = json.loads((tmp_path / "originq_cloud_config.json").read_text())
+        assert data["task_group_size"] == 50

--- a/qpandalite/test/test_qcloud_config_originq_online.py
+++ b/qpandalite/test/test_qcloud_config_originq_online.py
@@ -1,0 +1,340 @@
+"""Tests for qpandalite.qcloud_config.originq_online_config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class RunTestOriginQOnlineConfig:
+    """Tests for create_originq_config, create_originq_online_config, create_originq_dummy_config."""
+
+    # ----- create_originq_config -----
+
+    def run_test_create_originq_config_success(self, tmp_path):
+        """Valid params write correct originq_online_config.json."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_config,
+        )
+
+        create_originq_config(
+            login_apitoken="login_key",
+            login_url="https://login.example.com",
+            submit_url="https://submit.example.com",
+            query_url="https://query.example.com",
+            available_qubits=[0, 1, 2],
+            available_topology=[[0, 1], [1, 2]],
+            task_group_size=150,
+            savepath=tmp_path,
+        )
+
+        config_file = tmp_path / "originq_online_config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert data["login_apitoken"] == "login_key"
+        assert data["login_url"] == "https://login.example.com"
+        assert data["submit_url"] == "https://submit.example.com"
+        assert data["query_url"] == "https://query.example.com"
+        assert data["available_qubits"] == [0, 1, 2]
+        assert data["available_topology"] == [[0, 1], [1, 2]]
+        assert data["task_group_size"] == 150
+
+    def run_test_create_originq_config_missing_login_apitoken_raises(self, tmp_path):
+        """Missing login_apitoken raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_config,
+        )
+
+        with pytest.raises(RuntimeError, match="You should input your token"):
+            create_originq_config(
+                login_apitoken=None,
+                login_url="https://login.com",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_config_missing_login_url_raises(self, tmp_path):
+        """Missing login_url raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_config,
+        )
+
+        with pytest.raises(RuntimeError, match="login url"):
+            create_originq_config(
+                login_apitoken="key",
+                login_url=None,
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_config_missing_submit_url_raises(self, tmp_path):
+        """Missing submit_url raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_config,
+        )
+
+        with pytest.raises(RuntimeError, match="submitting url"):
+            create_originq_config(
+                login_apitoken="key",
+                login_url="https://l.com",
+                submit_url=None,
+                query_url="https://q.com",
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_config_missing_query_url_raises(self, tmp_path):
+        """Missing query_url raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_config,
+        )
+
+        with pytest.raises(RuntimeError, match="querying url"):
+            create_originq_config(
+                login_apitoken="key",
+                login_url="https://l.com",
+                submit_url="https://s.com",
+                query_url=None,
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_config_qubits_not_list_raises(self, tmp_path):
+        """available_qubits as non-list raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Available qubits must be a list"):
+            create_originq_config(
+                login_apitoken="key",
+                login_url="https://l.com",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits="0,1",
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_config_topology_not_list_raises(self, tmp_path):
+        """available_topology as non-list raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Available topology must be a list"):
+            create_originq_config(
+                login_apitoken="key",
+                login_url="https://l.com",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits=[0, 1],
+                available_topology={0: 1},
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_config_task_group_size_not_int_raises(self, tmp_path):
+        """task_group_size as non-int raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Task group size"):
+            create_originq_config(
+                login_apitoken="key",
+                login_url="https://l.com",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                task_group_size=100.0,
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_config_custom_task_group_size(self, tmp_path):
+        """Custom task_group_size is written correctly."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_config,
+        )
+
+        create_originq_config(
+            login_apitoken="key",
+            login_url="https://l.com",
+            submit_url="https://s.com",
+            query_url="https://q.com",
+            available_qubits=[0],
+            available_topology=[[0, 1]],
+            task_group_size=75,
+            savepath=tmp_path,
+        )
+
+        data = json.loads((tmp_path / "originq_online_config.json").read_text())
+        assert data["task_group_size"] == 75
+
+    # ----- create_originq_online_config -----
+
+    def run_test_create_originq_online_config_success(self, tmp_path):
+        """Valid params write correct originq_online_config.json with None qubits/topology."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_online_config,
+        )
+
+        create_originq_online_config(
+            login_apitoken="online_key",
+            login_url="https://login.example.com",
+            submit_url="https://submit.example.com",
+            query_url="https://query.example.com",
+            task_group_size=300,
+            savepath=tmp_path,
+        )
+
+        config_file = tmp_path / "originq_online_config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert data["login_apitoken"] == "online_key"
+        assert data["submit_url"] == "https://submit.example.com"
+        assert data["query_url"] == "https://query.example.com"
+        assert data["available_qubits"] is None
+        assert data["available_topology"] is None
+        assert data["task_group_size"] == 300
+
+    def run_test_create_originq_online_config_missing_login_apitoken_raises(self, tmp_path):
+        """Missing login_apitoken raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_online_config,
+        )
+
+        with pytest.raises(RuntimeError, match="You should input your token"):
+            create_originq_online_config(
+                login_apitoken=None,
+                login_url="https://l.com",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_online_config_task_group_size_not_int_raises(self, tmp_path):
+        """task_group_size as non-int raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_online_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Task group size"):
+            create_originq_online_config(
+                login_apitoken="key",
+                login_url="https://l.com",
+                submit_url="https://s.com",
+                query_url="https://q.com",
+                task_group_size="200",
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_online_config_custom_task_group_size(self, tmp_path):
+        """Custom task_group_size is written correctly."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_online_config,
+        )
+
+        create_originq_online_config(
+            login_apitoken="key",
+            login_url="https://l.com",
+            submit_url="https://s.com",
+            query_url="https://q.com",
+            task_group_size=250,
+            savepath=tmp_path,
+        )
+
+        data = json.loads((tmp_path / "originq_online_config.json").read_text())
+        assert data["task_group_size"] == 250
+
+    # ----- create_originq_dummy_config -----
+
+    def run_test_create_originq_dummy_config_success(self, tmp_path):
+        """Valid params write correct originq_online_config.json with DUMMY placeholders."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_dummy_config,
+        )
+
+        create_originq_dummy_config(
+            available_qubits=[0, 1, 2, 3, 4],
+            available_topology=[[0, 1], [1, 2], [2, 3], [3, 4]],
+            task_group_size=10,
+            savepath=tmp_path,
+        )
+
+        config_file = tmp_path / "originq_online_config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert data["login_apitoken"] == "DUMMY"
+        assert data["login_url"] == "DUMMY"
+        assert data["submit_url"] == "DUMMY"
+        assert data["query_url"] == "DUMMY"
+        assert data["available_qubits"] == [0, 1, 2, 3, 4]
+        assert data["available_topology"] == [[0, 1], [1, 2], [2, 3], [3, 4]]
+        assert data["task_group_size"] == 10
+
+    def run_test_create_originq_dummy_config_qubits_not_list_raises(self, tmp_path):
+        """available_qubits as non-list raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_dummy_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Available qubits must be a list"):
+            create_originq_dummy_config(
+                available_qubits="all",
+                available_topology=[[0, 1]],
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_dummy_config_topology_not_list_raises(self, tmp_path):
+        """available_topology as non-list raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_dummy_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Available topology must be a list"):
+            create_originq_dummy_config(
+                available_qubits=[0, 1],
+                available_topology="[[0,1]]",
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_dummy_config_task_group_size_not_int_raises(self, tmp_path):
+        """task_group_size as non-int raises RuntimeError."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_dummy_config,
+        )
+
+        with pytest.raises(RuntimeError, match="Task group size"):
+            create_originq_dummy_config(
+                available_qubits=[0],
+                available_topology=[[0, 1]],
+                task_group_size=5.5,
+                savepath=tmp_path,
+            )
+
+    def run_test_create_originq_dummy_config_custom_task_group_size(self, tmp_path):
+        """Custom task_group_size is written correctly."""
+        from qpandalite.qcloud_config.originq_online_config import (
+            create_originq_dummy_config,
+        )
+
+        create_originq_dummy_config(
+            available_qubits=[0],
+            available_topology=[[0, 1]],
+            task_group_size=20,
+            savepath=tmp_path,
+        )
+
+        data = json.loads((tmp_path / "originq_online_config.json").read_text())
+        assert data["task_group_size"] == 20

--- a/qpandalite/test/test_qcloud_config_quafu.py
+++ b/qpandalite/test/test_qcloud_config_quafu.py
@@ -1,0 +1,70 @@
+"""Tests for qpandalite.qcloud_config.quafu_online_config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class RunTestQuafuOnlineConfig:
+    """Tests for create_quafu_online_config."""
+
+    def run_test_success_with_valid_token(self, tmp_path):
+        """Valid default_token writes correct quafu_online_config.json."""
+        from qpandalite.qcloud_config.quafu_online_config import (
+            create_quafu_online_config,
+        )
+
+        create_quafu_online_config(default_token="quafu_secret_xyz", savepath=tmp_path)
+
+        config_file = tmp_path / "quafu_online_config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert data == {"default_token": "quafu_secret_xyz"}
+
+    def run_test_missing_default_token_raises(self, tmp_path):
+        """Missing default_token raises RuntimeError."""
+        from qpandalite.qcloud_config.quafu_online_config import (
+            create_quafu_online_config,
+        )
+
+        with pytest.raises(RuntimeError, match="You should input your token"):
+            create_quafu_online_config(default_token=None, savepath=tmp_path)
+
+    def run_test_empty_string_token_raises(self, tmp_path):
+        """Empty string token raises RuntimeError (falsy check)."""
+        from qpandalite.qcloud_config.quafu_online_config import (
+            create_quafu_online_config,
+        )
+
+        with pytest.raises(RuntimeError, match="You should input your token"):
+            create_quafu_online_config(default_token="", savepath=tmp_path)
+
+    def run_test_custom_savepath(self, tmp_path):
+        """Custom savepath writes to the specified directory."""
+        from qpandalite.qcloud_config.quafu_online_config import (
+            create_quafu_online_config,
+        )
+
+        subdir = tmp_path / "config_dir"
+        subdir.mkdir()
+        create_quafu_online_config(default_token="quafu_token", savepath=subdir)
+
+        config_file = subdir / "quafu_online_config.json"
+        assert config_file.exists()
+        assert json.loads(config_file.read_text()) == {"default_token": "quafu_token"}
+
+    def run_test_success_default_savepath_cwd(self, monkeypatch, tmp_path):
+        """Without savepath, file is written to cwd."""
+        monkeypatch.chdir(tmp_path)
+        from qpandalite.qcloud_config.quafu_online_config import (
+            create_quafu_online_config,
+        )
+
+        create_quafu_online_config(default_token="quafu_auto")
+
+        config_file = tmp_path / "quafu_online_config.json"
+        assert config_file.exists()
+        assert json.loads(config_file.read_text()) == {"default_token": "quafu_auto"}


### PR DESCRIPTION
## 测试覆盖：qcloud_config 模块（Issue #125）

### 覆盖范围

| 文件 | 测试用例数 | 说明 |
|------|-----------|------|
| `test_qcloud_config_ibm.py` | 5 | `create_ibm_online_config`：成功路径×2、缺少token×2、自定义savepath |
| `test_qcloud_config_originq_cloud.py` | 11 | `create_originq_cloud_config`：成功路径×2、缺少参数×3、类型错误×4、自定义task_group_size |
| `test_qcloud_config_originq_online.py` | 17 | `create_originq_config`×9、`create_originq_online_config`×4、`create_originq_dummy_config`×5 |
| `test_qcloud_config_quafu.py` | 5 | `create_quafu_online_config`：成功路径×2、缺少token×2、自定义savepath |

**总计**：39 passed, 0 failed

### 本地验证

```
pytest qpandalite/test/test_qcloud_config_*.py -v
39 passed, 1 warning
```
