### PR TITLE
build: use setuptools_scm for automatic versioning from git tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,9 @@ bad_circuits.txt
 *.png
 *.pdf
 
+# setuptools_scm generated version file
+qpandalite/_version.py
+
 # CMake build artifacts
 QPandaLiteCpp/CMakeCache.txt
 QPandaLiteCpp/CMakeFiles/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ ruff format .         # format
 ruff check . --fix    # auto-fix lint issues
 ```
 
-Ruff config: line length 120, target Python 3.9. Rules: E, F, W, I, N, UP, B, C4, SIM. E501 and physics naming conventions (N801/N803/N806) are intentionally ignored.
+Ruff config: line length 120, target Python 3.10. Rules: E, F, W, I, N, UP, B, C4, SIM. E501 and physics naming conventions (N801/N803/N806) are intentionally ignored.
 
 Pre-commit hooks are configured (ruff lint + format, YAML check, trailing whitespace).
 
@@ -78,6 +78,18 @@ Pre-commit hooks are configured (ruff lint + format, YAML check, trailing whites
 ### C++ Backend
 
 `QPandaLiteCpp/` contains the C++ simulation backend compiled as a pybind11 extension (`qpandalite_cpp`). Dependencies (pybind11 v2.13.6, fmt) are git submodules under `QPandaLiteCpp/Thirdparty/`. The `CMakeExtension` class in `setup.py` handles CMake-based compilation. Building without C++ uses `pip install . --no-cpp`.
+
+## Releasing
+
+The package version is automatically managed by [setuptools_scm](https://setuptools-scm.readthedocs.io/), which extracts the version from git tags. The version is determined at build time from the latest git tag matching `v*`.
+
+To release a new version:
+
+1. Ensure all changes are committed and merged to `main`
+2. Tag the release: `git tag vX.Y.Z` (the tag **must start with `v`**)
+3. Push the tag: `git push origin --tags`
+
+Pushing a `v*` tag triggers `pypi-publish.yml`, which builds wheels (Linux manylinux + Windows, Python 3.10–3.14) with the C++ extension via `cibuildwheel` and publishes them to PyPI using Trusted Publishing (OIDC). No manual version bump is needed — the version is automatically extracted from the git tag.
 
 ## Known Issues
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=64", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 # setup.py is retained for custom CMakeExtension / CMakeBuild logic
 
@@ -70,8 +70,9 @@ dev = [
     "pytest-cov>=7.1.0",
 ]
 
-[tool.setuptools.dynamic]
-version = { attr = "qpandalite.version.__version__" }
+[tool.setuptools_scm]
+write_to = "qpandalite/_version.py"
+fallback_version = "0.0.0"
 
 [tool.setuptools.package-data]
 "qpandalite" = ["test/QASMBench.pkl", "*.pyi"]

--- a/qpandalite/version.py
+++ b/qpandalite/version.py
@@ -1,7 +1,14 @@
 """QPanda-lite version information.
 
-This module defines the current version of the QPanda-lite package,
-which follows semantic versioning (MAJOR.MINOR.PATCH).
+This module provides the package version, automatically managed by setuptools_scm.
 """
 
-__version__ = "0.2.6"
+try:
+    from importlib.metadata import version, PackageNotFoundError
+    __version__ = version("qpandalite")
+except PackageNotFoundError:
+    # Package not installed (e.g., running from source without install)
+    try:
+        from qpandalite._version import __version__
+    except ImportError:
+        __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Summary

Migrate version management from manual `__version__` string to automatic versioning via `setuptools_scm`, extracting version from git tags.

## Changes

- **pyproject.toml**: Add `setuptools_scm>=8` to build requirements; configure `[tool.setuptools_scm]` section
- **qpandalite/version.py**: Dynamically read version from package metadata or auto-generated `_version.py`
- **.gitignore**: Add `qpandalite/_version.py` (auto-generated file)
- **CLAUDE.md**: Update release process documentation

## New Release Process

```bash
# 1. Tag with version (must start with 'v')
git tag v0.2.7

# 2. Push tags
git push origin --tags
```

No manual version bump needed — version is extracted from git tag automatically.

## Testing

- [ ] CI passes
- [ ] Version correctly extracted from git tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)