### PR TITLE
docs: add Google Style docstrings to qcloud_config module

### DIFF
--- a/qpandalite/qcloud_config/ibm_online_config.py
+++ b/qpandalite/qcloud_config/ibm_online_config.py
@@ -1,8 +1,24 @@
+"""IBM Quantum cloud configuration utilities.
+
+This module provides functions to create and save IBM Quantum
+cloud service configuration files.
+"""
+
 __all__ = ["create_ibm_online_config"]
 import json
 from pathlib import Path
 
-def create_ibm_online_config(default_token = None, savepath = None):    
+def create_ibm_online_config(default_token = None, savepath = None):
+    """Create IBM Quantum online configuration file.
+
+    Args:
+        default_token: IBM Quantum API token for authentication.
+        savepath: Directory path to save the configuration file.
+                  Defaults to current working directory.
+
+    Raises:
+        RuntimeError: If default_token is not provided.
+    """    
 
     if not default_token:
         raise RuntimeError('You should input your token.')

--- a/qpandalite/qcloud_config/originq_cloud_config.py
+++ b/qpandalite/qcloud_config/originq_cloud_config.py
@@ -1,3 +1,9 @@
+"""OriginQ cloud configuration utilities.
+
+This module provides functions to create and save OriginQ quantum
+cloud service configuration files for both standard and online modes.
+"""
+
 __all__ = ["create_originq_cloud_config", "create_originq_online_cloud_config"]
 import json
 from pathlib import Path
@@ -10,6 +16,22 @@ def create_originq_cloud_config(apitoken=None,
                           available_topology=None,
                           task_group_size=200,
                           savepath = None):
+    """Create OriginQ cloud configuration file with topology settings.
+
+    Args:
+        apitoken: API token for OriginQ cloud service authentication.
+        submit_url: URL endpoint for submitting quantum tasks.
+        query_url: URL endpoint for querying task results.
+        available_qubits: List of available qubit indices on the quantum device.
+        available_topology: List of connected qubit pairs [[q1, q2], ...].
+        task_group_size: Maximum number of circuits per task (default: 200).
+        savepath: Directory path to save the configuration file.
+                  Defaults to current working directory.
+
+    Raises:
+        RuntimeError: If required parameters (apitoken, submit_url, query_url)
+                      are not provided or if parameters have invalid types.
+    """
     if not apitoken:
         raise RuntimeError('You should input your api key.')
 
@@ -49,6 +71,23 @@ def create_originq_online_cloud_config(apitoken=None,
                                  query_url=None,
                                  task_group_size=200,
                                  savepath = None):
+    """Create OriginQ online cloud configuration file without topology.
+
+    This configuration is used for online OriginQ service where qubit
+topology is managed by the remote server.
+
+    Args:
+        apitoken: API token for OriginQ cloud service authentication.
+        submit_url: URL endpoint for submitting quantum tasks.
+        query_url: URL endpoint for querying task results.
+        task_group_size: Maximum number of circuits per task (default: 200).
+        savepath: Directory path to save the configuration file.
+                  Defaults to current working directory.
+
+    Raises:
+        RuntimeError: If required parameters are not provided or
+                      if task_group_size is not an integer.
+    """
     if not apitoken:
         raise RuntimeError('You should input your api key.')
 

--- a/qpandalite/qcloud_config/originq_online_config.py
+++ b/qpandalite/qcloud_config/originq_online_config.py
@@ -1,3 +1,9 @@
+"""OriginQ QPilot online configuration utilities.
+
+This module provides functions to create and save OriginQ QPilot
+online service configuration files for full, simplified, and dummy modes.
+"""
+
 __all__ = ["create_originq_config", "create_originq_online_config", "create_originq_dummy_config"]
 import json
 from pathlib import Path
@@ -9,7 +15,22 @@ def create_originq_config(login_apitoken = None,
                           available_qubits = None,
                           available_topology = None,
                           task_group_size = 200,
-                          savepath = None):    
+                          savepath = None):
+    """Create full OriginQ QPilot configuration file with all settings.
+
+    Args:
+        login_apitoken: API token for QPilot login authentication.
+        login_url: URL endpoint for user login (url 0).
+        submit_url: URL endpoint for submitting quantum tasks (url 1).
+        query_url: URL endpoint for querying task results (url 2).
+        available_qubits: List of available qubit indices on the device.
+        available_topology: List of connected qubit pairs [[q1, q2], ...].
+        task_group_size: Maximum circuits per task (default: 200).
+        savepath: Directory to save config file. Defaults to cwd.
+
+    Raises:
+        RuntimeError: If required parameters missing or types invalid.
+    """    
 
     if not login_apitoken:
         raise RuntimeError('You should input your token.')
@@ -53,8 +74,20 @@ def create_originq_online_config(login_apitoken = None,
                                  submit_url = None, 
                                  query_url = None, 
                                  task_group_size = 200,
-                                 savepath = None):    
+                                 savepath = None):
+    """Create OriginQ QPilot online configuration without topology settings.
 
+    Args:
+        login_apitoken: API token for QPilot login authentication.
+        login_url: URL endpoint for user login.
+        submit_url: URL endpoint for submitting quantum tasks.
+        query_url: URL endpoint for querying task results.
+        task_group_size: Maximum circuits per task (default: 200).
+        savepath: Directory to save config file. Defaults to cwd.
+
+    Raises:
+        RuntimeError: If required parameters missing or types invalid.
+    """
     if not login_apitoken:
         raise RuntimeError('You should input your token.')
 
@@ -90,8 +123,21 @@ def create_originq_dummy_config(
     available_qubits = None,
     available_topology = None,
     task_group_size = 200,
-    savepath = None):    
+    savepath = None):
+    """Create dummy OriginQ configuration for testing.
 
+    Uses placeholder values for API credentials. Useful for local
+    testing and development without real credentials.
+
+    Args:
+        available_qubits: List of available qubit indices.
+        available_topology: List of connected qubit pairs.
+        task_group_size: Maximum circuits per task (default: 200).
+        savepath: Directory to save config file. Defaults to cwd.
+
+    Raises:
+        RuntimeError: If parameters have invalid types.
+    """
     if not isinstance(available_qubits, list):
         raise RuntimeError('Available qubits must be a list.')
 

--- a/qpandalite/qcloud_config/quafu_online_config.py
+++ b/qpandalite/qcloud_config/quafu_online_config.py
@@ -1,9 +1,25 @@
+"""Quafu cloud configuration utilities.
+
+This module provides functions to create and save Quafu
+cloud service configuration files.
+"""
+
 __all__ = ["create_quafu_online_config"]
 import json
 from pathlib import Path
 
 def create_quafu_online_config(default_token = None,
-                               savepath = None):    
+                               savepath = None):
+    """Create Quafu online configuration file.
+
+    Args:
+        default_token: Quafu API token for authentication.
+        savepath: Directory path to save the configuration file.
+                  Defaults to current working directory.
+
+    Raises:
+        RuntimeError: If default_token is not provided.
+    """    
 
     if not default_token:
         raise RuntimeError('You should input your token here.')


### PR DESCRIPTION
## 变更内容

为 qcloud_config 模块的 4 个文件补充 Google Style docstring。

### 涉及文件

| 文件 | 补充内容 |
|------|----------|
| `ibm_online_config.py` | 模块级 + `create_ibm_online_config()` |
| `originq_cloud_config.py` | 模块级 + `create_originq_cloud_config()` + `create_originq_online_cloud_config()` |
| `originq_online_config.py` | 模块级 + `create_originq_config()` + `create_originq_online_config()` + `create_originq_dummy_config()` |
| `quafu_online_config.py` | 模块级 + `create_quafu_online_config()` |

### 文档规范

- 使用 Google Style docstring 格式
- 模块级文档说明模块用途
- 函数文档包含 Args、Raises 等标准章节

### 相关任务

任务块 3/6：qcloud_config 模块（P1 - 配置模块）
