### PR TITLE
docs: add docstrings to remaining files (block 6)

### DIFF
--- a/qpandalite/algorithmics/measurement/test_measurement.py
+++ b/qpandalite/algorithmics/measurement/test_measurement.py
@@ -15,15 +15,22 @@ from qpandalite.algorithmics.measurement import (
 
 
 class TestPauliExpectation:
+    """Tests for Pauli string expectation value calculations."""
     def test_zz_on_computational(self):
-        """⟨ZZ⟩ on |00⟩ should be +1."""
+        """Test ⟨ZZ⟩ expectation on |00⟩ state.
+
+        Verifies that the expectation value of ZZ operator on |00⟩ is +1.
+        """
         c = Circuit()
         c.measure(0, 1)
         val = pauli_expectation(c, "ZZ", shots=None)
         assert np.isclose(val, 1.0)
 
     def test_zz_on_one_minus_one(self):
-        """⟨ZZ⟩ on |01⟩ should be -1."""
+        """Test ⟨ZZ⟩ expectation on |01⟩ state.
+
+        Verifies that the expectation value of ZZ operator on |01⟩ is -1.
+        """
         c = Circuit()
         c.x(0)
         c.measure(0, 1)
@@ -31,7 +38,11 @@ class TestPauliExpectation:
         assert np.isclose(val, -1.0)
 
     def test_xx_on_bell(self):
-        """⟨XX⟩ on Bell (|00⟩+|11⟩)/√2 should be +1."""
+        """Test ⟨XX⟩ expectation on Bell state.
+
+        Verifies that the expectation value of XX operator on Bell state
+        (|00⟩+|11⟩)/√2 is +1.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -40,7 +51,10 @@ class TestPauliExpectation:
         assert np.isclose(val, 1.0)
 
     def test_yy_on_bell(self):
-        """⟨YY⟩ on Bell should be +1."""
+        """Test ⟨YY⟩ expectation on Bell state.
+
+        Verifies that the expectation value of YY operator on Bell state is +1.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -49,7 +63,10 @@ class TestPauliExpectation:
         assert np.isclose(val, 1.0)
 
     def test_ix_on_bell(self):
-        """⟨IX⟩ on Bell = ⟨X⟩ on qubit 1 should be 0 (uniform)."""
+        """Test ⟨IX⟩ expectation on Bell state.
+
+        Verifies that ⟨IX⟩ = ⟨X⟩ on qubit 1 equals 0 for uniform distribution.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -58,7 +75,11 @@ class TestPauliExpectation:
         assert np.isclose(val, 0.0)
 
     def test_shots_variance(self):
-        """shots mode should give a result close to the exact value."""
+        """Test finite shots measurement variance.
+
+        Verifies that shots mode produces results close to the exact value
+        within expected statistical variance.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -68,12 +89,14 @@ class TestPauliExpectation:
         assert abs(sampled - exact) < 0.1
 
     def test_wrong_length_raises(self):
+        """Test that mismatched Pauli length raises ValueError."""
         c = Circuit()
         c.measure(0, 1)
         with pytest.raises(ValueError, match="length"):
             pauli_expectation(c, "Z", shots=None)
 
     def test_invalid_pauli_char_raises(self):
+        """Test that invalid Pauli characters raise ValueError."""
         c = Circuit()
         c.measure(0, 1)
         with pytest.raises(ValueError, match="I/X/Y/Z"):
@@ -81,8 +104,12 @@ class TestPauliExpectation:
 
 
 class TestBasisRotationMeasurement:
+    """Tests for basis rotation measurement functionality."""
     def test_z_basis_on_plus(self):
-        """|+⟩ measured in Z basis: P(0)=0.5, P(1)=0.5."""
+        """Test |+⟩ measurement in Z basis.
+
+        Verifies that |+⟩ state measured in Z basis yields P(0)=0.5, P(1)=0.5.
+        """
         c = Circuit()
         c.h(0)
         c.measure(0)
@@ -91,7 +118,10 @@ class TestBasisRotationMeasurement:
         assert np.isclose(result["1"], 0.5)
 
     def test_x_basis_on_plus(self):
-        """|+⟩ measured in X basis: P(0)=1, P(1)=0."""
+        """Test |+⟩ measurement in X basis.
+
+        Verifies that |+⟩ state measured in X basis yields P(0)=1, P(1)=0.
+        """
         c = Circuit()
         c.h(0)
         c.measure(0)
@@ -99,7 +129,10 @@ class TestBasisRotationMeasurement:
         assert np.isclose(result["0"], 1.0)
 
     def test_x_basis_on_minus(self):
-        """|-⟩ measured in X basis: P(0)=0, P(1)=1."""
+        """Test |-⟩ measurement in X basis.
+
+        Verifies that |-⟩ state measured in X basis yields P(0)=0, P(1)=1.
+        """
         c = Circuit()
         c.x(0)
         c.h(0)
@@ -108,7 +141,10 @@ class TestBasisRotationMeasurement:
         assert np.isclose(result["1"], 1.0)
 
     def test_y_basis_on_iplus(self):
-        """|i⟩ = S|0⟩ measured in Y basis: P(0)=1 (eigenstate |0⟩_Y)."""
+        """Test |i⟩ measurement in Y basis.
+
+        Verifies that |i⟩ = S|0⟩ measured in Y basis is eigenstate |0⟩_Y.
+        """
         c = Circuit()
         c.s(0)
         c.measure(0)
@@ -116,7 +152,10 @@ class TestBasisRotationMeasurement:
         assert np.isclose(result["0"], 1.0)
 
     def test_two_qubit_xy(self):
-        """2-qubit state |+⟩|0⟩ measured in X,Z basis."""
+        """Test two-qubit measurement in mixed bases.
+
+        Verifies that |+⟩|0⟩ state measured in X,Z basis yields correct probabilities.
+        """
         c = Circuit()
         c.h(0)
         c.measure(0, 1)
@@ -125,7 +164,11 @@ class TestBasisRotationMeasurement:
         assert np.isclose(result["10"], 0.5)
 
     def test_shots_mode(self):
-        """shots mode returns integer counts."""
+        """Test shots mode returns integer counts.
+
+        Verifies that finite shots mode returns integer count results
+        with correct total sum.
+        """
         c = Circuit()
         c.h(0)
         c.measure(0)
@@ -136,8 +179,13 @@ class TestBasisRotationMeasurement:
 
 
 class TestStateTomography:
+    """Tests for quantum state tomography reconstruction."""
     def test_pure_state_reconstruction(self):
-        """|ψ⟩ = (|00⟩+|11⟩)/√2 should reconstruct to a rank-1 density matrix."""
+        """Test pure Bell state reconstruction.
+
+        Verifies that |ψ⟩ = (|00⟩+|11⟩)/√2 reconstructs to a rank-1 density matrix
+        with correct Hermiticity, normalization, and purity.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -151,7 +199,10 @@ class TestStateTomography:
         assert abs(purity - 1.0) < 0.05
 
     def test_mixed_state(self):
-        """|0⟩⊗|0⟩ (product state) should have purity 1 after tomography."""
+        """Test product state tomography.
+
+        Verifies that |0⟩⊗|0⟩ product state reconstructs with purity ≈ 1.
+        """
         c = Circuit()
         c.measure(0, 1)
         rho = state_tomography(c, shots=4096)
@@ -159,7 +210,10 @@ class TestStateTomography:
         assert abs(purity - 1.0) < 0.05
 
     def test_tomography_summary_runs(self):
-        """tomography_summary should run without error."""
+        """Test tomography_summary execution.
+
+        Verifies that tomography_summary runs without error on reconstructed state.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -169,6 +223,7 @@ class TestStateTomography:
         tomography_summary(rho)
 
     def test_wrong_shots_raises(self):
+        """Test that negative shots raises ValueError."""
         c = Circuit()
         c.measure(0)
         with pytest.raises(ValueError):
@@ -176,7 +231,9 @@ class TestStateTomography:
 
 
 class TestClassicalShadow:
+    """Tests for classical shadow estimation technique."""
     def test_shadow_generates_correct_count(self):
+        """Test that shadow generates correct number of snapshots."""
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -185,7 +242,11 @@ class TestClassicalShadow:
         assert len(shadows) == 16
 
     def test_auto_n_shadow(self):
-        """Auto n_shadow should scale with qubit count."""
+        """Test auto n_shadow scaling.
+
+        Verifies that automatic n_shadow calculation scales appropriately
+        with qubit count.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -194,7 +255,10 @@ class TestClassicalShadow:
         assert len(shadows) > 0
 
     def test_shadow_expectation_zz_bell(self):
-        """|Φ+⟩ = (|00⟩+|11⟩)/√2: ⟨ZZ⟩ ≈ 1."""
+        """Test ⟨ZZ⟩ estimation on Bell state.
+
+        Verifies that classical shadow estimates ⟨ZZ⟩ ≈ 1 for Bell state |Φ+⟩.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -204,7 +268,10 @@ class TestClassicalShadow:
         assert abs(est - 1.0) < 0.2
 
     def test_shadow_expectation_xx_bell(self):
-        """|Φ+⟩: ⟨XX⟩ ≈ 1."""
+        """Test ⟨XX⟩ estimation on Bell state.
+
+        Verifies that classical shadow estimates ⟨XX⟩ ≈ 1 for Bell state |Φ+⟩.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -214,7 +281,10 @@ class TestClassicalShadow:
         assert abs(est - 1.0) < 0.2
 
     def test_shadow_expectation_identity(self):
-        """|Φ+⟩: ⟨II⟩ = 1 always."""
+        """Test identity operator estimation.
+
+        Verifies that classical shadow always estimates ⟨II⟩ = 1.
+        """
         c = Circuit()
         c.h(0)
         c.cx(0, 1)
@@ -224,6 +294,7 @@ class TestClassicalShadow:
         assert np.isclose(est, 1.0)
 
     def test_shadow_wrong_length_raises(self):
+        """Test that mismatched operator length raises ValueError."""
         c = Circuit()
         c.measure(0, 1)
         shadows = classical_shadow(c, shots=512, n_shadow=8)
@@ -231,6 +302,7 @@ class TestClassicalShadow:
             shadow_expectation(shadows, "Z")   # 1 qubit, shadow has 2
 
     def test_empty_shadows_raises(self):
+        """Test that empty shadow list raises ValueError."""
         c = Circuit()
         c.measure(0)
         with pytest.raises(ValueError, match="empty"):

--- a/qpandalite/task/originq/task.py
+++ b/qpandalite/task/originq/task.py
@@ -1,9 +1,10 @@
-'''
+"""OriginQ QPilot task submission module.
+
 Commit task to originq QPilot directly.
 
-This module is not available in current version. 
+This module is not available in current version.
 Please use qpandalite.task.originq_cloud instead.
-'''
+"""
 
 raise ImportError('This module is not available in current version. '
                   'Please use qpandalite.task.originq_cloud instead.')
@@ -24,6 +25,19 @@ from ..task_utils import make_savepath, load_all_online_info, write_taskinfo
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 def get_token(pilot_api, login_url):
+    """Authenticate with OriginQ server and obtain access token.
+
+    Args:
+        pilot_api (str): The API key for authentication.
+        login_url (str): The URL endpoint for login requests.
+
+    Raises:
+        RuntimeError: If the server returns a non-200 status code
+            or if the response cannot be parsed.
+
+    Returns:
+        str: The authentication token from the server.
+    """
     request_body = dict()
     request_body['apiKey'] = pilot_api
     request_body = json.dumps(request_body)

--- a/qpandalite/task/quafu/task.py
+++ b/qpandalite/task/quafu/task.py
@@ -205,7 +205,22 @@ def query_by_taskid(
     taskid: str | list[str],
     savepath: Path | str | None = None,
 ) -> dict[str, Any]:
-    """Query task status by task ID (non-blocking)."""
+    """Query task status by task ID (non-blocking).
+
+    Args:
+        taskid (str | list[str]): Single task ID or list of task IDs to query.
+        savepath (Path | str | None, optional): Directory path for saving task
+            results locally. Defaults to ./quafu_online_info/.
+
+    Returns:
+        dict[str, Any]: Task status dictionary containing:
+            - "status": "success", "running", or "failed"
+            - "result": Task result data when status is "success",
+              or error information when status is "failed"
+
+    Raises:
+        ValueError: If taskid is empty or has invalid type.
+    """
     adapter = _get_adapter()
     savepath = Path(savepath) if savepath else Path.cwd() / "quafu_online_info"
 

--- a/qpandalite/task/quafu/task.py
+++ b/qpandalite/task/quafu/task.py
@@ -174,7 +174,21 @@ def _ensure_savepath(savepath: Path) -> None:
 def query_by_taskid_single(
     taskid: str, savepath: Path | str
 ) -> str | dict[str, Any]:
-    """Query a single task's status from the Quafu platform."""
+    """Query a single task's status from the Quafu platform.
+
+    Args:
+        taskid (str): The unique task identifier.
+        savepath (Path | str): Directory path for saving task results.
+
+    Returns:
+        str | dict[str, Any]: One of the following:
+            - "Running": Task is still executing.
+            - "Failed": Task execution failed.
+            - dict: Task result dictionary when completed successfully.
+
+    Note:
+        Results are cached locally to avoid redundant API calls.
+    """
     adapter = _get_adapter()
     result = adapter.query(taskid)
     savepath = Path(savepath)
@@ -223,7 +237,24 @@ def query_by_taskid_sync(
     timeout: float = 60.0,
     retry: int = 5,
 ) -> list[dict[str, Any]]:
-    """Query task status by task ID (blocking) until completion or timeout."""
+    """Query task status by task ID (blocking) until completion or timeout.
+
+    Continuously polls the Quafu platform until the task completes,
+    fails, or the timeout is reached.
+
+    Args:
+        taskid (str | list[str]): Single task ID or list of task IDs to query.
+        interval (float, optional): Polling interval in seconds. Defaults to 2.0.
+        timeout (float, optional): Maximum wait time in seconds. Defaults to 60.0.
+        retry (int, optional): Number of retry attempts on query failure. Defaults to 5.
+
+    Raises:
+        TimeoutError: If the task does not complete within the specified timeout.
+        RuntimeError: If the task fails or all retry attempts are exhausted.
+
+    Returns:
+        list[dict[str, Any]]: List of task result dictionaries when all tasks succeed.
+    """
     adapter = _get_adapter()
     starttime = time.time()
 
@@ -256,7 +287,25 @@ def query_task_by_group(
     verbose: bool = True,
     savepath: Path | str | None = None,
 ) -> list:
-    """Retrieve all tasks belonging to a named Quafu group."""
+    """Retrieve all tasks belonging to a named Quafu group.
+
+    Queries the Quafu platform for all tasks associated with the specified
+    group name and caches the results locally.
+
+    Args:
+        group_name (str): The name of the task group to query.
+        history (dict[str, list[str]] | None, optional): Cache of previously
+            queried group tasks. If None, loads from local savepath.
+        verbose (bool, optional): Whether to print detailed output. Defaults to True.
+        savepath (Path | str | None, optional): Directory for saving results.
+            Defaults to current working directory / "quafu_online_info".
+
+    Raises:
+        ValueError: If group_name is empty or not a string.
+
+    Returns:
+        list: List of task result objects from the Quafu platform.
+    """
     if not group_name:
         raise ValueError("Task id ??")
     if not isinstance(group_name, str):
@@ -298,7 +347,26 @@ def query_task_by_group_sync(
     timeout: float = 60.0,
     retry: int = 5,
 ) -> list:
-    """Blocking query for all tasks in a named Quafu group."""
+    """Blocking query for all tasks in a named Quafu group.
+
+    Polls the Quafu platform until all tasks in the specified group have
+    reached a terminal state (completed or failed), or until timeout.
+
+    Args:
+        group_name (str): The name of the task group to query.
+        verbose (bool, optional): Whether to print detailed output. Defaults to True.
+        savepath (Path | str | None, optional): Directory for saving results.
+            Defaults to current working directory / "quafu_online_info".
+        interval (float, optional): Polling interval in seconds. Defaults to 2.0.
+        timeout (float, optional): Maximum wait time in seconds. Defaults to 60.0.
+        retry (int, optional): Number of retry attempts on query failure. Defaults to 5.
+
+    Raises:
+        TimeoutError: If not all tasks complete within the specified timeout.
+
+    Returns:
+        list: List of task result objects when all tasks are complete.
+    """
     if savepath is None:
         savepath = Path.cwd() / "quafu_online_info"
 

--- a/qpandalite/version.py
+++ b/qpandalite/version.py
@@ -1,1 +1,7 @@
+"""QPanda-lite version information.
+
+This module defines the current version of the QPanda-lite package,
+which follows semantic versioning (MAJOR.MINOR.PATCH).
+"""
+
 __version__ = "0.2.6"


### PR DESCRIPTION
## 变更内容

为剩余的 4 个文件补充 Google Style docstring，完成全部 30 个文件的文档补充任务。

### 涉及文件

| 文件 | 补充内容 |
|------|----------|
| `version.py` | 模块级 docstring（版本信息） |
| `task/originq/task.py` | 模块级 docstring + `get_token()` 函数 docstring |
| `task/quafu/task.py` | 4 个查询函数 docstring（query_by_taskid_single, query_by_taskid_sync, query_task_by_group, query_task_by_group_sync） |
| `algorithmics/measurement/test_measurement.py` | 4 个测试类 docstring + 所有测试方法 docstring |

### 文档规范

- 使用 Google Style docstring 格式
- 模块级文档说明模块用途
- 类/函数文档包含 Args、Returns、Raises 等标准章节

### 任务完成

全部 6 个任务块已完成：
- ✅ 块 1: circuit_builder 模块 (PR #149)
- ✅ 块 2: simulator 模块 (PR #150)
- ✅ 块 3: qcloud_config 模块 (PR #151)
- ✅ 块 4: parser 模块 (PR #152)
- ✅ 块 5: transpiler 模块 (PR #153)
- ✅ 块 6: 其他文件 (本 PR)

总计：30 个文件，约 450+ 行新增文档
