### PR TITLE
fix: use single line for pytest deselect to fix PowerShell parsing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,8 +62,5 @@ jobs:
     - name: Test
       run: |
         pip install pytest --quiet
-        pytest qpandalite/test/ -v \
-          --deselect qpandalite/test/test_random_QASM.py::test_random_qasm_compare_density_operator \
-          --deselect qpandalite/test/test_random_OriginIR.py::run_test_random_originir_density_operator \
-          --deselect qpandalite/test/test_random_QASM.py::run_test_random_qasm_density_operator_compare_with_qutip
+        pytest qpandalite/test/ -v --deselect qpandalite/test/test_random_QASM.py::test_random_qasm_compare_density_operator --deselect qpandalite/test/test_random_OriginIR.py::run_test_random_originir_density_operator --deselect qpandalite/test/test_random_QASM.py::run_test_random_qasm_density_operator_compare_with_qutip
    


### PR DESCRIPTION
## Summary

Fixes PowerShell parsing error in CI workflow caused by line continuation (`\`) with `--deselect` arguments.

## Problem

Windows PowerShell interprets `--` as a unary operator when used with line continuation, causing:
```
ParserError: Missing expression after unary operator '--'.
```

## Solution

Changed the multi-line pytest command to a single line to avoid PowerShell parsing issues.

## Changes

- Consolidated the pytest command in `.github/workflows/build_and_test.yml` to a single line

## Related

- Fixes CI failure introduced in PR #144
