### PR TITLE
fix: drop Python 3.14 support (pyqpanda3 not compatible)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22
         env:
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: "*-musllinux_* *-win32"
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_BEFORE_BUILD: pip install ninja

--- a/.github/workflows/python_build_wheel.yml
+++ b/.github/workflows/python_build_wheel.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         # 定义操作系统和 Python 版本的矩阵
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     # 第一步：检出代码库

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ To release a new version:
 2. Tag the release: `git tag vX.Y.Z` (the tag **must start with `v`**)
 3. Push the tag: `git push origin --tags`
 
-Pushing a `v*` tag triggers `pypi-publish.yml`, which builds wheels (Linux manylinux + Windows, Python 3.10–3.14) with the C++ extension via `cibuildwheel` and publishes them to PyPI using Trusted Publishing (OIDC). No manual version bump is needed — the version is automatically extracted from the git tag.
+Pushing a `v*` tag triggers `pypi-publish.yml`, which builds wheels (Linux manylinux + Windows, Python 3.10–3.13) with the C++ extension via `cibuildwheel` and publishes them to PyPI using Trusted Publishing (OIDC). No manual version bump is needed — the version is automatically extracted from the git tag.
 
 ## Known Issues
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 description = "QPanda-Lite. A python-native version for pyqpanda. Simple, easy, and transparent."
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.14"
 authors = [
     { name = "Agony", email = "chenzhaoyun@iai.ustc.edu.cn" },
 ]
@@ -24,7 +24,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
## Problem

Build fails with:
```
ERROR: No matching distribution found for pyqpanda3
```

`pyqpanda3` dependency does not yet support Python 3.14.

## Solution

Remove Python 3.14 support until pyqpanda3 adds compatibility.

### Changes

| File | Modification |
|------|--------------|
| `pyproject.toml` | `requires-python = ">=3.10,<3.14"`, remove 3.14 classifier |
| `pypi-publish.yml` | Remove `cp314-*` from cibuildwheel |
| `python_build_wheel.yml` | Remove 3.14 from test matrix |
| `CLAUDE.md` | Update docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)