### PR TITLE
docs: add module-level docstrings to transpiler module

### DIFF
--- a/qpandalite/transpiler/_utils.py
+++ b/qpandalite/transpiler/_utils.py
@@ -1,4 +1,10 @@
 
+"""Compilation exception classes for the transpiler module.
+
+This module defines custom exceptions for quantum circuit compilation
+and IR conversion failures.
+"""
+
 __all__ = ["CompilationFailedException", "IRConversionFailedException"]
 class CompilationFailedException(RuntimeError):
     """Raised when quantum circuit compilation fails."""

--- a/qpandalite/transpiler/converter.py
+++ b/qpandalite/transpiler/converter.py
@@ -1,3 +1,9 @@
+"""OriginIR and OpenQASM2 format conversion utilities.
+
+This module provides bidirectional conversion between OriginIR and
+OpenQASM2 quantum circuit representations.
+"""
+
 __all__ = ["convert_oir_to_qasm", "convert_qasm_to_oir"]
 from qpandalite import OriginIR_BaseParser, OpenQASM2_BaseParser
 from ._utils import IRConversionFailedException

--- a/qpandalite/transpiler/draw.py
+++ b/qpandalite/transpiler/draw.py
@@ -1,3 +1,9 @@
+"""Quantum circuit visualization tools.
+
+This module provides text-based circuit drawing capabilities for
+quantum programs in OriginIR or QASM format.
+"""
+
 __all__ = ["draw"]
 from pyqpanda3.core import draw_qprog, PIC_TYPE
 from pyqpanda3.intermediate_compiler import convert_originir_string_to_qprog

--- a/qpandalite/transpiler/qiskit_transpiler.py
+++ b/qpandalite/transpiler/qiskit_transpiler.py
@@ -1,3 +1,9 @@
+"""Qiskit transpiler backend integration.
+
+This module provides transpilation services using Qiskit's transpiler
+for optimizing quantum circuits with configurable topology and gate sets.
+"""
+
 __all__ = ["transpile_qasm", "transpile_originir"]
 import qiskit
 from qiskit import QuantumCircuit

--- a/qpandalite/transpiler/timeline.py
+++ b/qpandalite/transpiler/timeline.py
@@ -1,3 +1,9 @@
+"""Compiled circuit timeline analysis and visualization.
+
+This module provides tools for analyzing and visualizing the temporal
+execution schedule of compiled quantum programs.
+"""
+
 __all__ = ["format_result", "create_time_line_table", "plot_time_line"]
 import pandas as pd
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## 变更内容

为 transpiler 模块的 5 个文件补充模块级 Google Style docstring。

### 涉及文件

| 文件 | 模块描述 |
|------|----------|
| `_utils.py` | 编译异常类定义（CompilationFailedException, IRConversionFailedException） |
| `converter.py` | OriginIR 与 OpenQASM2 格式互转工具 |
| `draw.py` | 量子电路可视化工具（文本格式） |
| `qiskit_transpiler.py` | Qiskit 编译后端集成 |
| `timeline.py` | 编译结果时序分析与可视化工具 |

### 文档规范

- 使用 Google Style docstring 格式
- 模块级文档说明模块用途和关键导出项

### 相关任务

任务块 5/6：transpiler 模块（P2 - 编译器）
