### PR TITLE
docs: distinguish stable and latest documentation versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
       - 'docs/**'
       - 'qpandalite/**'
       - '.github/workflows/docs.yml'
+    tags:
+      - 'v*'
   pull_request:
     branches: [main]
     paths:
@@ -17,12 +19,15 @@ on:
 
 jobs:
   build-docs:
-    name: Build Documentation
+    name: Build Documentation (${{ github.ref_type == 'tag' && 'stable' || 'latest' }})
     runs-on: ubuntu-latest
+    env:
+      DOCS_STABLE_VERSION: ${{ github.ref_type == 'tag' && '1' || '0' }}
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: true
+          fetch-depth: 0  # Need full history for setuptools_scm
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -37,7 +42,6 @@ jobs:
 
       - name: Install package (no C++ extension)
         run: |
-          # --no-cpp flag is handled by setup.py
           python setup.py develop --no-cpp
 
       - name: Build docs
@@ -48,5 +52,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: docs-html
+          name: docs-${{ github.ref_type == 'tag' && 'stable' || 'latest' }}
           path: docs/_build/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,31 +2,26 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
+    python: "3.12"
+  jobs:
+    pre_install:
+      # Install without C++ extension (not needed for docs)
+      - python setup.py develop --no-cpp
 
-# Build documentation in the "docs/" directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF and ePub
-# formats:
-#    - pdf
-#    - epub
-
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-   install:
-   - requirements: docs/requirements.txt
+  install:
+    - requirements: docs/requirements.txt
+
+# RTD automatically creates:
+# - "stable" version from the latest tag (shows clean version like 0.3.0)
+# - "latest" version from the default branch (shows dev version like 0.4.0.dev1)
+# - Individual versions for each tag (v0.3.0, v0.2.6, etc.)
+# Users can switch between versions via the version selector in the UI

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,0 +1,18 @@
+[
+    {
+        "name": "stable",
+        "version": "stable",
+        "url": "https://qpandalite.readthedocs.io/zh-cn/stable/",
+        "preferred": true
+    },
+    {
+        "name": "latest (dev)",
+        "version": "latest",
+        "url": "https://qpandalite.readthedocs.io/zh-cn/latest/"
+    },
+    {
+        "name": "v0.3.0",
+        "version": "0.3.0",
+        "url": "https://qpandalite.readthedocs.io/zh-cn/v0.3.0/"
+    }
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,26 +18,96 @@ parent_path = pathlib.Path(__file__).resolve().parent.parent
 # Only the project root is needed; qpandalite/ lives directly under it.
 sys.path.insert(0, os.path.abspath(parent_path))
 
-# Read version from setuptools_scm (git tags) or fallback
-try:
-    from setuptools_scm import get_version
-    release = get_version(root=str(parent_path), relative_to=__file__)
-except Exception:
-    # Fallback: try importlib.metadata (works when package is installed)
+# Read version from setuptools_scm or git tags
+# For stable releases: set DOCS_STABLE_VERSION env var to force clean version
+
+import subprocess
+import os
+
+def get_version_from_setuptools_scm(strip_dev=False):
+    """Get version from setuptools_scm.
+
+    Args:
+        strip_dev: If True, strip .devN+g... suffix to get base version.
+                   Used for stable/release builds.
+    """
+    try:
+        from setuptools_scm import get_version
+        version = get_version(root=str(parent_path), relative_to=__file__)
+        if strip_dev:
+            # Extract base version (strip .devN+g... suffix)
+            import re
+            match = re.match(r'^(\d+\.\d+\.\d+)', version)
+            return match.group(1) if match else version
+        return version
+    except Exception:
+        return None
+
+def get_version_from_git_tag():
+    """Get clean version from nearest git tag (e.g., v0.3.0 -> 0.3.0)."""
+    try:
+        result = subprocess.run(
+            ['git', 'describe', '--tags', '--abbrev=0'],
+            capture_output=True, text=True, check=True,
+            cwd=str(parent_path)
+        )
+        tag = result.stdout.strip()
+        return tag[1:] if tag.startswith('v') else tag
+    except Exception:
+        return None
+
+def get_version_from_metadata():
+    """Get version from installed package metadata."""
     try:
         from importlib.metadata import version as get_version, PackageNotFoundError
-        release = get_version('qpandalite')
+        return get_version('qpandalite')
     except (PackageNotFoundError, Exception):
-        # Fallback: try to read from _version.py (setuptools_scm generated)
-        try:
-            _version_file = parent_path / 'qpandalite' / '_version.py'
-            if _version_file.exists():
-                exec(_version_file.read_text())
-                release = __version__
-            else:
-                release = '0.0.0+unknown'
-        except Exception:
-            release = '0.0.0+unknown'
+        return None
+
+def get_version_from_file():
+    """Get version from _version.py file."""
+    try:
+        _version_file = parent_path / 'qpandalite' / '_version.py'
+        if _version_file.exists():
+            exec(_version_file.read_text())
+            return __version__
+    except Exception:
+        pass
+    return None
+
+# If DOCS_STABLE_VERSION=1, use clean version from git tag (for releases)
+# Otherwise, use setuptools_scm which shows dev versions for main branch
+# RTD sets READTHEDOCS_VERSION env var: 'stable', 'latest', or tag name
+
+# Determine if this is a stable/release build
+is_stable = (
+    os.environ.get('DOCS_STABLE_VERSION') == '1' or
+    os.environ.get('READTHEDOCS_VERSION') == 'stable' or
+    (os.environ.get('READTHEDOCS_VERSION', '').startswith('v') and
+     os.environ.get('READTHEDOCS') == 'True')
+)
+
+if is_stable:
+    release = (
+        get_version_from_git_tag() or
+        get_version_from_setuptools_scm(strip_dev=True) or
+        get_version_from_metadata() or
+        get_version_from_file() or
+        '0.0.0+unknown'
+    )
+else:
+    # Default: show actual version (including dev versions for unreleased changes)
+    release = (
+        get_version_from_setuptools_scm(strip_dev=False) or
+        get_version_from_git_tag() or
+        get_version_from_metadata() or
+        get_version_from_file() or
+        '0.0.0+unknown'
+    )
+
+# Get RTD version for version switcher
+rtd_version = os.environ.get('READTHEDOCS_VERSION', 'latest')
+version_match = rtd_version if rtd_version in ('stable', 'latest') else release
 
 copyright = '2025, Agony5757'
 author = ', '.join(['Agony5757', 'YunJ1e', 'automatic-code-ztr', 'didaozi'])
@@ -125,6 +195,13 @@ html_theme_options = {
     "navigation_with_keys": True,
     "show_toc_level": 2,
     "header_links_before_dropdown": 6,
+    # Version switcher configuration for RTD
+    "switcher": {
+        "json_url": "https://qpandalite.readthedocs.io/zh-cn/latest/_static/switcher.json",
+        "version_match": version_match,
+    },
+    # Add version switcher to navbar
+    "navbar_end": ["theme-switcher", "version-switcher"],
 }
 
 suppress_warnings = ["myst.xref_missing"]


### PR DESCRIPTION
## Summary

区分 stable 和 latest 文档版本，遵循版本管理最佳实践。

## 问题

当前 setuptools_scm 在 main 分支显示 dev 版本号（如 `0.4.0.dev1+ge508e86`），但这其实是正确的行为。问题在于需要在 release 时显示 clean version。

## 解决方案

| 构建来源 | 版本类型 | 版本号示例 |
|---------|---------|-----------|
| main 分支 | latest (dev) | `0.4.0.dev1+ge508e86` |
| tag (v0.3.0) | stable | `0.3.0` |

### 实现方式

**docs/conf.py**：
- `DOCS_STABLE_VERSION=1`：从 git tag 获取 clean version
- `DOCS_STABLE_VERSION=0`：使用 setuptools_scm 默认行为（显示 dev 版本）

**docs.yml**：
- main 分支 push → `docs-latest` artifact
- tag push → `docs-stable` artifact
- `fetch-depth: 0` 确保 setuptools_scm 能访问完整 git 历史

🤖 Generated with [Claude Code](https://claude.com/claude-code)