### PR TITLE
ci: fix CIBW_BEFORE_BUILD_LINUX shell command

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -37,7 +37,7 @@ jobs:
           CIBW_SKIP: "*-musllinux_* *-win32"
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_BEFORE_BUILD: pip install ninja
-          CIBW_BEFORE_BUILD_LINUX: yum install -y python3-devel || apt-get update && apt-get install -y python3-dev
+          CIBW_BEFORE_BUILD_LINUX: "if command -v yum >/dev/null 2>&1; then yum install -y python3-devel; elif command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y python3-dev; fi"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Problem

The CIBW_BEFORE_BUILD_LINUX command was using `||` and `&&` which caused `apt-get` to be executed even when `yum` succeeded:

```yaml
yum install -y python3-devel || apt-get update && apt-get install -y python3-dev
```

Due to operator precedence, this evaluates as:
```
yum install ... || (apt-get update && apt-get install ...)
```

So even when yum succeeds, the exit code 1 from the first part causes the second part to execute, and apt-get fails with "command not found" on CentOS-based manylinux images.

## Fix

Use if/elif to properly detect and use the available package manager:

```yaml
if command -v yum >/dev/null 2>&1; then yum install -y python3-devel; elif command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y python3-dev; fi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)