### PR TITLE
fix(measurement): resolve estimator, tomography, and simulator bugs (#134)

### DIFF
--- a/qpandalite/algorithmics/measurement/classical_shadow.py
+++ b/qpandalite/algorithmics/measurement/classical_shadow.py
@@ -211,7 +211,7 @@ def shadow_expectation(
     For each snapshot the single-qubit estimator is:
 
         P_i = 1                                          if Pauli = I
-        P_i = 2·⟨P⟩_b − 1 = 3·⟨b|P|b⟩ − 1            if Pauli ≠ I
+        P_i = 3·⟨b|P|b⟩                                   if Pauli ≠ I
 
     where the basis is ``\|b>`` (Z for unitary 0, X for unitary 1, Y for unitary 2)
     and the Born probability is ``\<P>_b`` for the
@@ -285,11 +285,11 @@ def shadow_expectation(
                         # Born probability of outcome o_i in basis b:
                         # eigenvalue of P_i for |b_o⟩ = (-1)^o_i
                         ev = 1.0 if o_i == 0 else -1.0
-                        # Shadow inverse channel: (d+1)*⟨P⟩_b - 1 with d=2 → 3*⟨P⟩_b - 1
-                        s = 3.0 * ev - 1.0
+                        # Shadow inverse channel: (d+1)*⟨P⟩_b with d=2 → 3*⟨P⟩_b
+                        s = 3.0 * ev
                     else:
-                        # Misaligned basis: estimator contribution = -1
-                        s = -1.0
+                        # Misaligned basis: estimator contribution = 0
+                        s = 0.0
 
                 est *= s
 

--- a/qpandalite/algorithmics/measurement/state_tomography.py
+++ b/qpandalite/algorithmics/measurement/state_tomography.py
@@ -370,10 +370,9 @@ def state_tomography(
         for outcome, prob in probs_dict.items():
             if prob == 0:
                 continue
-            outcome_str = f"{outcome:0{n}b}"
             sign = 1.0
             for i, (p_i, b_i) in enumerate(zip(p, basis_for_p)):
-                k_i = int(outcome_str[i])
+                k_i = (outcome >> i) & 1
                 if p_i == "I":
                     # identity: always +1
                     s = 1
@@ -454,21 +453,20 @@ def state_tomography(
         rho = (rho + rho.conj().T) / 2
 
     except ImportError:
-        # Fallback: manual construction (only handles real matrices correctly)
+        # Fallback: manual construction
         d = 2**n
-        rho = np.zeros((d, d), dtype=float)
+        rho = np.zeros((d, d), dtype=complex)
 
         # Build lookup: for each (a,b) pair, compute sum_P <P> * <a|P|b>
         for a in range(d):
             for b in range(d):
-                a_str = f"{a:0{n}b}"
-                b_str = f"{b:0{n}b}"
-                val = 0.0
+                val = 0.0 + 0.0j
                 for p in pauli_strings:
                     exp = expectations[p]
-                    prod = 1.0 + 0.0j  # complex for uniform handling
+                    prod = 1.0 + 0.0j
                     for i in range(n):
-                        ai, bi = int(a_str[i]), int(b_str[i])
+                        ai = (a >> i) & 1
+                        bi = (b >> i) & 1
                         pi = p[i]
                         if pi == "I":
                             prod *= 1
@@ -488,8 +486,7 @@ def state_tomography(
                     val += exp * prod
                 rho[a, b] = val / (2**n)
 
-        rho = rho.real
-        rho = (rho + rho.T) / 2  # symmetrize (should already be symmetric for pure states)
+        rho = (rho + rho.conj().T) / 2  # enforce Hermiticity
 
     return rho
 

--- a/qpandalite/simulator/base_simulator.py
+++ b/qpandalite/simulator/base_simulator.py
@@ -73,10 +73,16 @@ class BaseSimulator:
             self._add_used_qubit(qubit)
 
         if not self.least_qubit_remapping:
-            self.qubit_num = max(self.qubit_mapping.keys()) + 1
-            self.qubit_mapping = {q : q for q in range(self.qubit_num)}
+            if self.qubit_mapping:
+                self.qubit_num = max(self.qubit_mapping.keys()) + 1
+                self.qubit_mapping = {q : q for q in range(self.qubit_num)}
+            else:
+                self.qubit_num = 0
         else:
-            self.qubit_num = max(self.qubit_mapping.values()) + 1
+            if self.qubit_mapping:
+                self.qubit_num = max(self.qubit_mapping.values()) + 1
+            else:
+                self.qubit_num = 0
     
     def _check_available_qubits(self):        
         used_qubits = list(self.qubit_mapping.keys())

--- a/qpandalite/test/test_measurement_basis_rotation.py
+++ b/qpandalite/test/test_measurement_basis_rotation.py
@@ -158,5 +158,5 @@ class TestBasisRotationEdgeCases:
         c.h(0)
         c.measure(0, 1)
         result = basis_rotation_measurement(c, basis=["X", "Z"], shots=None)
-        assert np.isclose(result["01"], 0.5)
-        assert np.isclose(result["00"], 0.5)
+        # X on q0: H|+⟩ = |0⟩, Z on q1: |0⟩ stays |0⟩ → P(00)=1
+        assert np.isclose(result["00"], 1.0)


### PR DESCRIPTION
## Summary
- Fix classical shadow single-snapshot estimator formula for qubits (d=2): correct estimator is `3*ev` when aligned, `0` when misaligned (was `3*ev-1` and `-1`)
- Fix state tomography bit ordering: simulator uses LSB=qubit0 convention but code read MSB first via string formatting; changed to bit shifting `(outcome >> i) & 1`
- Fix fallback density matrix construction to use complex dtype and enforce Hermiticity instead of discarding imaginary parts
- Fix `test_list_basis` expectations: with basis `["X","Z"]` on `|+⟩|0⟩`, `H|+⟩=|0⟩` so `P(00)=1`
- Guard `_extract_actual_used_qubits` against empty `qubit_mapping` to prevent `ValueError` from `max()` on empty sequence

## Test plan
- [x] Verify classical_shadow estimator with analytical examples (|0⟩, |+⟩, Bell state)
- [x] Verify basis_rotation_measurement test expectations
- [x] Verify state tomography bit ordering consistency with simulator convention
- [ ] CI: run full test suite on ubuntu-latest and windows-latest
- [ ] CI: verify GHZ3 purity test passes
- [ ] CI: verify thermal_state tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)