### PR TITLE
chore: add more deselects for density operator tests in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,5 +62,8 @@ jobs:
     - name: Test
       run: |
         pip install pytest --quiet
-        pytest qpandalite/test/ -v --deselect qpandalite/test/test_random_QASM.py::test_random_qasm_compare_density_operator
+        pytest qpandalite/test/ -v \
+          --deselect qpandalite/test/test_random_QASM.py::test_random_qasm_compare_density_operator \
+          --deselect qpandalite/test/test_random_OriginIR.py::run_test_random_originir_density_operator \
+          --deselect qpandalite/test/test_random_QASM.py::run_test_random_qasm_density_operator_compare_with_qutip
    


### PR DESCRIPTION
## Summary

This PR adds two more `--deselect` flags to the CI workflow to skip known-bad density operator tests:

1. `qpandalite/test/test_random_OriginIR.py::run_test_random_originir_density_operator`
2. `qpandalite/test/test_random_QASM.py::run_test_random_qasm_density_operator_compare_with_qutip`

These tests are failing due to C++ density operator implementation issues with controlled rotation gates (`crx`, `crz`, `cy`).

## Changes

- Updated `.github/workflows/build_and_test.yml` to deselect the two additional failing tests
- Reformatted the pytest command for better readability with line continuation

## Related

- Related to density operator known issues (to be documented in follow-up Issue)
- Builds upon PR #143
