### PR TITLE
fix: let pybind11 handle Python detection in CMake

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -37,7 +37,6 @@ jobs:
           CIBW_SKIP: "*-musllinux_* *-win32"
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_BEFORE_BUILD: pip install ninja
-          CIBW_BEFORE_BUILD_LINUX: "if command -v yum >/dev/null 2>&1; then yum install -y python3-devel; elif command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y python3-dev; fi"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,7 @@ if (UNIX)
     add_definitions("-fPIC")
 endif()
 
-find_package(Python COMPONENTS Interpreter Development REQUIRED)
-include_directories(${PYTHON_INCLUDE_DIRS})
-message("Python include dirs: ${PYTHON_INCLUDE_DIRS}")
+# Python detection is handled by pybind11 in Thirdparty/pybind11
+# pybind11_add_module will automatically find the correct Python version
 
 add_subdirectory(QPandaLiteCpp)


### PR DESCRIPTION
## Problem

CMake was finding system Python 2.7 instead of the target Python version (3.10-3.14) in cibuildwheel's manylinux containers:

```
CMake Error: Could NOT find Python (missing: Python_INCLUDE_DIRS Python_LIBRARIES)
(found version "2.7.5")
```

The `yum install python3-devel` was installing Python 3.6 headers, which doesn't help for Python 3.10+ builds.

## Solution

- Remove explicit `find_package(Python)` call from CMakeLists.txt
- Let `pybind11_add_module` automatically detect the correct Python version from cibuildwheel's build environment
- Remove unnecessary `CIBW_BEFORE_BUILD_LINUX` setting

pybind11 already has built-in Python detection that respects the Python interpreter used to build the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)