### PR TITLE
docs: add module-level docstrings to parser module

### DIFF
--- a/qpandalite/originir/originir_base_parser.py
+++ b/qpandalite/originir/originir_base_parser.py
@@ -1,3 +1,12 @@
+"""OriginIR base parser module.
+
+This module provides the base parser for OriginIR quantum circuit representation,
+including parsing QINIT, CREG statements and quantum operations.
+
+Key exports:
+    OriginIR_BaseParser: Base parser class for OriginIR circuits.
+"""
+
 __all__ = ["OriginIR_BaseParser"]
 from copy import deepcopy
 from typing import List, Tuple

--- a/qpandalite/originir/originir_line_parser.py
+++ b/qpandalite/originir/originir_line_parser.py
@@ -1,3 +1,12 @@
+"""OriginIR line parser module.
+
+This module provides regex-based parsing for individual OriginIR lines,
+supporting 1-3 qubit gates, parameterized gates, dagger flags, and control qubits.
+
+Key exports:
+    OriginIR_LineParser: Parser class for individual OriginIR lines.
+"""
+
 __all__ = ["OriginIR_LineParser"]
 import re
 

--- a/qpandalite/qasm/exceptions.py
+++ b/qpandalite/qasm/exceptions.py
@@ -1,4 +1,3 @@
-
 """QASM parser exceptions module.
 
 This module defines custom exceptions for OpenQASM 2.0 parsing,

--- a/qpandalite/qasm/exceptions.py
+++ b/qpandalite/qasm/exceptions.py
@@ -1,4 +1,16 @@
 
+"""QASM parser exceptions module.
+
+This module defines custom exceptions for OpenQASM 2.0 parsing,
+including errors for unsupported gates and register-related issues.
+
+Key exports:
+    NotSupportedGateError: Exception for unsupported quantum gates.
+    RegisterNotFoundError: Exception for missing quantum/classical registers.
+    RegisterOutOfRangeError: Exception for register index out of bounds.
+    RegisterDefinitionError: Exception for invalid register definitions.
+"""
+
 __all__ = ["NotSupportedGateError", "RegisterNotFoundError", "RegisterOutOfRangeError", "RegisterDefinitionError"]
 class NotSupportedGateError(Exception):
     """Raised when an unsupported gate is encountered in OpenQASM 2."""

--- a/qpandalite/qasm/qasm_base_parser.py
+++ b/qpandalite/qasm/qasm_base_parser.py
@@ -1,3 +1,12 @@
+"""OpenQASM 2.0 base parser module.
+
+This module provides the base parser for OpenQASM 2.0 quantum circuit representation,
+including parsing qreg/creg definitions, quantum operations, and measurement statements.
+
+Key exports:
+    OpenQASM2_BaseParser: Base parser class for OpenQASM 2.0 circuits.
+"""
+
 __all__ = ["OpenQASM2_BaseParser"]
 from typing import List, Tuple
 from qpandalite.circuit_builder.qcircuit import Circuit

--- a/qpandalite/qasm/qasm_line_parser.py
+++ b/qpandalite/qasm/qasm_line_parser.py
@@ -1,3 +1,12 @@
+"""OpenQASM 2.0 line parser module.
+
+This module provides regex-based parsing for individual OpenQASM 2.0 lines,
+supporting qreg/creg definitions, 1-4 qubit gates, parameterized gates, and measurements.
+
+Key exports:
+    OpenQASM2_LineParser: Parser class for individual OpenQASM 2.0 lines.
+"""
+
 from __future__ import annotations
 
 __all__ = ["OpenQASM2_LineParser"]


### PR DESCRIPTION
## 变更内容

为 parser 模块的 5 个文件补充模块级 Google Style docstring。

### 涉及文件

| 文件 | 模块描述 |
|------|----------|
| `originir/originir_base_parser.py` | OriginIR 量子电路表示解析器基类 |
| `originir/originir_line_parser.py` | OriginIR 逐行语句解析器 |
| `qasm/exceptions.py` | OpenQASM 2.0 解析异常类定义 |
| `qasm/qasm_base_parser.py` | OpenQASM 2.0 电路表示解析器基类 |
| `qasm/qasm_line_parser.py` | OpenQASM 2.0 逐行语句解析器 |

### 文档规范

- 使用 Google Style docstring 格式
- 模块级文档说明模块用途和关键导出项

### 相关任务

任务块 4/6：parser 模块（P2 - 解析器）
