### PR TITLE
fix(simulator): use row-major reshape for density matrix (order='F'→'C')

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,5 +62,5 @@ jobs:
     - name: Test
       run: |
         pip install pytest --quiet
-        pytest qpandalite/test/ -v --deselect qpandalite/test/test_random_QASM.py::test_random_qasm_compare_density_operator --deselect qpandalite/test/test_random_OriginIR.py::run_test_random_originir_density_operator --deselect qpandalite/test/test_random_QASM.py::run_test_random_qasm_density_operator_compare_with_qutip
+        pytest qpandalite/test/ -v
    

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -27,7 +27,7 @@ jobs:
       run: pip install pytest pytest-cov
 
     - name: Run tests with coverage
-      run: pytest qpandalite/test/ --cov=qpandalite --cov-report=term-missing --cov-report=xml -v --deselect qpandalite/test/test_random_QASM.py::test_random_qasm_compare_density_operator --deselect qpandalite/test/test_random_OriginIR.py::run_test_random_originir_density_operator --deselect qpandalite/test/test_random_QASM.py::run_test_random_qasm_density_operator_compare_with_qutip
+      run: pytest qpandalite/test/ --cov=qpandalite --cov-report=term-missing --cov-report=xml -v
 
     - name: Upload coverage report
       if: always()

--- a/qpandalite/simulator/opcode_simulator.py
+++ b/qpandalite/simulator/opcode_simulator.py
@@ -331,7 +331,7 @@ class OpcodeSimulator:
                 self.simulate_gate(operation, qubit, cbit, parameter, is_dagger, control_qubits_set)
             state = self.simulator.state
             state = np.array(state)
-            density_matrix = np.reshape(state, (2 ** n_qubit, 2 ** n_qubit), order='F')
+            density_matrix = np.reshape(state, (2 ** n_qubit, 2 ** n_qubit), order='C')
             return density_matrix
 
         if self.simulator_typestr =='statevector':


### PR DESCRIPTION
## Summary

- Fix `np.reshape(..., order='F')` → `order='C'` in `opcode_simulator.py:334` to match the C++ density operator's row-major memory layout
- Re-enable 3 previously-deselected density operator tests in both CI workflows

## Root cause

`val(state, i, j, N)` in `simulator_density_op_impl.cpp:5-13` uses `state[i*N+j]` — strictly row-major. Using `order='F'` in Python silently transposed every density matrix returned from the C++ backend.

Commit `b2c2047` (Fix variable swap bugs in density matrix u22 and u44 evolution) made the C++ argument ordering consistently row-major throughout, fully exposing this Python-side transposition. Before that commit, the C++ argument-swap bug and the Python transpose bug partially cancelled each other on some circuits.

## Tests re-enabled

All three tests attributed to issue #145 (crx/crz/cy C++ bug) now pass locally with `order='C'`:

- `test_random_OriginIR.py::run_test_random_originir_density_operator` ✅
- `test_random_QASM.py::test_random_qasm_compare_density_operator` ✅
- `test_random_QASM.py::run_test_random_qasm_density_operator_compare_with_qutip` ✅

This suggests the actual root cause of those CI failures was the transposition bug, not a real crx/crz/cy gate defect. Enabling them in CI will confirm. If any test still fails on CI (different platform/seed), that one can be selectively re-deselected and issue #145 updated accordingly.

## Test plan

- [x] Local: `uv run pytest qpandalite/test/ -v` → 953 passed / 3 xfailed / 956 collected / 0 failed
- [x] Targeted: all 3 re-enabled tests pass in isolation
- [ ] CI `build_and_test` ({ubuntu, windows} × {gcc, clang, cl}) — confirm via CI
- [ ] CI `pytest_coverage` (Python 3.11) — confirm via CI

Closes #145 if all CI runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)