### PR TITLE
docs: add Google Style docstrings to circuit_builder module

### DIFF
--- a/qpandalite/circuit_builder/originir_spec.py
+++ b/qpandalite/circuit_builder/originir_spec.py
@@ -1,5 +1,17 @@
-# This file specifies the OriginIR language specification,
-# including the grammar and the syntax of the language.
+"""OriginIR language specification for quantum gates and error channels.
+
+This module defines the available gates and error channels in OriginIR format,
+including their qubit requirements and parameter counts. It also provides
+utility functions for generating subsets of gates and error channels.
+
+Key exports:
+    available_originir_gates: Dictionary of all available OriginIR gates.
+    angular_gates: List of gates that accept angular parameters.
+    available_originir_error_channels: Dictionary of available error channels.
+    available_originir_error_channels_without_kraus: Error channels excluding Kraus operators.
+    generate_sub_gateset_originir: Function to generate a subset of gates.
+    generate_sub_error_channel_originir: Function to generate a subset of error channels.
+"""
 
 __all__ = [
     'available_originir_gates',
@@ -76,6 +88,15 @@ available_originir_gates.update({
 })
 
 def generate_sub_gateset_originir(gate_list):
+    """Generate a subset of the OriginIR gateset filtered by gate names.
+
+    Args:
+        gate_list (list[str]): List of gate names to include in the subset.
+
+    Returns:
+        dict[str, dict]: A dictionary containing only the gates specified in
+            gate_list, with their qubit and parameter requirements.
+    """
     return {k : v for k, v in available_originir_gates.items() if k in gate_list}
 
 
@@ -120,6 +141,15 @@ available_originir_error_channels.update({
 })
 
 def generate_sub_error_channel_originir(channel_list):
+    """Generate a subset of the OriginIR error channels filtered by channel names.
+
+    Args:
+        channel_list (list[str]): List of error channel names to include in the subset.
+
+    Returns:
+        dict[str, dict]: A dictionary containing only the error channels specified
+            in channel_list, with their qubit and parameter requirements.
+    """
     return {k : v for k, v in available_originir_error_channels.items() if k in channel_list}
 
 # TODO: This is a temporary workaround. When Kraus1Q random generation

--- a/qpandalite/circuit_builder/qasm_spec.py
+++ b/qpandalite/circuit_builder/qasm_spec.py
@@ -1,5 +1,13 @@
-# This file specifies the QASM language specification,
-# including the grammar and the syntax of the language.
+"""OpenQASM 2.0 language specification for quantum gates.
+
+This module defines the available gates in OpenQASM 2.0 format, including their
+qubit requirements and parameter counts. It provides a utility function for
+generating subsets of gates based on a given list.
+
+Key exports:
+    available_qasm_gates: Dictionary of all available OpenQASM 2.0 gates.
+    generate_sub_gateset_qasm: Function to generate a subset of gates.
+"""
 
 __all__ = [
     'available_qasm_gates',
@@ -56,5 +64,14 @@ available_qasm_gates.update({
 })
 
 def generate_sub_gateset_qasm(gate_list):
+    """Generate a subset of the OpenQASM gateset filtered by gate names.
+
+    Args:
+        gate_list (list[str]): List of gate names to include in the subset.
+
+    Returns:
+        dict[str, dict]: A dictionary containing only the gates specified in
+            gate_list, with their qubit and parameter requirements.
+    """
     return {k : v for k, v in available_qasm_gates.items() if k in gate_list}
     

--- a/qpandalite/circuit_builder/qasm_spec.py
+++ b/qpandalite/circuit_builder/qasm_spec.py
@@ -74,4 +74,3 @@ def generate_sub_gateset_qasm(gate_list):
             gate_list, with their qubit and parameter requirements.
     """
     return {k : v for k, v in available_qasm_gates.items() if k in gate_list}
-    

--- a/qpandalite/circuit_builder/qcircuit.py
+++ b/qpandalite/circuit_builder/qcircuit.py
@@ -1,3 +1,14 @@
+"""Quantum circuit builder with OriginIR and OpenQASM 2.0 output.
+
+This module provides a Circuit class for building quantum circuits programmatically.
+It supports various quantum gates, controlled operations, dagger (adjoint) blocks,
+and measurement operations. The circuit can be exported to OriginIR or OpenQASM format.
+
+Key exports:
+    Circuit: Main quantum circuit builder class.
+    OpcodeType: Type alias for opcode tuples.
+"""
+
 from __future__ import annotations
 
 from copy import deepcopy

--- a/qpandalite/circuit_builder/random_originir.py
+++ b/qpandalite/circuit_builder/random_originir.py
@@ -1,4 +1,15 @@
-# random_originir.py is a python file that generates random OriginIR code.
+"""Random OriginIR circuit generator.
+
+This module provides functions for generating random quantum circuits in OriginIR
+format. It supports random gate selection, error channel insertion, and full
+measurement generation for testing and simulation purposes.
+
+Key exports:
+    build_originir_gate: Build a single OriginIR gate string.
+    build_originir_error_channel: Build an error channel instruction.
+    build_full_measurements: Generate measurement instructions for all qubits.
+    random_originir: Generate a complete random OriginIR program.
+"""
 
 import random
 from .opcode import opcode_to_line_originir

--- a/qpandalite/circuit_builder/random_originir.py
+++ b/qpandalite/circuit_builder/random_originir.py
@@ -24,7 +24,7 @@ __all__ = [
 
 def build_originir_gate(gate, qubits, params, dagger_flag = False, 
                         control_qubit_set = None):
-    '''
+    """
     Build a line of OriginIR code for a given gate, qubits, and parameters.
     
     Args:
@@ -34,7 +34,7 @@ def build_originir_gate(gate, qubits, params, dagger_flag = False,
         
     Returns:
         str: A line of OriginIR code
-    '''
+    """
 
     if not qubits:
         raise ValueError("No qubits specified for gate")
@@ -68,7 +68,7 @@ def build_originir_gate(gate, qubits, params, dagger_flag = False,
 
 
 def build_originir_error_channel(channel, qubits, params):
-    '''
+    """
     Build a line of OriginIR code for a given error channel, qubits, and parameters.
     
     Args:
@@ -77,7 +77,7 @@ def build_originir_error_channel(channel, qubits, params):
         
     Returns:
         str: A line of OriginIR code
-    '''
+    """
 
     if not qubits:
         raise ValueError("No qubits specified for error channel")
@@ -96,7 +96,7 @@ def build_originir_error_channel(channel, qubits, params):
     return f"{channel} {qubit_str}, ({param_str})"
 
 def build_full_measurements(n_qubits):
-    '''
+    """
     Build a line of OriginIR code for a full measurement on a set of qubits.
     
     Args:
@@ -104,7 +104,7 @@ def build_full_measurements(n_qubits):
         
     Returns:
         str: A line of OriginIR code
-    '''
+    """
 
     measure_instructions = []
     for qubit in range(n_qubits):
@@ -117,7 +117,7 @@ def random_originir(n_qubits, n_gates,
                     channel_set = None,
                     allow_control = False,
                     allow_dagger = False):
-    '''
+    """
     Generate a random OriginIR program with a given number of qubits and gates.
     
     Args:
@@ -127,7 +127,7 @@ def random_originir(n_qubits, n_gates,
         
     Returns:
         str: A string of OriginIR code.
-    '''
+    """
 
     program = [f'QINIT {n_qubits}',
                f'CREG {n_qubits}']

--- a/qpandalite/circuit_builder/random_qasm.py
+++ b/qpandalite/circuit_builder/random_qasm.py
@@ -1,4 +1,16 @@
-# random_qasm.py is a python script that generates random QASM code.
+"""Random OpenQASM 2.0 circuit generator.
+
+This module provides functions for generating random quantum circuits in OpenQASM
+2.0 format. It supports random gate selection, measurement generation, and
+circuit construction from opcode lists.
+
+Key exports:
+    build_qasm_gate: Build a single QASM gate string.
+    build_full_measurements: Generate measurement instructions for all qubits.
+    build_measurements: Generate measurement instructions for specified qubits.
+    random_qasm: Generate a complete random QASM program.
+    build_qasm_from_opcodes: Convert a list of opcodes to QASM code.
+"""
 
 import random
 from typing import List

--- a/qpandalite/circuit_builder/random_qasm.py
+++ b/qpandalite/circuit_builder/random_qasm.py
@@ -56,7 +56,7 @@ def build_qasm_gate(gate, qubits, params, qreg_name = 'q'):
     return qasm_gate
 
 def build_full_measurements(n_qubits, qreg_name = 'q', creg_name = 'c'):
-    '''
+    """
     Build a QASM string that measures all qubits in the given qreg to the given creg.
 
     Args:
@@ -66,7 +66,7 @@ def build_full_measurements(n_qubits, qreg_name = 'q', creg_name = 'c'):
 
     Returns:
         List[str]: a list of QASM strings that measure all qubits in the given qreg to the given creg.
-    '''
+    """
     measure_instructions = []
     for i in range(n_qubits):
         measure_instructions.append(f"measure {qreg_name}[{i}] -> {creg_name}[{i}];")
@@ -75,17 +75,17 @@ def build_full_measurements(n_qubits, qreg_name = 'q', creg_name = 'c'):
 
 
 def build_measurements(measure_qbit_cbit_pairs, qreg_name = 'q', creg_name = 'c'):
-    '''
-    Build a QASM string that measures all qubits in the given qreg to the given creg.
+    """
+    Build a QASM string that measures specified qubits to classical bits.
 
     Args:
-        n_qubits (int): number of qubits to measure
-        qreg_name (str): name of the qreg to measure from
-        creg_name (str): name of the creg to measure to
+        measure_qbit_cbit_pairs: Iterable of (qubit_index, cbit_index) tuples.
+        qreg_name (str): name of the quantum register.
+        creg_name (str): name of the classical register.
 
     Returns:
-        List[str]: a list of QASM strings that measure all qubits in the given qreg to the given creg.
-    '''
+        List[str]: a list of QASM measurement instructions.
+    """
     measure_instructions = []
     for qbit, cbit in range(measure_qbit_cbit_pairs):
         measure_instructions.append(f"measure {qreg_name}[{qbit}] -> {creg_name}[{cbit}];")

--- a/qpandalite/circuit_builder/translate_qasm2_oir.py
+++ b/qpandalite/circuit_builder/translate_qasm2_oir.py
@@ -1,4 +1,17 @@
-# Translation between QASM2 and OriginIR.
+"""Translation utilities between OpenQASM 2.0 and OriginIR.
+
+This module provides bidirectional translation between OpenQASM 2.0 and OriginIR
+quantum circuit representations. It includes direct mapping dictionaries,
+opcode conversion functions, and multi-controlled gate decomposition.
+
+Key exports:
+    OriginIR_QASM2_dict: Mapping from OriginIR to QASM2 operations.
+    QASM2_OriginIR_dict: Mapping from QASM2 to OriginIR operations.
+    direct_mapping_qasm2_to_oir: Function for direct QASM2 to OriginIR lookup.
+    get_opcode_from_QASM2: Convert QASM2 operation to OriginIR opcode.
+    get_QASM2_from_opcode: Convert OriginIR opcode to QASM2 operation.
+    decompose_mcx_qasm_text: Decompose multi-controlled X gates for QASM2.
+"""
 
 from typing import List, Tuple, Union
 from .qasm_spec import available_qasm_gates

--- a/qpandalite/circuit_builder/translate_qasm2_oir.py
+++ b/qpandalite/circuit_builder/translate_qasm2_oir.py
@@ -61,23 +61,23 @@ OriginIR_QASM2_dict = {
 }
 
 def direct_mapping_qasm2_to_oir(qasm2_operation):
-    '''
+    """
     Return the corresponding OriginIR by given QASM2 operation.
     Return None when there is no direct-mapping. 
 
     Note: There are also operations that do not sastify "direct mapping"
     from QASM -> OIR or OIR -> QASM.
-    '''
+    """
     return QASM2_OriginIR_dict.get(qasm2_operation, None)
 
 
 def get_opcode_from_QASM2(operation, qubits, cbits, parameters):
-    '''Here list all supported operations of OpenQASM2.0 and its corresponding operation 
+    """Here list all supported operations of OpenQASM2.0 and its corresponding operation 
        in OriginIR in QPanda-lite.
 
        Opcode Definition:
        opcodes = (operation,qubits,cbit,parameter,dagger_flag,control_qubits_set)    
-    '''
+    """
 
     # 1-qubit gates
     if operation == 'id':


### PR DESCRIPTION
## 变更内容

为 circuit_builder 模块的 6 个文件补充 Google Style docstring，提高代码可维护性和文档覆盖率。

### 涉及文件

| 文件 | 补充内容 |
|------|----------|
| `qcircuit.py` | 模块级 docstring（Circuit 构建器核心） |
| `originir_spec.py` | 模块级 + `generate_sub_gateset_originir()` + `generate_sub_error_channel_originir()` 函数 docstring |
| `qasm_spec.py` | 模块级 + `generate_sub_gateset_qasm()` 函数 docstring |
| `random_originir.py` | 模块级 docstring（随机 OriginIR 生成器） |
| `random_qasm.py` | 模块级 docstring（随机 QASM 生成器） |
| `translate_qasm2_oir.py` | 模块级 docstring（QASM2/OriginIR 互转） |

### 文档规范

- 使用 Google Style docstring 格式
- 模块级文档说明模块用途和关键导出项
- 函数文档包含 Args、Returns 等标准章节

### 相关任务

任务块 1/6：circuit_builder 模块（P0 - 核心模块）

