### PR TITLE
fix(adapters): resolve 4 test_task_adapters failures (#135)

### DIFF
--- a/qpandalite/task/adapters/quafu_adapter.py
+++ b/qpandalite/task/adapters/quafu_adapter.py
@@ -85,7 +85,12 @@ class QuafuAdapter(QuantumAdapter):
         qc: "QuantumCircuit | None" = None
 
         for line in lines:
-            operation, qubit, cbit, parameter = OriginIR_LineParser.parse_line(line)
+            try:
+                operation, qubit, cbit, parameter, dagger_flag, control_qubits = OriginIR_LineParser.parse_line(line)
+            except NotImplementedError:
+                raise RuntimeError(
+                    f"Unknown OriginIR operation in quafu adapter: {line.strip()}"
+                ) from None
             if operation == "QINIT":
                 qc = self._QuantumCircuit(int(qubit))  # type: ignore[arg-type]
                 continue

--- a/qpandalite/test/test_task_adapters.py
+++ b/qpandalite/test/test_task_adapters.py
@@ -198,7 +198,7 @@ class RunTestOriginQAdapterCircuitTranslation:
                 )
                 mock_submit.assert_called_once()
                 args, kwargs = mock_submit.call_args
-                assert args[0] == [ORIGINIR_BELL]
+                assert kwargs["circuits"] == [ORIGINIR_BELL]
                 assert task_id == "task_abc123"
 
     def run_test_submit_batch_splits_large_groups(self):
@@ -342,29 +342,26 @@ MEASURE q[1], c[1]
                 "qpandalite.task.adapters.qiskit_adapter.load_ibm_config",
                 return_value={"api_token": "ibm_tok"},
             ):
+                from qpandalite.task.adapters import QiskitAdapter
+
+                adapter = QiskitAdapter.__new__(QiskitAdapter)
+                adapter._api_token = "ibm_tok"
+                adapter._provider = MagicMock()
+                adapter._backends = []
+                adapter._provider.backends = MagicMock(return_value=[])
+
                 with patch(
-                    "qpandalite.task.adapters.qiskit_adapter.qiskit_ibm_provider.IBMProvider.save_account"
-                ):
-                    from qpandalite.task.adapters import QiskitAdapter
+                    "qpandalite.circuit_builder.qcircuit.Circuit"
+                ) as mock_circuit_cls:
+                    mock_circuit = MagicMock()
+                    mock_circuit.qasm = "OPENQASM 2.0; ..."
+                    mock_circuit_cls.return_value = mock_circuit
 
-                    adapter = QiskitAdapter.__new__(QiskitAdapter)
-                    adapter._api_token = "ibm_tok"
-                    adapter._provider = MagicMock()
-                    adapter._backends = []
-                    adapter._provider.backends = MagicMock(return_value=[])
+                    result = adapter.translate_circuit(originir)
 
-                    with patch(
-                        "qpandalite.circuit_builder.qcircuit.Circuit"
-                    ) as mock_circuit_cls:
-                        mock_circuit = MagicMock()
-                        mock_circuit.qasm = "OPENQASM 2.0; ..."
-                        mock_circuit_cls.return_value = mock_circuit
-
-                        result = adapter.translate_circuit(originir)
-
-                    mock_qiskit.QuantumCircuit.from_qasm_str.assert_called_once_with(
-                        "OPENQASM 2.0; ..."
-                    )
+                mock_qiskit.QuantumCircuit.from_qasm_str.assert_called_once_with(
+                    "OPENQASM 2.0; ..."
+                )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- 修复 `quafu_adapter.py` 中 `parse_line` 返回值解包错误（6 值 vs 4 值），并捕获 `NotImplementedError` 转为 `RuntimeError`
- 修复 OriginQ adapter 测试中 mock 参数解包方式（`args[0]` → `kwargs["circuits"]`）
- 移除 IBM adapter 测试中对 `qiskit_ibm_provider` 的无效 patch（该模块仅在 `TYPE_CHECKING` 下可用）

Closes #135

## Test plan
- [ ] CI Build-and-test 通过
- [ ] 以下 4 个测试变绿：
  - `test_task_adapters.py::RunTestOriginQAdapterCircuitTranslation::run_test_submit_calls_http_client`
  - `test_task_adapters.py::RunTestQuafuAdapterCircuitTranslation::run_test_translate_simple_gates`
  - `test_task_adapters.py::RunTestQuafuAdapterCircuitTranslation::run_test_translate_unknown_gate_raises`
  - `test_task_adapters.py::RunTestIBMAdapterCircuitTranslation::run_test_translate_calls_circuit_qasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)