### PR TITLE
chore: add missing deselects to coverage workflow

### DIFF
--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -27,7 +27,7 @@ jobs:
       run: pip install pytest pytest-cov
 
     - name: Run tests with coverage
-      run: pytest qpandalite/test/ --cov=qpandalite --cov-report=term-missing --cov-report=xml -v --deselect qpandalite/test/test_random_QASM.py::test_random_qasm_compare_density_operator
+      run: pytest qpandalite/test/ --cov=qpandalite --cov-report=term-missing --cov-report=xml -v --deselect qpandalite/test/test_random_QASM.py::test_random_qasm_compare_density_operator --deselect qpandalite/test/test_random_OriginIR.py::run_test_random_originir_density_operator --deselect qpandalite/test/test_random_QASM.py::run_test_random_qasm_density_operator_compare_with_qutip
 
     - name: Upload coverage report
       if: always()


### PR DESCRIPTION
## Summary

Adds the missing `--deselect` flags to the pytest coverage workflow.

## Changes

Updated `.github/workflows/pytest_coverage.yml` to include all three deselects:
- `test_random_QASM.py::test_random_qasm_compare_density_operator`
- `test_random_OriginIR.py::run_test_random_originir_density_operator`
- `test_random_QASM.py::run_test_random_qasm_density_operator_compare_with_qutip`

## Related

- Issue #145
- PR #146 (added deselects to build_and_test.yml)
