### PR TITLE
docs: add module-level docstrings to simulator module

### DIFF
--- a/qpandalite/simulator/base_simulator.py
+++ b/qpandalite/simulator/base_simulator.py
@@ -1,4 +1,14 @@
-# generic simulator class for qpanda-lite
+"""Base simulator classes for QPanda-lite.
+
+This module provides abstract base classes for quantum circuit simulators,
+defining common behaviors and interfaces for statevector and density matrix
+simulations. It also includes topology validation and qubit mapping utilities.
+
+Key exports:
+    - TopologyError: Exception for invalid qubit/topology configurations.
+    - BaseSimulator: Abstract base for ideal circuit simulators.
+    - BaseNoisySimulator: Abstract base for noisy circuit simulators.
+"""
 
 __all__ = ["TopologyError", "BaseSimulator", "BaseNoisySimulator"]
 import random

--- a/qpandalite/simulator/error_model.py
+++ b/qpandalite/simulator/error_model.py
@@ -1,4 +1,24 @@
-# Error model
+"""Quantum error models for noisy simulation.
+
+This module defines various quantum noise models that can be applied to
+circuit simulations, including bit-flip, phase-flip, depolarizing, amplitude
+damping, and Kraus operator errors.
+
+Key exports:
+    - ErrorModel: Base class for all error models.
+    - BitFlip: Bit-flip (X) error model.
+    - PhaseFlip: Phase-flip (Z) error model.
+    - Depolarizing: Single-qubit depolarizing channel.
+    - TwoQubitDepolarizing: Two-qubit depolarizing channel.
+    - AmplitudeDamping: Amplitude damping (T1) error model.
+    - PauliError1Q: Single-qubit Pauli error model.
+    - PauliError2Q: Two-qubit Pauli error model.
+    - Kraus1Q: Single-qubit Kraus operator error model.
+    - ErrorLoader: Base error loader interface.
+    - ErrorLoader_GenericError: Generic error loader.
+    - ErrorLoader_GateTypeError: Gate-type specific error loader.
+    - ErrorLoader_GateSpecificError: Gate-specific error loader.
+"""
 
 from __future__ import annotations
 

--- a/qpandalite/simulator/get_backend.py
+++ b/qpandalite/simulator/get_backend.py
@@ -1,3 +1,12 @@
+"""Simulator backend factory for QPanda-lite.
+
+This module provides a factory function to obtain appropriate simulator
+instances based on the quantum program type (OriginIR or QASM).
+
+Key exports:
+    - get_backend: Factory function to create simulator backends.
+"""
+
 __all__ = ["get_backend"]
 from .originir_simulator import OriginIR_Simulator
 from .qasm_simulator import QASM_Simulator

--- a/qpandalite/simulator/originir_simulator.py
+++ b/qpandalite/simulator/originir_simulator.py
@@ -1,3 +1,13 @@
+"""OriginIR quantum program simulator.
+
+This module provides simulators for OriginIR-format quantum programs,
+supporting both ideal and noisy simulations with topology validation.
+
+Key exports:
+    - OriginIR_Simulator: Ideal simulator for OriginIR programs.
+    - OriginIR_NoisySimulator: Noisy simulator for OriginIR programs with error models.
+"""
+
 __all__ = ["OriginIR_Simulator", "OriginIR_NoisySimulator"]
 import random
 from typing import Dict, List, Tuple, TYPE_CHECKING, Union

--- a/qpandalite/simulator/qasm_simulator.py
+++ b/qpandalite/simulator/qasm_simulator.py
@@ -1,3 +1,13 @@
+"""OpenQASM 2.0 quantum program simulator.
+
+This module provides simulators for OpenQASM 2.0 format quantum programs,
+supporting both ideal and noisy simulations.
+
+Key exports:
+    - QASM_Simulator: Ideal simulator for OpenQASM 2.0 programs.
+    - QASM_Noisy_Simulator: Noisy simulator for OpenQASM 2.0 programs with error models.
+"""
+
 __all__ = ["QASM_Simulator", "QASM_Noisy_Simulator"]
 from typing import Dict, List, Tuple, TYPE_CHECKING
 from qpandalite.qasm import OpenQASM2_BaseParser

--- a/qpandalite/simulator/qutip_sim_impl.py
+++ b/qpandalite/simulator/qutip_sim_impl.py
@@ -1,3 +1,13 @@
+"""QuTiP-backed density matrix simulator implementation.
+
+This module provides a density-matrix quantum simulator implementation using
+QuTiP, supporting unitary operations, Kraus channels, and measurement for
+noisy quantum simulation.
+
+Key exports:
+    - DensityOperatorSimulatorQutip: Density-matrix simulator backed by QuTiP.
+"""
+
 from __future__ import annotations
 
 from itertools import product


### PR DESCRIPTION
## 变更内容

为 simulator 模块的 6 个文件补充模块级 Google Style docstring。

### 涉及文件

| 文件 | 模块描述 |
|------|----------|
| `base_simulator.py` | 通用模拟器基类，定义 statevector 和 density matrix 模拟的共同行为和接口 |
| `error_model.py` | 量子噪声错误模型，包含 bit-flip、phase-flip、depolarizing 等 |
| `get_backend.py` | 后端工厂函数，根据程序类型获取对应的模拟器实例 |
| `originir_simulator.py` | OriginIR 格式量子程序模拟器（理想/噪声） |
| `qasm_simulator.py` | OpenQASM 2.0 格式量子程序模拟器（理想/噪声） |
| `qutip_sim_impl.py` | QuTiP 后端密度矩阵模拟器实现 |

### 文档规范

- 使用 Google Style docstring 格式
- 模块级文档说明模块用途和关键导出项

### 相关任务

任务块 2/6：simulator 模块（P1 - 重要模块）
