### PR TITLE
fix: use setuptools_scm to get version in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,21 +18,26 @@ parent_path = pathlib.Path(__file__).resolve().parent.parent
 # Only the project root is needed; qpandalite/ lives directly under it.
 sys.path.insert(0, os.path.abspath(parent_path))
 
-# Read version from package metadata or fallback to version.py
+# Read version from setuptools_scm (git tags) or fallback
 try:
-    from importlib.metadata import version as get_version, PackageNotFoundError
-    release = get_version('qpandalite')
-except (PackageNotFoundError, Exception):
-    # Fallback: try to read from _version.py (setuptools_scm generated)
+    from setuptools_scm import get_version
+    release = get_version(root=str(parent_path), relative_to=__file__)
+except Exception:
+    # Fallback: try importlib.metadata (works when package is installed)
     try:
-        _version_file = parent_path / 'qpandalite' / '_version.py'
-        if _version_file.exists():
-            exec(_version_file.read_text())
-            release = __version__
-        else:
+        from importlib.metadata import version as get_version, PackageNotFoundError
+        release = get_version('qpandalite')
+    except (PackageNotFoundError, Exception):
+        # Fallback: try to read from _version.py (setuptools_scm generated)
+        try:
+            _version_file = parent_path / 'qpandalite' / '_version.py'
+            if _version_file.exists():
+                exec(_version_file.read_text())
+                release = __version__
+            else:
+                release = '0.0.0+unknown'
+        except Exception:
             release = '0.0.0+unknown'
-    except Exception:
-        release = '0.0.0+unknown'
 
 copyright = '2025, Agony5757'
 author = ', '.join(['Agony5757', 'YunJ1e', 'automatic-code-ztr', 'didaozi'])

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ sphinx-markdown-tables
 linkify-it-py
 myst_parser
 numpy
+setuptools_scm


### PR DESCRIPTION
## Problem

Since switching to setuptools_scm, the docs version number doesn't automatically track git tags. The current approach using `importlib.metadata.version()` only works when the package is already installed.

## Solution

Use `setuptools_scm.get_version()` to directly read version from git tags:

```python
from setuptools_scm import get_version
release = get_version(root=str(parent_path), relative_to=__file__)
```

### Fallback chain

1. **setuptools_scm** - reads version from git tags (primary)
2. **importlib.metadata** - works when package is installed
3. **_version.py** - setuptools_scm generated file

### Changes

| File | Modification |
|------|--------------|
| `docs/conf.py` | Use `setuptools_scm.get_version()` |
| `docs/requirements.txt` | Add `setuptools_scm` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)