### PR TITLE
fix: docstring follow-up fixes (#149 #152)

### DIFF
--- a/qpandalite/circuit_builder/opcode.py
+++ b/qpandalite/circuit_builder/opcode.py
@@ -1,6 +1,6 @@
-'''
+"""
 This file is used to convert the opcode to various quantum code formats.
-'''
+"""
 
 from typing import List, Optional, Tuple, Union
 from .translate_qasm2_oir import OriginIR_QASM2_dict, get_QASM2_from_opcode, decompose_mcx_qasm_text
@@ -25,7 +25,7 @@ OpcodeType = Tuple[str, QubitType, CbitType, ParameterType, set, bool]
 
 
 def make_header_originir(qubit_num: int, cbit_num: int) -> str:
-    '''
+    """
     Generate the header of OriginIR code for the given qubit and cbit number.
 
     Args:
@@ -34,14 +34,14 @@ def make_header_originir(qubit_num: int, cbit_num: int) -> str:
 
     Returns:
         str: The header of OriginIR code.
-    '''
+    """
     ret = 'QINIT {}\n'.format(qubit_num)
     ret += 'CREG {}\n'.format(cbit_num)
     return ret
 
 
-def opcode_to_line_originir(opcode : OpcodeType) -> str:            
-    '''
+def opcode_to_line_originir(opcode : OpcodeType) -> str:
+    """
     Convert the given opcode to OriginIR line format.
 
     opcode is a tuple with the following format:
@@ -66,7 +66,7 @@ def opcode_to_line_originir(opcode : OpcodeType) -> str:
 
     Returns:
         str: The converted OriginIR line format.
-    '''
+    """
     (operation, qubit, cbit, parameter, dagger_flag, control_qubits_set) = opcode
     
     # operation qubits (,parameter?) (,cbits?) (dagger?) (control?)
@@ -108,7 +108,7 @@ def opcode_to_line_originir(opcode : OpcodeType) -> str:
 
 
 def make_measure_originir(measure_list : List[int]):
-    '''
+    """
     Generate the measure statement of OriginIR code for the given measure list.
 
     Args:
@@ -116,7 +116,7 @@ def make_measure_originir(measure_list : List[int]):
 
     Returns:
         str: The measure statement of OriginIR code.
-    '''
+    """
 
     ret = ''
     for i, meas_qubit in enumerate(measure_list):
@@ -125,7 +125,7 @@ def make_measure_originir(measure_list : List[int]):
 
 
 def make_header_qasm(qubit_num: int, cbit_num: int) -> str:
-    '''
+    """
     Generate the header of QASM code for the given qubit and cbit number.
 
     Args:
@@ -134,7 +134,7 @@ def make_header_qasm(qubit_num: int, cbit_num: int) -> str:
 
     Returns:
         str: The header of QASM code.
-    '''
+    """
     
     ret = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\n"
     ret += 'qreg q[{}];\n'.format(qubit_num)
@@ -143,7 +143,7 @@ def make_header_qasm(qubit_num: int, cbit_num: int) -> str:
 
 
 def opcode_to_line_qasm(opcode: OpcodeType, qubit_num: Optional[int] = None) -> str:
-    '''
+    """
     Convert the given opcode to QASM line format.
 
     For gates with ≥ 4 control qubits on an X gate, a multi-line Toffoli-ladder
@@ -159,7 +159,7 @@ def opcode_to_line_qasm(opcode: OpcodeType, qubit_num: Optional[int] = None) -> 
     Returns:
         str: The converted QASM line format (potentially multi-line for MCX
         decompositions).
-    '''
+    """
 
     operation, qubit, cbit, parameter = get_QASM2_from_opcode(opcode)
 
@@ -203,7 +203,7 @@ def opcode_to_line_qasm(opcode: OpcodeType, qubit_num: Optional[int] = None) -> 
 
 
 def make_measure_qasm(measure_list : List[int]) -> str:
-    '''
+    """
     Generate the measure statement of QASM code for the given measure list.
 
     Args:
@@ -211,9 +211,9 @@ def make_measure_qasm(measure_list : List[int]) -> str:
 
     Returns:
         str: The measure statement of QASM code.
-    '''
+    """
     
     ret = ''
     for i, meas_qubit in enumerate(measure_list):
         ret += 'measure q[{}] -> c[{}];\n'.format(meas_qubit, i)
-    return ret   
+    return ret

--- a/qpandalite/circuit_builder/random_qasm.py
+++ b/qpandalite/circuit_builder/random_qasm.py
@@ -87,7 +87,7 @@ def build_measurements(measure_qbit_cbit_pairs, qreg_name = 'q', creg_name = 'c'
         List[str]: a list of QASM measurement instructions.
     """
     measure_instructions = []
-    for qbit, cbit in range(measure_qbit_cbit_pairs):
+    for qbit, cbit in measure_qbit_cbit_pairs:
         measure_instructions.append(f"measure {qreg_name}[{qbit}] -> {creg_name}[{cbit}];")
 
     return measure_instructions

--- a/qpandalite/qasm/exceptions.py
+++ b/qpandalite/qasm/exceptions.py
@@ -1,16 +1,32 @@
+"""QASM parser exceptions module.
+
+This module defines custom exceptions for OpenQASM 2.0 parsing,
+including errors for unsupported gates and register-related issues.
+
+Key exports:
+    NotSupportedGateError: Exception for unsupported quantum gates.
+    RegisterNotFoundError: Exception for missing quantum/classical registers.
+    RegisterOutOfRangeError: Exception for register index out of bounds.
+    RegisterDefinitionError: Exception for invalid register definitions.
+"""
 
 __all__ = ["NotSupportedGateError", "RegisterNotFoundError", "RegisterOutOfRangeError", "RegisterDefinitionError"]
+
+
 class NotSupportedGateError(Exception):
     """Raised when an unsupported gate is encountered in OpenQASM 2."""
     pass
+
 
 class RegisterNotFoundError(Exception):
     """Raised when a quantum or classical register is not found."""
     pass
 
+
 class RegisterOutOfRangeError(Exception):
     """Raised when a register index exceeds its defined size."""
     pass
+
 
 class RegisterDefinitionError(Exception):
     """Raised when a register definition is invalid (e.g., duplicate name, empty)."""

--- a/qpandalite/test/test_circuit_builder_opcode_and_random.py
+++ b/qpandalite/test/test_circuit_builder_opcode_and_random.py
@@ -558,24 +558,31 @@ class TestQasmBuildFullMeasurements:
 
 
 class TestBuildMeasurements:
-    """
-    BUG NOTE: `build_measurements` uses `range(measure_qbit_cbit_pairs)` instead
-    of iterating over the argument as pairs (it should use `for qbit, cbit in ...`).
-    This means passing an integer works (iterating range), but passing actual
-    pairs would raise a TypeError.  Tests below document the actual behaviour.
-    """
+    """Tests for `build_measurements` function."""
 
     def test_integer_arg_raises_typeerror(self):
-        # Passing an integer raises TypeError because range(int) yields ints,
-        # and the loop tries to unpack each int as (qbit, cbit).
+        # Passing an integer should raise TypeError because it is not iterable
+        # as pairs (the function expects an iterable of (qubit, cbit) tuples).
         with pytest.raises(TypeError):
             build_measurements(3)
 
-    def test_pairs_raises_typeerror(self):
-        # Passing correct pairs should work logically but the implementation
-        # has a bug: `range(measure_qbit_cbit_pairs)` calls range() on a list.
-        with pytest.raises(TypeError):
-            build_measurements([(0, 0), (1, 1)])
+    def test_pairs_works_correctly(self):
+        # After bug fix: passing correct pairs should work correctly
+        result = build_measurements([(0, 0), (1, 1)])
+        assert len(result) == 2
+        assert "measure q[0] -> c[0];" in result[0]
+        assert "measure q[1] -> c[1];" in result[1]
+
+    def test_single_pair(self):
+        # Test with a single (qubit, cbit) pair
+        result = build_measurements([(2, 0)])
+        assert len(result) == 1
+        assert "measure q[2] -> c[0];" in result[0]
+
+    def test_empty_pairs(self):
+        # Test with empty pairs list
+        result = build_measurements([])
+        assert result == []
 
 
 class TestRandomQasm:


### PR DESCRIPTION
## 修复内容

针对 QA 审阅反馈的修复：

### PR #149 相关修复
1. **random_qasm.py**: 修复 `build_measurements` 函数中的 `range()` 误用
   - 错误: `for qbit, cbit in range(measure_qbit_cbit_pairs):`
   - 正确: `for qbit, cbit in measure_qbit_cbit_pairs:`

2. **opcode.py**: 统一所有 docstring 引号为双引号

### PR #152 相关修复
3. **exceptions.py**: 
   - 删除第一行空行
   - 添加模块级 docstring

## 相关 PR
- 修复 #149 circuit_builder 模块残留问题
- 修复 #152 parser 模块残留问题
