### PR TITLE
fix: docstring residual bugs (#149 #152)

### DIFF
--- a/qpandalite/circuit_builder/opcode.py
+++ b/qpandalite/circuit_builder/opcode.py
@@ -1,6 +1,6 @@
-'''
+"""
 This file is used to convert the opcode to various quantum code formats.
-'''
+"""
 
 from typing import List, Optional, Tuple, Union
 from .translate_qasm2_oir import OriginIR_QASM2_dict, get_QASM2_from_opcode, decompose_mcx_qasm_text

--- a/qpandalite/circuit_builder/random_qasm.py
+++ b/qpandalite/circuit_builder/random_qasm.py
@@ -87,7 +87,7 @@ def build_measurements(measure_qbit_cbit_pairs, qreg_name = 'q', creg_name = 'c'
         List[str]: a list of QASM measurement instructions.
     """
     measure_instructions = []
-    for qbit, cbit in range(measure_qbit_cbit_pairs):
+    for qbit, cbit in measure_qbit_cbit_pairs:
         measure_instructions.append(f"measure {qreg_name}[{qbit}] -> {creg_name}[{cbit}];")
 
     return measure_instructions

--- a/qpandalite/qasm/exceptions.py
+++ b/qpandalite/qasm/exceptions.py
@@ -1,16 +1,32 @@
+"""QASM parser exceptions module.
+
+This module defines custom exceptions for OpenQASM 2.0 parsing,
+including errors for unsupported gates and register-related issues.
+
+Key exports:
+    NotSupportedGateError: Exception for unsupported quantum gates.
+    RegisterNotFoundError: Exception for missing quantum/classical registers.
+    RegisterOutOfRangeError: Exception for register index out of bounds.
+    RegisterDefinitionError: Exception for invalid register definitions.
+"""
 
 __all__ = ["NotSupportedGateError", "RegisterNotFoundError", "RegisterOutOfRangeError", "RegisterDefinitionError"]
+
+
 class NotSupportedGateError(Exception):
     """Raised when an unsupported gate is encountered in OpenQASM 2."""
     pass
+
 
 class RegisterNotFoundError(Exception):
     """Raised when a quantum or classical register is not found."""
     pass
 
+
 class RegisterOutOfRangeError(Exception):
     """Raised when a register index exceeds its defined size."""
     pass
+
 
 class RegisterDefinitionError(Exception):
     """Raised when a register definition is invalid (e.g., duplicate name, empty)."""

--- a/qpandalite/test/test_circuit_builder_opcode_and_random.py
+++ b/qpandalite/test/test_circuit_builder_opcode_and_random.py
@@ -558,24 +558,31 @@ class TestQasmBuildFullMeasurements:
 
 
 class TestBuildMeasurements:
-    """
-    BUG NOTE: `build_measurements` uses `range(measure_qbit_cbit_pairs)` instead
-    of iterating over the argument as pairs (it should use `for qbit, cbit in ...`).
-    This means passing an integer works (iterating range), but passing actual
-    pairs would raise a TypeError.  Tests below document the actual behaviour.
-    """
+    """Tests for `build_measurements` function."""
 
     def test_integer_arg_raises_typeerror(self):
-        # Passing an integer raises TypeError because range(int) yields ints,
-        # and the loop tries to unpack each int as (qbit, cbit).
+        # Passing an integer should raise TypeError because it is not iterable
+        # as pairs (the function expects an iterable of (qubit, cbit) tuples).
         with pytest.raises(TypeError):
             build_measurements(3)
 
-    def test_pairs_raises_typeerror(self):
-        # Passing correct pairs should work logically but the implementation
-        # has a bug: `range(measure_qbit_cbit_pairs)` calls range() on a list.
-        with pytest.raises(TypeError):
-            build_measurements([(0, 0), (1, 1)])
+    def test_pairs_works_correctly(self):
+        # After bug fix: passing correct pairs should work correctly
+        result = build_measurements([(0, 0), (1, 1)])
+        assert len(result) == 2
+        assert "measure q[0] -> c[0];" in result[0]
+        assert "measure q[1] -> c[1];" in result[1]
+
+    def test_single_pair(self):
+        # Test with a single (qubit, cbit) pair
+        result = build_measurements([(2, 0)])
+        assert len(result) == 1
+        assert "measure q[2] -> c[0];" in result[0]
+
+    def test_empty_pairs(self):
+        # Test with empty pairs list
+        result = build_measurements([])
+        assert result == []
 
 
 class TestRandomQasm:


### PR DESCRIPTION
## 修复内容

修复已合并 PR 中发现的残留问题：

### circuit_builder 模块 (#149 残留)
1. **random_qasm.py**: 修复 `build_measurements` 函数中的 `range()` 误用
   - 错误: `for qbit, cbit in range(measure_qbit_cbit_pairs):`
   - 正确: `for qbit, cbit in measure_qbit_cbit_pairs:`

2. **opcode.py**: 统一模块 docstring 引号为双引号

### parser 模块 (#152 残留)
3. **exceptions.py**: 
   - 删除第一行空行
   - 添加模块级 docstring

## 相关 PR
- 修复 #149 circuit_builder 模块残留问题
- 修复 #152 parser 模块残留问题
