### PR TITLE
docs: show only project name in sidebar title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,6 +195,10 @@ html_theme_options = {
     "navigation_with_keys": True,
     "show_toc_level": 2,
     "header_links_before_dropdown": 6,
+    # Logo/title configuration - only show project name without version
+    "logo": {
+        "text": "QPanda-lite",
+    },
     # Version switcher configuration for RTD
     "switcher": {
         "json_url": "https://qpanda-lite.readthedocs.io/zh-cn/latest/_static/switcher.json",


### PR DESCRIPTION
## 问题

左侧标题栏显示版本号太长：`QPanda-lite 0.3.1.dev8+geecbf17b7`

## 解决方案

在 `html_theme_options` 中配置 `logo.text`，只显示项目名：

```python
"logo": {
    "text": "QPanda-lite",
},
```

## 效果

| 修改前 | 修改后 |
|--------|--------|
| QPanda-lite 0.3.1.dev8+geecbf17b7 | QPanda-lite |

版本信息仍然可以通过版本切换器查看。

🤖 Generated with [Claude Code](https://claude.com/claude-code)