### PR TITLE
ci: use cibuildwheel for PyPI publishing with C++ extension

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-musllinux_*"
           CIBW_BEFORE_BUILD: pip install ninja
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,31 +8,54 @@ on:
       - 'v*'
 
 jobs:
+  build_wheels:
+    name: Build wheel (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.26.x'
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          CIBW_SKIP: "*-musllinux_*"
+          CIBW_BEFORE_BUILD: pip install ninja
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
   publish:
     name: Publish to PyPI
+    needs: build_wheels
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/project/qpandalite/
-
     permissions:
-      id-token: write  # required for trusted publishing
+      id-token: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
         with:
-          submodules: true
+          path: dist/
+          merge-multiple: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Build sdist and wheel
-        run: |
-          python -m pip install build
-          python -m build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python_build_wheel.yml
+++ b/.github/workflows/python_build_wheel.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         # 定义操作系统和 Python 版本的矩阵
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     # 第一步：检出代码库

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 description = "QPanda-Lite. A python-native version for pyqpanda. Simple, easy, and transparent."
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.15"
 authors = [
     { name = "Agony", email = "chenzhaoyun@iai.ustc.edu.cn" },
 ]
@@ -20,10 +20,11 @@ classifiers = [
     "Programming Language :: C++",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Operating System :: Microsoft :: Windows",
@@ -54,7 +55,7 @@ packages = { find = { exclude = ["qpandalite.test", "qpandalite.test.*"] } }
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "C4", "SIM"]


### PR DESCRIPTION
## Summary
- Replace manual `python -m build` with `cibuildwheel` to build wheels that include the `qpandalite_cpp` C++ extension
- Targets Linux (manylinux) and Windows for Python 3.9–3.12
- Two-stage workflow: `build_wheels` (per-platform) → `publish` (aggregates and uploads to PyPI)
- Uses Trusted Publishing (OIDC), no API token needed

## Test plan
- [ ] Verify PyPI Trusted Publisher is configured with the new workflow name
- [ ] Push a `v*` tag and confirm all 8 wheels (4 Python × 2 OS) build successfully
- [ ] Confirm wheels on PyPI contain the `qpandalite_cpp` native extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)