### PR TITLE
feat: 统一量子云平台接入层 (OriginQ/Quafu/IBM)

### DIFF
--- a/examples/config_example.py
+++ b/examples/config_example.py
@@ -1,0 +1,185 @@
+"""Example: Using QPanda-lite configuration management system.
+
+This example demonstrates how to use the new config module to manage
+quantum cloud platform configurations.
+"""
+
+from qpandalite.config import (
+    load_config,
+    save_config,
+    get_platform_config,
+    validate_config,
+    update_platform_config,
+    create_default_config,
+    get_originq_config,
+    get_quafu_config,
+    get_ibm_config,
+    DEFAULT_CONFIG,
+)
+
+
+def example_1_create_default_config():
+    """Example 1: Create default configuration file."""
+    print("=" * 60)
+    print("Example 1: Create default configuration")
+    print("=" * 60)
+    
+    # Create default config at ~/.qpandalite/qpandalite.yml
+    create_default_config()
+    print("✓ Default configuration created at ~/.qpandalite/qpandalite.yml")
+    print()
+
+
+def example_2_load_and_modify():
+    """Example 2: Load, modify and save configuration."""
+    print("=" * 60)
+    print("Example 2: Load, modify and save configuration")
+    print("=" * 60)
+    
+    # Load current configuration
+    config = load_config()
+    print("Current config:")
+    print(f"  Profiles: {list(config.keys())}")
+    
+    # Modify configuration
+    config["default"]["originq"]["token"] = "your_originq_token_here"
+    config["default"]["originq"]["submit_url"] = "https://api.originq.com/submit"
+    config["default"]["originq"]["query_url"] = "https://api.originq.com/query"
+    
+    config["default"]["quafu"]["token"] = "your_quafu_token_here"
+    
+    config["default"]["ibm"]["token"] = "your_ibm_token_here"
+    config["default"]["ibm"]["proxy"] = {
+        "http": "http://proxy.example.com:8080",
+        "https": "https://proxy.example.com:8080",
+    }
+    
+    # Save configuration
+    save_config(config)
+    print("✓ Configuration updated and saved")
+    print()
+
+
+def example_3_get_platform_config():
+    """Example 3: Get platform-specific configuration."""
+    print("=" * 60)
+    print("Example 3: Get platform configuration")
+    print("=" * 60)
+    
+    # Get OriginQ configuration
+    originq = get_platform_config("originq")
+    print(f"OriginQ token: {originq.get('token', 'Not set')}")
+    
+    # Get Quafu configuration
+    quafu = get_platform_config("quafu")
+    print(f"Quafu token: {quafu.get('token', 'Not set')}")
+    
+    # Get IBM configuration
+    ibm = get_platform_config("ibm")
+    print(f"IBM token: {ibm.get('token', 'Not set')}")
+    if ibm.get("proxy", {}).get("http"):
+        print(f"IBM proxy: {ibm['proxy']['http']}")
+    print()
+
+
+def example_4_convenience_functions():
+    """Example 4: Use convenience functions."""
+    print("=" * 60)
+    print("Example 4: Convenience functions")
+    print("=" * 60)
+    
+    # These are shorthand for get_platform_config()
+    originq = get_originq_config()
+    quafu = get_quafu_config()
+    ibm = get_ibm_config()
+    
+    print(f"OriginQ: {originq.get('token', 'Not set')}")
+    print(f"Quafu: {quafu.get('token', 'Not set')}")
+    print(f"IBM: {ibm.get('token', 'Not set')}")
+    print()
+
+
+def example_5_multiple_profiles():
+    """Example 5: Work with multiple profiles."""
+    print("=" * 60)
+    print("Example 5: Multiple profiles")
+    print("=" * 60)
+    
+    # Add a 'prod' profile
+    update_platform_config("originq", {
+        "token": "prod_originq_token",
+        "submit_url": "https://prod.originq.com/submit",
+        "query_url": "https://prod.originq.com/query",
+    }, profile="prod")
+    
+    update_platform_config("quafu", {
+        "token": "prod_quafu_token",
+    }, profile="prod")
+    
+    # Get configuration from different profiles
+    default_originq = get_platform_config("originq", profile="default")
+    prod_originq = get_platform_config("originq", profile="prod")
+    
+    print(f"Default OriginQ token: {default_originq['token']}")
+    print(f"Prod OriginQ token: {prod_originq['token']}")
+    print()
+
+
+def example_6_validate_config():
+    """Example 6: Validate configuration."""
+    print("=" * 60)
+    print("Example 6: Validate configuration")
+    print("=" * 60)
+    
+    # Validate current configuration
+    errors = validate_config()
+    
+    if errors:
+        print("Configuration errors found:")
+        for error in errors:
+            print(f"  - {error}")
+    else:
+        print("✓ Configuration is valid")
+    print()
+
+
+def example_7_environment_variable():
+    """Example 7: Use environment variable for active profile."""
+    print("=" * 60)
+    print("Example 7: Environment variable QPANDALITE_PROFILE")
+    print("=" * 60)
+    
+    print("Set QPANDALITE_PROFILE environment variable to switch profiles:")
+    print("  export QPANDALITE_PROFILE=prod")
+    print("  python your_script.py")
+    print()
+    print("Or in Python:")
+    print("  import os")
+    print("  os.environ['QPANDALITE_PROFILE'] = 'prod'")
+    print()
+
+
+def main():
+    """Run all examples."""
+    print("\n" + "=" * 60)
+    print("QPanda-lite Configuration Management Examples")
+    print("=" * 60 + "\n")
+    
+    # Note: These examples create/modify ~/.qpandalite/qpandalite.yml
+    # Uncomment the ones you want to run
+    
+    # example_1_create_default_config()
+    # example_2_load_and_modify()
+    # example_3_get_platform_config()
+    # example_4_convenience_functions()
+    # example_5_multiple_profiles()
+    # example_6_validate_config()
+    example_7_environment_variable()
+    
+    print("=" * 60)
+    print("Examples completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "qutip",
     "qutip-qip",
     "pyqpanda3",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]

--- a/qpandalite/__init__.py
+++ b/qpandalite/__init__.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from . import config
 from .circuit_builder import Circuit
 from .originir import OriginIR_BaseParser
 from .qasm import OpenQASM2_BaseParser
@@ -22,5 +23,50 @@ from .qcloud_config.ibm_online_config import create_ibm_online_config
 from .qcloud_config.originq_cloud_config import create_originq_cloud_config
 from .transpiler import plot_time_line
 from .task.task_utils import (get_last_taskid, load_circuit, load_circuit_group, load_all_online_info)
+
+from .circuit_adapter import (
+    CircuitAdapter,
+    OriginQCircuitAdapter,
+    QuafuCircuitAdapter,
+    IBMCircuitAdapter,
+)
+
+from .exceptions import (
+    QPandaLiteError,
+    AuthenticationError,
+    InsufficientCreditsError,
+    QuotaExceededError,
+    NetworkError,
+    TaskFailedError,
+    TaskTimeoutError,
+    TaskNotFoundError,
+    BackendError,
+    BackendNotAvailableError,
+    BackendNotFoundError,
+    CircuitError,
+    CircuitTranslationError,
+    UnsupportedGateError,
+)
+
+from .task_manager import (
+    submit_task,
+    submit_batch,
+    query_task,
+    wait_for_result,
+    save_task,
+    get_task,
+    list_tasks,
+    clear_completed_tasks,
+    clear_cache,
+    TaskInfo,
+    TaskManager,
+)
+
+from .network_utils import (
+    check_proxy_connectivity,
+    detect_system_proxy,
+    test_ibm_connectivity,
+    get_ibm_proxy_from_config,
+)
 
 from .version import __version__

--- a/qpandalite/backend.py
+++ b/qpandalite/backend.py
@@ -1,0 +1,744 @@
+"""Unified backend management for quantum computing platforms.
+
+This module provides a centralized Backend management system with:
+- Abstract base class QuantumBackend defining a unified interface
+- Factory pattern for backend instance creation/retrieval
+- Caching mechanism for backend instances
+- Integration with existing adapters (OriginQ, Quafu, IBM)
+
+Usage:
+    # Get or create a backend instance
+    backend = get_backend('originq')
+    
+    # List all available backends
+    available = list_backends()
+    
+    # Submit a circuit
+    task_id = backend.submit(circuit, shots=1000)
+    
+    # Query task status
+    result = backend.query(task_id)
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "QuantumBackend",
+    "OriginQBackend",
+    "QuafuBackend",
+    "IBMBackend",
+    "get_backend",
+    "list_backends",
+    "BACKENDS",
+]
+
+import abc
+import json
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Type
+
+if TYPE_CHECKING:
+    from qpandalite.circuit_builder.qcircuit import Circuit
+
+from qpandalite.task.adapters import (
+    OriginQAdapter,
+    QuafuAdapter,
+    QiskitAdapter,
+    QuantumAdapter,
+    TASK_STATUS_FAILED,
+    TASK_STATUS_RUNNING,
+    TASK_STATUS_SUCCESS,
+)
+
+# -----------------------------------------------------------------------------
+# Cache Configuration
+# -----------------------------------------------------------------------------
+
+DEFAULT_CACHE_DIR = Path.home() / ".qpandalite" / "cache"
+CACHE_FILE_SUFFIX = "_backend.json"
+
+
+def _get_cache_file_path(platform: str, cache_dir: Path | None = None) -> Path:
+    """Get the cache file path for a specific platform.
+    
+    Args:
+        platform: The backend platform identifier.
+        cache_dir: Optional custom cache directory. Uses default if None.
+        
+    Returns:
+        Path to the cache file.
+    """
+    cache_path = cache_dir or DEFAULT_CACHE_DIR
+    cache_path.mkdir(parents=True, exist_ok=True)
+    return cache_path / f"{platform}{CACHE_FILE_SUFFIX}"
+
+
+# -----------------------------------------------------------------------------
+# Abstract Base Backend
+# -----------------------------------------------------------------------------
+
+class QuantumBackend(abc.ABC):
+    """Abstract base class for quantum backend management.
+    
+    This class provides a unified interface for all quantum computing backends,
+    wrapping the underlying adapters and providing caching capabilities.
+    
+    Attributes:
+        name: The name of this backend instance.
+        platform: The platform identifier (e.g., 'originq', 'quafu', 'ibm').
+        adapter: The underlying quantum adapter instance.
+        config: Backend-specific configuration dictionary.
+    """
+    
+    # Class-level registry of backend instances
+    _instances: ClassVar[dict[str, "QuantumBackend"]] = {}
+    
+    # Platform identifier (must be set by subclasses)
+    platform: ClassVar[str] = ""
+    
+    # Adapter class (must be set by subclasses)
+    _adapter_class: ClassVar[Type[QuantumAdapter]] = QuantumAdapter
+    
+    def __init__(
+        self,
+        name: str | None = None,
+        config: dict[str, Any] | None = None,
+        cache_dir: Path | str | None = None,
+    ) -> None:
+        """Initialize the backend.
+        
+        Args:
+            name: Optional name for this backend instance. Uses platform name if None.
+            config: Optional configuration dictionary.
+            cache_dir: Optional custom cache directory path.
+        """
+        self.name = name or self.platform
+        self.config = config or {}
+        self._cache_dir = Path(cache_dir) if cache_dir else DEFAULT_CACHE_DIR
+        self._adapter: QuantumAdapter | None = None
+        
+    @property
+    def adapter(self) -> QuantumAdapter:
+        """Get or create the underlying adapter instance.
+        
+        Returns:
+            The quantum adapter for this backend.
+            
+        Raises:
+            RuntimeError: If the adapter cannot be initialized.
+        """
+        if self._adapter is None:
+            self._adapter = self._create_adapter()
+        return self._adapter
+    
+    @abc.abstractmethod
+    def _create_adapter(self) -> QuantumAdapter:
+        """Create and return the platform-specific adapter.
+        
+        Returns:
+            A new adapter instance for this backend.
+        """
+        ...
+    
+    # -------------------------------------------------------------------------
+    # Circuit Adapter
+    # -------------------------------------------------------------------------
+    
+    def get_circuit_adapter(self) -> QuantumAdapter:
+        """Get the circuit adapter for translating circuits.
+        
+        Returns:
+            The quantum adapter that handles circuit translation.
+        """
+        return self.adapter
+    
+    def translate_circuit(self, originir: str) -> Any:
+        """Translate an OriginIR circuit to the platform's native format.
+        
+        Args:
+            originir: Circuit in OriginIR format.
+            
+        Returns:
+            Provider-specific circuit object.
+        """
+        return self.adapter.translate_circuit(originir)
+    
+    # -------------------------------------------------------------------------
+    # Task Submission
+    # -------------------------------------------------------------------------
+    
+    def submit(self, circuit: Any, *, shots: int = 1000, **kwargs: Any) -> str:
+        """Submit a circuit to the backend.
+        
+        Args:
+            circuit: Provider-native circuit object or OriginIR string.
+            shots: Number of measurement shots.
+            **kwargs: Additional provider-specific parameters.
+            
+        Returns:
+            Task ID assigned by the backend.
+        """
+        return self.adapter.submit(circuit, shots=shots, **kwargs)
+    
+    def submit_batch(
+        self, circuits: list[Any], *, shots: int = 1000, **kwargs: Any
+    ) -> str | list[str]:
+        """Submit multiple circuits as a batch.
+        
+        Args:
+            circuits: List of provider-native circuit objects or OriginIR strings.
+            shots: Number of measurement shots.
+            **kwargs: Additional provider-specific parameters.
+            
+        Returns:
+            Task ID(s) assigned by the backend.
+        """
+        return self.adapter.submit_batch(circuits, shots=shots, **kwargs)
+    
+    # -------------------------------------------------------------------------
+    # Task Query
+    # -------------------------------------------------------------------------
+    
+    def query(self, task_id: str) -> dict[str, Any]:
+        """Query a task's status and result.
+        
+        Args:
+            task_id: Task identifier.
+            
+        Returns:
+            Dict with keys:
+                - 'status': 'success' | 'failed' | 'running'
+                - 'result': Execution result (when status is 'success' or 'failed')
+        """
+        return self.adapter.query(task_id)
+    
+    def query_batch(self, task_ids: list[str]) -> dict[str, Any]:
+        """Query multiple tasks' status and merge results.
+        
+        Args:
+            task_ids: List of task identifiers.
+            
+        Returns:
+            Dict with keys: 'status', 'result' (list of results).
+        """
+        return self.adapter.query_batch(task_ids)
+    
+    # -------------------------------------------------------------------------
+    # Availability
+    # -------------------------------------------------------------------------
+    
+    def is_available(self) -> bool:
+        """Check if this backend is available.
+        
+        Returns:
+            True if the backend is properly configured and ready to use.
+        """
+        try:
+            return self.adapter.is_available()
+        except Exception:
+            return False
+    
+    # -------------------------------------------------------------------------
+    # Cache Management
+    # -------------------------------------------------------------------------
+    
+    def save_to_cache(self) -> None:
+        """Save this backend instance configuration to cache."""
+        cache_file = _get_cache_file_path(self.platform, self._cache_dir)
+        cache_data = {
+            "name": self.name,
+            "platform": self.platform,
+            "config": self.config,
+        }
+        try:
+            with open(cache_file, "w", encoding="utf-8") as f:
+                json.dump(cache_data, f, indent=2, ensure_ascii=False)
+        except (IOError, OSError) as e:
+            # Cache saving is non-critical, log but don't fail
+            import warnings
+            warnings.warn(f"Failed to save backend cache: {e}")
+    
+    @classmethod
+    def load_from_cache(
+        cls,
+        cache_dir: Path | str | None = None,
+    ) -> "QuantumBackend" | None:
+        """Load a backend instance from cache.
+        
+        Args:
+            cache_dir: Optional custom cache directory path.
+            
+        Returns:
+            Loaded backend instance or None if cache doesn't exist or is invalid.
+        """
+        cache_path = Path(cache_dir) if cache_dir else DEFAULT_CACHE_DIR
+        cache_file = _get_cache_file_path(cls.platform, cache_path)
+        
+        if not cache_file.exists():
+            return None
+        
+        try:
+            with open(cache_file, "r", encoding="utf-8") as f:
+                cache_data = json.load(f)
+            
+            # Verify platform matches
+            if cache_data.get("platform") != cls.platform:
+                return None
+            
+            instance = cls(
+                name=cache_data.get("name"),
+                config=cache_data.get("config", {}),
+                cache_dir=cache_path,
+            )
+            return instance
+        except (IOError, OSError, json.JSONDecodeError, KeyError):
+            return None
+    
+    def clear_cache(self) -> None:
+        """Clear the cache for this backend instance."""
+        cache_file = _get_cache_file_path(self.platform, self._cache_dir)
+        if cache_file.exists():
+            try:
+                cache_file.unlink()
+            except (IOError, OSError):
+                pass
+    
+    # -------------------------------------------------------------------------
+    # Class Methods for Instance Management
+    # -------------------------------------------------------------------------
+    
+    @classmethod
+    def get_instance(
+        cls,
+        name: str | None = None,
+        config: dict[str, Any] | None = None,
+        use_cache: bool = True,
+        cache_dir: Path | str | None = None,
+    ) -> "QuantumBackend":
+        """Get or create a backend instance (factory method).
+        
+        Args:
+            name: Optional name for the instance.
+            config: Optional configuration dictionary.
+            use_cache: Whether to use/load cache. Defaults to True.
+            cache_dir: Optional custom cache directory.
+            
+        Returns:
+            A backend instance.
+        """
+        cache_key = f"{cls.platform}:{name or 'default'}"
+        
+        # Check in-memory cache first
+        if cache_key in cls._instances:
+            return cls._instances[cache_key]
+        
+        # Try loading from disk cache if enabled
+        if use_cache and config is None:
+            cached = cls.load_from_cache(cache_dir)
+            if cached is not None:
+                cls._instances[cache_key] = cached
+                return cached
+        
+        # Create new instance
+        instance = cls(name=name, config=config, cache_dir=cache_dir)
+        
+        # Save to cache if enabled
+        if use_cache:
+            instance.save_to_cache()
+        
+        cls._instances[cache_key] = instance
+        return instance
+    
+    @classmethod
+    def list_available(cls) -> bool:
+        """Check if this backend type is available.
+        
+        Returns:
+            True if the backend can be instantiated and is configured.
+        """
+        try:
+            instance = cls.get_instance(use_cache=False)
+            return instance.is_available()
+        except Exception:
+            return False
+
+
+# -----------------------------------------------------------------------------
+# Concrete Backend Implementations
+# -----------------------------------------------------------------------------
+
+class OriginQBackend(QuantumBackend):
+    """Backend for OriginQ Cloud (本源量子云).
+    
+    This backend connects to the OriginQ Cloud service for executing
+    quantum circuits on OriginQ quantum computers and simulators.
+    """
+    
+    platform = "originq"
+    _adapter_class = OriginQAdapter
+    
+    def _create_adapter(self) -> OriginQAdapter:
+        """Create an OriginQ adapter.
+        
+        Returns:
+            A configured OriginQAdapter instance.
+        """
+        return OriginQAdapter()
+
+
+class QuafuBackend(QuantumBackend):
+    """Backend for BAQIS Quafu (ScQ) quantum cloud platform.
+    
+    This backend connects to the Quafu service for executing quantum
+    circuits on superconducting quantum computers.
+    """
+    
+    platform = "quafu"
+    _adapter_class = QuafuAdapter
+    
+    # Valid chip IDs for Quafu
+    VALID_CHIP_IDS = frozenset(
+        {"ScQ-P10", "ScQ-P18", "ScQ-P136", "ScQ-P10C", "Dongling"}
+    )
+    
+    def _create_adapter(self) -> QuafuAdapter:
+        """Create a Quafu adapter.
+        
+        Returns:
+            A configured QuafuAdapter instance.
+        """
+        return QuafuAdapter()
+    
+    def validate_chip_id(self, chip_id: str) -> bool:
+        """Validate if the chip ID is valid for Quafu.
+        
+        Args:
+            chip_id: The chip identifier to validate.
+            
+        Returns:
+            True if the chip ID is valid.
+        """
+        return chip_id in self.VALID_CHIP_IDS
+
+
+class IBMBackend(QuantumBackend):
+    """Backend for IBM Quantum via Qiskit.
+
+    This backend connects to IBM Quantum services for executing quantum
+    circuits on IBM quantum computers and simulators.
+
+    Proxy Configuration:
+        Proxies can be configured in multiple ways (in priority order):
+        1. Explicit config dict passed to constructor
+        2. Environment variables (HTTP_PROXY, HTTPS_PROXY)
+        3. qpandalite.yml configuration file
+
+    Example:
+        >>> # Using config file
+        >>> backend = get_backend('ibm')
+        >>> # Check proxy availability
+        >>> backend.check_proxy()
+        True
+        >>> # Test IBM connectivity
+        >>> result = backend.test_connectivity()
+        >>> print(result['success'])
+        True
+    """
+
+    platform = "ibm"
+    _adapter_class = QiskitAdapter
+
+    def __init__(
+        self,
+        name: str | None = None,
+        config: dict[str, Any] | None = None,
+        cache_dir: Path | str | None = None,
+    ) -> None:
+        """Initialize the IBM backend.
+
+        Args:
+            name: Optional name for this backend instance.
+            config: Optional configuration dictionary. Can include:
+                - token: IBM Quantum API token
+                - proxy: Dict with 'http' and/or 'https' keys
+            cache_dir: Optional custom cache directory path.
+        """
+        super().__init__(name=name, config=config, cache_dir=cache_dir)
+        self._proxy_config: dict[str, str] | None = None
+        self._api_token: str | None = None
+        self._load_ibm_config()
+
+    def _load_ibm_config(self) -> None:
+        """Load IBM configuration including proxy settings.
+
+        Loads from (in priority order):
+        1. Explicit config dict passed to constructor
+        2. Environment variables (HTTP_PROXY, HTTPS_PROXY)
+        3. qpandalite.yml configuration file
+        """
+        from qpandalite.config import get_ibm_config
+        from qpandalite.network_utils import (
+            detect_system_proxy,
+            get_ibm_proxy_from_config,
+        )
+
+        # Start with config file settings
+        try:
+            file_config = get_ibm_config()
+            self._api_token = file_config.get("token")
+            self._proxy_config = get_ibm_proxy_from_config(file_config)
+        except Exception:
+            file_config = {}
+
+        # Override with explicit config if provided
+        if self.config:
+            if "token" in self.config:
+                self._api_token = self.config["token"]
+            if "proxy" in self.config:
+                proxy = self.config["proxy"]
+                if isinstance(proxy, dict):
+                    self._proxy_config = {
+                        k: v for k, v in proxy.items()
+                        if k in ("http", "https") and v
+                    }
+                elif isinstance(proxy, str):
+                    self._proxy_config = {"http": proxy, "https": proxy}
+
+        # Environment variables take highest priority
+        env_proxies = detect_system_proxy()
+        if env_proxies.get("http"):
+            if self._proxy_config is None:
+                self._proxy_config = {}
+            self._proxy_config["http"] = env_proxies["http"]
+        if env_proxies.get("https"):
+            if self._proxy_config is None:
+                self._proxy_config = {}
+            self._proxy_config["https"] = env_proxies["https"]
+
+    def _create_adapter(self) -> QiskitAdapter:
+        """Create an IBM Qiskit adapter.
+
+        Returns:
+            A configured QiskitAdapter instance.
+        """
+        # Pass proxy configuration to adapter if available
+        if self._proxy_config:
+            return QiskitAdapter(proxy=self._proxy_config)
+        return QiskitAdapter()
+
+    def check_proxy(self) -> bool:
+        """Check if the configured proxy is available.
+
+        Returns:
+            True if proxy is configured and reachable, False otherwise.
+
+        Note:
+            If no proxy is configured, returns True (direct connection).
+        """
+        from qpandalite.network_utils import check_proxy_connectivity
+
+        if not self._proxy_config:
+            return True  # No proxy configured, direct connection
+
+        # Check HTTPS proxy first (preferred for IBM Quantum)
+        https_proxy = self._proxy_config.get("https")
+        if https_proxy:
+            return check_proxy_connectivity(https_proxy)
+
+        # Fall back to HTTP proxy
+        http_proxy = self._proxy_config.get("http")
+        if http_proxy:
+            return check_proxy_connectivity(http_proxy)
+
+        return False
+
+    def test_connectivity(self) -> dict[str, Any]:
+        """Test connectivity to IBM Quantum services.
+
+        Returns:
+            dict with connectivity test results:
+            {
+                'success': bool,
+                'message': str,
+                'proxy_used': dict | None,
+                'response_time_ms': float | None,
+            }
+        """
+        from qpandalite.network_utils import test_ibm_connectivity
+
+        return test_ibm_connectivity(
+            token=self._api_token,
+            proxy=self._proxy_config,
+        )
+
+    def get_proxy_config(self) -> dict[str, str] | None:
+        """Get the current proxy configuration.
+
+        Returns:
+            Dict with 'http' and/or 'https' proxy URLs, or None if not configured.
+        """
+        return self._proxy_config.copy() if self._proxy_config else None
+
+
+# -----------------------------------------------------------------------------
+# Backend Registry
+# -----------------------------------------------------------------------------
+
+BACKENDS: dict[str, Type[QuantumBackend]] = {
+    "originq": OriginQBackend,
+    "quafu": QuafuBackend,
+    "ibm": IBMBackend,
+}
+
+
+# -----------------------------------------------------------------------------
+# Public API Functions
+# -----------------------------------------------------------------------------
+
+def get_backend(
+    name: str,
+    *,
+    config: dict[str, Any] | None = None,
+    use_cache: bool = True,
+    cache_dir: Path | str | None = None,
+) -> QuantumBackend:
+    """Get or create a backend instance by name.
+    
+    This is the main factory function for obtaining backend instances.
+    It uses the BACKENDS registry to look up the appropriate backend class
+    and returns a configured instance.
+    
+    Args:
+        name: The platform name ('originq', 'quafu', or 'ibm').
+        config: Optional configuration dictionary for the backend.
+        use_cache: Whether to use cache. Defaults to True.
+        cache_dir: Optional custom cache directory path.
+        
+    Returns:
+        A configured QuantumBackend instance.
+        
+    Raises:
+        ValueError: If the backend name is not recognized.
+        RuntimeError: If the backend cannot be initialized.
+        
+    Example:
+        >>> backend = get_backend('originq')
+        >>> task_id = backend.submit(circuit, shots=1000)
+    """
+    if name not in BACKENDS:
+        available = ", ".join(BACKENDS.keys())
+        raise ValueError(
+            f"Unknown backend '{name}'. Available backends: {available}"
+        )
+    
+    backend_class = BACKENDS[name]
+    return backend_class.get_instance(
+        name=None,
+        config=config,
+        use_cache=use_cache,
+        cache_dir=cache_dir,
+    )
+
+
+def list_backends() -> dict[str, dict[str, Any]]:
+    """List all available backends and their status.
+    
+    Returns:
+        A dictionary mapping backend names to their information:
+        {
+            'originq': {'available': True, 'platform': 'originq'},
+            'quafu': {'available': False, 'platform': 'quafu'},
+            ...
+        }
+        
+    Example:
+        >>> backends = list_backends()
+        >>> for name, info in backends.items():
+        ...     print(f"{name}: {'available' if info['available'] else 'unavailable'}")
+    """
+    result = {}
+    for name, backend_class in BACKENDS.items():
+        result[name] = {
+            "platform": name,
+            "available": backend_class.list_available(),
+            "class": backend_class.__name__,
+        }
+    return result
+
+
+def register_backend(
+    name: str,
+    backend_class: Type[QuantumBackend],
+    allow_override: bool = False,
+) -> None:
+    """Register a custom backend class.
+    
+    Args:
+        name: The platform name to register.
+        backend_class: The backend class to register.
+        allow_override: Whether to allow overriding existing registrations.
+        
+    Raises:
+        ValueError: If the name is already registered and override is False.
+        
+    Example:
+        >>> class MyBackend(QuantumBackend):
+        ...     platform = "my_platform"
+        ...     def _create_adapter(self):
+        ...         return MyAdapter()
+        ...
+        >>> register_backend("my_platform", MyBackend)
+    """
+    if name in BACKENDS and not allow_override:
+        raise ValueError(
+            f"Backend '{name}' is already registered. "
+            "Use allow_override=True to replace it."
+        )
+    
+    # Validate the backend class
+    if not issubclass(backend_class, QuantumBackend):
+        raise TypeError(
+            f"Backend class must be a subclass of QuantumBackend, "
+            f"got {type(backend_class)}"
+        )
+    
+    if not backend_class.platform:
+        raise ValueError(
+            f"Backend class {backend_class.__name__} must define a platform attribute"
+        )
+    
+    BACKENDS[name] = backend_class
+
+
+def unregister_backend(name: str) -> None:
+    """Unregister a backend.
+    
+    Args:
+        name: The platform name to unregister.
+        
+    Raises:
+        ValueError: If the backend is not registered.
+    """
+    if name not in BACKENDS:
+        raise ValueError(f"Backend '{name}' is not registered")
+    
+    del BACKENDS[name]
+
+
+def clear_backend_cache(cache_dir: Path | str | None = None) -> None:
+    """Clear all backend caches.
+    
+    Args:
+        cache_dir: Optional custom cache directory. Uses default if None.
+    """
+    cache_path = Path(cache_dir) if cache_dir else DEFAULT_CACHE_DIR
+    
+    if not cache_path.exists():
+        return
+    
+    for cache_file in cache_path.glob(f"*{CACHE_FILE_SUFFIX}"):
+        try:
+            cache_file.unlink()
+        except (IOError, OSError):
+            pass

--- a/qpandalite/backend.py
+++ b/qpandalite/backend.py
@@ -505,16 +505,16 @@ class IBMBackend(QuantumBackend):
                 elif isinstance(proxy, str):
                     self._proxy_config = {"http": proxy, "https": proxy}
 
-        # Environment variables take highest priority
+        # Environment variables take highest priority, but merge with existing config
         env_proxies = detect_system_proxy()
-        if env_proxies.get("http"):
+        if env_proxies.get("http") or env_proxies.get("https"):
             if self._proxy_config is None:
                 self._proxy_config = {}
-            self._proxy_config["http"] = env_proxies["http"]
-        if env_proxies.get("https"):
-            if self._proxy_config is None:
-                self._proxy_config = {}
-            self._proxy_config["https"] = env_proxies["https"]
+            # Merge: file config first, then override with env vars
+            if env_proxies.get("http"):
+                self._proxy_config["http"] = env_proxies["http"]
+            if env_proxies.get("https"):
+                self._proxy_config["https"] = env_proxies["https"]
 
     def _create_adapter(self) -> QiskitAdapter:
         """Create an IBM Qiskit adapter.

--- a/qpandalite/circuit_adapter.py
+++ b/qpandalite/circuit_adapter.py
@@ -201,6 +201,10 @@ class QuafuCircuitAdapter(CircuitAdapter[Any]):
         originir = self._get_originir(circuit)
         lines = originir.splitlines()
         qc: Any = None
+        
+        # Track control structure state
+        control_stack: list[list[int]] = []  # Stack of control qubit lists
+        dagger_count = 0  # Nested DAGGER counter (odd = dagger active)
 
         for line in lines:
             line = line.strip()
@@ -234,8 +238,38 @@ class QuafuCircuitAdapter(CircuitAdapter[Any]):
             if operation == "CREG":
                 continue
 
+            # Handle control structure markers
+            if operation == "CONTROL":
+                # Parse control qubits from the line
+                ctrl_qubits = qubit if isinstance(qubit, list) else [int(qubit)]
+                control_stack.append(ctrl_qubits)
+                continue
+            elif operation == "ENDCONTROL":
+                if control_stack:
+                    control_stack.pop()
+                continue
+            elif operation == "DAGGER":
+                dagger_count += 1
+                continue
+            elif operation == "ENDDAGGER":
+                dagger_count -= 1
+                continue
+
+            # Merge control qubits from stack
+            effective_control_qubits: list[int] = []
+            if control_qubits:
+                effective_control_qubits.extend(control_qubits)
+            for ctrl in control_stack:
+                effective_control_qubits.extend(ctrl)
+            
+            # Apply dagger from DAGGER block
+            effective_dagger = dagger_flag or (dagger_count % 2 == 1)
+
             # Apply gates
-            qc = self._apply_gate(qc, operation, qubit, cbit, parameter, dagger_flag, control_qubits)
+            qc = self._apply_gate(
+                qc, operation, qubit, cbit, parameter, 
+                effective_dagger, effective_control_qubits if effective_control_qubits else None
+            )
 
         if qc is None:
             raise RuntimeError("OriginIR string produced no circuit.")
@@ -269,46 +303,96 @@ class QuafuCircuitAdapter(CircuitAdapter[Any]):
         if operation is None:
             return qc
 
+        # Normalize control qubits
+        has_control = control_qubits is not None and len(control_qubits) > 0
+        ctrl_qubits = control_qubits if has_control else []
+
+        # Helper function to apply controlled gate
+        def apply_controlled(gate_fn, target_qubit, *args):
+            """Apply gate with control qubits if present."""
+            if has_control:
+                # For multi-controlled gates, use Quafu's mcx or controlled methods
+                if len(ctrl_qubits) == 1:
+                    # Single control: use cnot-like control
+                    qc.cnot(int(ctrl_qubits[0]), int(target_qubit))
+                    gate_fn(int(target_qubit), *args)
+                    qc.cnot(int(ctrl_qubits[0]), int(target_qubit))
+                else:
+                    # Multi-control: use mcx if available
+                    if hasattr(qc, 'mcx'):
+                        qc.mcx([int(c) for c in ctrl_qubits], int(target_qubit))
+                        gate_fn(int(target_qubit), *args)
+                        qc.mcx([int(c) for c in ctrl_qubits], int(target_qubit))
+                    else:
+                        raise NotImplementedError(
+                            f"Multi-controlled gates with {len(ctrl_qubits)} controls "
+                            "not supported by this Quafu version"
+                        )
+            else:
+                gate_fn(int(target_qubit), *args)
+
         # Single-qubit gates
         if operation == "H":
-            qc.h(int(qubit))
+            if has_control:
+                qc.ch(int(ctrl_qubits[0]), int(qubit)) if len(ctrl_qubits) == 1 else apply_controlled(qc.h, qubit)
+            else:
+                qc.h(int(qubit))
         elif operation == "X":
-            qc.x(int(qubit))
+            if has_control:
+                if len(ctrl_qubits) == 1:
+                    qc.cnot(int(ctrl_qubits[0]), int(qubit))
+                else:
+                    qc.mcx([int(c) for c in ctrl_qubits], int(qubit))
+            else:
+                qc.x(int(qubit))
         elif operation == "Y":
-            qc.y(int(qubit))
+            apply_controlled(qc.y, qubit)
         elif operation == "Z":
-            qc.z(int(qubit))
+            if has_control:
+                qc.cz(int(ctrl_qubits[0]), int(qubit)) if len(ctrl_qubits) == 1 else apply_controlled(qc.z, qubit)
+            else:
+                qc.z(int(qubit))
         elif operation == "S":
             if dagger_flag:
-                qc.sdg(int(qubit))
+                apply_controlled(qc.sdg, qubit)
             else:
-                qc.s(int(qubit))
+                apply_controlled(qc.s, qubit)
         elif operation == "T":
             if dagger_flag:
-                qc.tdg(int(qubit))
+                apply_controlled(qc.tdg, qubit)
             else:
-                qc.t(int(qubit))
+                apply_controlled(qc.t, qubit)
         elif operation == "SX":
             if dagger_flag:
-                qc.sxdg(int(qubit))
+                apply_controlled(qc.sxdg, qubit)
             else:
-                qc.sx(int(qubit))
+                apply_controlled(qc.sx, qubit)
 
         # Single-qubit rotation gates
         elif operation == "RX":
-            qc.rx(int(qubit), float(parameter))
+            apply_controlled(lambda q: qc.rx(q, float(parameter)), qubit)
         elif operation == "RY":
-            qc.ry(int(qubit), float(parameter))
+            apply_controlled(lambda q: qc.ry(q, float(parameter)), qubit)
         elif operation == "RZ":
-            qc.rz(int(qubit), float(parameter))
+            apply_controlled(lambda q: qc.rz(q, float(parameter)), qubit)
 
         # Two-qubit gates
         elif operation == "CNOT":
             qubits = qubit if isinstance(qubit, list) else [qubit]
-            qc.cnot(int(qubits[0]), int(qubits[1]))
+            if has_control:
+                # Add additional controls to existing CNOT
+                all_controls = list(ctrl_qubits) + [int(qubits[0])]
+                qc.mcx(all_controls, int(qubits[1]))
+            else:
+                qc.cnot(int(qubits[0]), int(qubits[1]))
         elif operation == "CZ":
             qubits = qubit if isinstance(qubit, list) else [qubit]
-            qc.cz(int(qubits[0]), int(qubits[1]))
+            if has_control:
+                qc.mcx([int(ctrl_qubits[0])], int(qubits[0]))
+                qc.cz(int(qubits[0]), int(qubits[1]))
+                qc.mcx([int(ctrl_qubits[0])], int(qubits[0]))
+            else:
+                qc.cz(int(qubits[0]), int(qubits[1]))
         elif operation == "SWAP":
             qubits = qubit if isinstance(qubit, list) else [qubit]
             qc.swap(int(qubits[0]), int(qubits[1]))

--- a/qpandalite/circuit_adapter.py
+++ b/qpandalite/circuit_adapter.py
@@ -1,0 +1,434 @@
+"""Circuit adapter layer for converting QPanda-lite circuits to provider-native formats.
+
+This module provides adapter classes for converting QPanda-lite Circuit objects
+to native circuit formats used by different quantum computing platforms:
+- OriginQ (pyqpanda)
+- Quafu (pyquafu)
+- IBM (qiskit)
+
+Usage:
+    from qpandalite.circuit_adapter import OriginQCircuitAdapter, QuafuCircuitAdapter, IBMCircuitAdapter
+    from qpandalite.circuit_builder import Circuit
+
+    # Create a QPanda-lite circuit
+    circuit = Circuit()
+    circuit.h(0)
+    circuit.cnot(0, 1)
+    circuit.measure(0, 1)
+
+    # Convert to provider-native circuits
+    originq_adapter = OriginQCircuitAdapter()
+    pyqpanda_circuit = originq_adapter.adapt(circuit)
+
+    quafu_adapter = QuafuCircuitAdapter()
+    quafu_circuit = quafu_adapter.adapt(circuit)
+
+    ibm_adapter = IBMCircuitAdapter()
+    qiskit_circuit = ibm_adapter.adapt(circuit)
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "CircuitAdapter",
+    "OriginQCircuitAdapter",
+    "QuafuCircuitAdapter",
+    "IBMCircuitAdapter",
+]
+
+import abc
+from typing import TYPE_CHECKING, Any, List, TypeVar, Generic, Optional
+
+if TYPE_CHECKING:
+    from qpandalite.circuit_builder.qcircuit import Circuit
+
+# Type variable for provider-native circuit types
+T = TypeVar("T")
+
+
+class CircuitAdapter(abc.ABC, Generic[T]):
+    """Abstract base class for circuit adapters.
+
+    Provides a unified interface for converting QPanda-lite Circuit objects
+to provider-native circuit formats.
+    """
+
+    @abc.abstractmethod
+    def adapt(self, circuit: "Circuit") -> T:
+        """Convert a QPanda-lite Circuit to the provider's native circuit format.
+
+        Args:
+            circuit: QPanda-lite Circuit object.
+
+        Returns:
+            Provider-native circuit object.
+        """
+        ...
+
+    def adapt_batch(self, circuits: List["Circuit"]) -> List[T]:
+        """Convert multiple QPanda-lite Circuits to provider-native format.
+
+        Args:
+            circuits: List of QPanda-lite Circuit objects.
+
+        Returns:
+            List of provider-native circuit objects.
+        """
+        return [self.adapt(c) for c in circuits]
+
+    @abc.abstractmethod
+    def get_supported_gates(self) -> List[str]:
+        """Return the list of gate names supported by this adapter.
+
+        Returns:
+            List of supported gate names (uppercase strings).
+        """
+        ...
+
+    def _get_originir(self, circuit: "Circuit") -> str:
+        """Extract OriginIR string from a QPanda-lite Circuit.
+
+        Args:
+            circuit: QPanda-lite Circuit object.
+
+        Returns:
+            OriginIR string representation of the circuit.
+        """
+        return circuit.originir
+
+
+class OriginQCircuitAdapter(CircuitAdapter[Any]):
+    """Adapter for converting QPanda-lite Circuit to pyqpanda (OriginQ) format.
+
+    Uses pyqpanda3's intermediate compiler to convert OriginIR to QProg.
+    """
+
+    # Gate mapping from OriginIR names to pyqpanda supported gates
+    SUPPORTED_GATES = [
+        "H", "X", "Y", "Z", "S", "T", "SX",
+        "RX", "RY", "RZ", "RPhi", "RPhi90", "RPhi180",
+        "U1", "U2", "U3", "U4",
+        "CNOT", "CZ", "SWAP", "ISWAP",
+        "TOFFOLI", "CSWAP",
+        "XX", "YY", "ZZ", "XY",
+        "PHASE2Q", "UU15",
+        "I", "BARRIER", "MEASURE",
+    ]
+
+    def __init__(self) -> None:
+        self._pyqpanda3: Any = None
+        self._convert_originir: Any = None
+
+    def _ensure_imports(self) -> None:
+        """Lazily import pyqpanda3 modules."""
+        if self._pyqpanda3 is None:
+            try:
+                from pyqpanda3 import core as pyqpanda3_core
+                from pyqpanda3.intermediate_compiler import (
+                    convert_originir_string_to_qprog,
+                )
+                self._pyqpanda3 = pyqpanda3_core
+                self._convert_originir = convert_originir_string_to_qprog
+            except ImportError as e:
+                raise RuntimeError(
+                    "pyqpanda3 is required for OriginQCircuitAdapter. "
+                    "Install it with: pip install pyqpanda3"
+                ) from e
+
+    def adapt(self, circuit: "Circuit") -> Any:
+        """Convert QPanda-lite Circuit to pyqpanda QProg.
+
+        Args:
+            circuit: QPanda-lite Circuit object.
+
+        Returns:
+            pyqpanda3.core.QProg object.
+        """
+        self._ensure_imports()
+        originir = self._get_originir(circuit)
+        return self._convert_originir(originir)
+
+    def get_supported_gates(self) -> List[str]:
+        """Return the list of gate names supported by this adapter."""
+        return self.SUPPORTED_GATES.copy()
+
+
+class QuafuCircuitAdapter(CircuitAdapter[Any]):
+    """Adapter for converting QPanda-lite Circuit to pyquafu (Quafu) format.
+
+    Translates OriginIR gate by gate to quafu.QuantumCircuit.
+    """
+
+    # Gate mapping from OriginIR to Quafu
+    SUPPORTED_GATES = [
+        "H", "X", "Y", "Z",
+        "RX", "RY", "RZ",
+        "CNOT", "CZ",
+        "MEASURE",
+        # Note: Quafu supports more gates, these are the most common ones
+    ]
+
+    def __init__(self) -> None:
+        self._quafu: Any = None
+        self._QuantumCircuit: Any = None
+
+    def _ensure_imports(self) -> None:
+        """Lazily import quafu modules."""
+        if self._quafu is None:
+            try:
+                import quafu
+                from quafu import QuantumCircuit
+                self._quafu = quafu
+                self._QuantumCircuit = QuantumCircuit
+            except ImportError as e:
+                raise RuntimeError(
+                    "quafu is required for QuafuCircuitAdapter. "
+                    "Install it with: pip install pyquafu"
+                ) from e
+
+    def adapt(self, circuit: "Circuit") -> Any:
+        """Convert QPanda-lite Circuit to quafu QuantumCircuit.
+
+        Args:
+            circuit: QPanda-lite Circuit object.
+
+        Returns:
+            quafu.QuantumCircuit object.
+        """
+        self._ensure_imports()
+        from qpandalite.originir.originir_line_parser import OriginIR_LineParser
+
+        originir = self._get_originir(circuit)
+        lines = originir.splitlines()
+        qc: Any = None
+
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                (
+                    operation,
+                    qubit,
+                    cbit,
+                    parameter,
+                    dagger_flag,
+                    control_qubits,
+                ) = OriginIR_LineParser.parse_line(line)
+            except NotImplementedError:
+                raise RuntimeError(
+                    f"Unknown OriginIR operation in Quafu adapter: {line}"
+                ) from None
+
+            # Initialize circuit on QINIT
+            if operation == "QINIT":
+                num_qubits = int(qubit)
+                qc = self._QuantumCircuit(num_qubits)
+                continue
+
+            if qc is None:
+                raise RuntimeError("QINIT must appear before any gate operation.")
+
+            # Skip CREG (handled implicitly)
+            if operation == "CREG":
+                continue
+
+            # Apply gates
+            qc = self._apply_gate(qc, operation, qubit, cbit, parameter, dagger_flag, control_qubits)
+
+        if qc is None:
+            raise RuntimeError("OriginIR string produced no circuit.")
+
+        return qc
+
+    def _apply_gate(
+        self,
+        qc: Any,
+        operation: Optional[str],
+        qubit: Any,
+        cbit: Any,
+        parameter: Any,
+        dagger_flag: Optional[bool],
+        control_qubits: Any,
+    ) -> Any:
+        """Apply a single gate to the Quafu QuantumCircuit.
+
+        Args:
+            qc: Quafu QuantumCircuit object.
+            operation: Gate operation name.
+            qubit: Target qubit(s).
+            cbit: Classical bit for measurement.
+            parameter: Gate parameter(s).
+            dagger_flag: Whether the gate is daggered.
+            control_qubits: Control qubits for controlled gates.
+
+        Returns:
+            Modified QuantumCircuit object.
+        """
+        if operation is None:
+            return qc
+
+        # Single-qubit gates
+        if operation == "H":
+            qc.h(int(qubit))
+        elif operation == "X":
+            qc.x(int(qubit))
+        elif operation == "Y":
+            qc.y(int(qubit))
+        elif operation == "Z":
+            qc.z(int(qubit))
+        elif operation == "S":
+            if dagger_flag:
+                qc.sdg(int(qubit))
+            else:
+                qc.s(int(qubit))
+        elif operation == "T":
+            if dagger_flag:
+                qc.tdg(int(qubit))
+            else:
+                qc.t(int(qubit))
+        elif operation == "SX":
+            if dagger_flag:
+                qc.sxdg(int(qubit))
+            else:
+                qc.sx(int(qubit))
+
+        # Single-qubit rotation gates
+        elif operation == "RX":
+            qc.rx(int(qubit), float(parameter))
+        elif operation == "RY":
+            qc.ry(int(qubit), float(parameter))
+        elif operation == "RZ":
+            qc.rz(int(qubit), float(parameter))
+
+        # Two-qubit gates
+        elif operation == "CNOT":
+            qubits = qubit if isinstance(qubit, list) else [qubit]
+            qc.cnot(int(qubits[0]), int(qubits[1]))
+        elif operation == "CZ":
+            qubits = qubit if isinstance(qubit, list) else [qubit]
+            qc.cz(int(qubits[0]), int(qubits[1]))
+        elif operation == "SWAP":
+            qubits = qubit if isinstance(qubit, list) else [qubit]
+            qc.swap(int(qubits[0]), int(qubits[1]))
+        elif operation == "ISWAP":
+            qubits = qubit if isinstance(qubit, list) else [qubit]
+            qc.iswap(int(qubits[0]), int(qubits[1]))
+
+        # Measurement
+        elif operation == "MEASURE":
+            # Quafu measure takes lists of qubits and cbits
+            if cbit is not None:
+                qc.measure([int(qubit)], [int(cbit)])
+            else:
+                qc.measure([int(qubit)])
+
+        # Barrier
+        elif operation == "BARRIER":
+            if isinstance(qubit, list):
+                qc.barrier(qubit)
+            else:
+                qc.barrier([qubit])
+
+        # Ignore control structure markers
+        elif operation in ("CONTROL", "ENDCONTROL", "DAGGER", "ENDDAGGER"):
+            pass
+
+        else:
+            # For unsupported gates, raise a clear error
+            raise NotImplementedError(
+                f"Gate '{operation}' is not supported by QuafuCircuitAdapter. "
+                f"Supported gates: {self.SUPPORTED_GATES}"
+            )
+
+        return qc
+
+    def get_supported_gates(self) -> List[str]:
+        """Return the list of gate names supported by this adapter."""
+        return self.SUPPORTED_GATES.copy()
+
+
+class IBMCircuitAdapter(CircuitAdapter[Any]):
+    """Adapter for converting QPanda-lite Circuit to qiskit (IBM) format.
+
+    Converts Circuit -> OriginIR -> QASM -> Qiskit QuantumCircuit.
+    """
+
+    # QASM 2.0 standard gates supported by qiskit
+    SUPPORTED_GATES = [
+        "H", "X", "Y", "Z", "S", "T", "SX",
+        "RX", "RY", "RZ",
+        "U1", "U2", "U3",
+        "CNOT", "CX", "CZ", "SWAP", "ISWAP",
+        "TOFFOLI", "CCX", "CSWAP", "Fredkin",
+        "MEASURE", "BARRIER",
+        "I", "ID",
+    ]
+
+    def __init__(self) -> None:
+        self._qiskit: Any = None
+
+    def _ensure_imports(self) -> None:
+        """Lazily import qiskit modules."""
+        if self._qiskit is None:
+            try:
+                import qiskit
+                self._qiskit = qiskit
+            except ImportError as e:
+                raise RuntimeError(
+                    "qiskit is required for IBMCircuitAdapter. "
+                    "Install it with: pip install qiskit"
+                ) from e
+
+    def adapt(self, circuit: "Circuit") -> Any:
+        """Convert QPanda-lite Circuit to qiskit QuantumCircuit.
+
+        The conversion path is:
+        QPanda-lite Circuit -> OriginIR -> QASM -> Qiskit QuantumCircuit
+
+        Args:
+            circuit: QPanda-lite Circuit object.
+
+        Returns:
+            qiskit.QuantumCircuit object.
+        """
+        self._ensure_imports()
+
+        # Get QASM representation (via OriginIR -> QASM conversion)
+        qasm_str = circuit.qasm
+
+        # Parse QASM to Qiskit QuantumCircuit
+        return self._qiskit.QuantumCircuit.from_qasm_str(qasm_str)
+
+    def adapt_with_transpilation(
+        self,
+        circuit: "Circuit",
+        backend: Any = None,
+        optimization_level: int = 1,
+        **kwargs: Any,
+    ) -> Any:
+        """Convert and transpile the circuit for a specific backend.
+
+        Args:
+            circuit: QPanda-lite Circuit object.
+            backend: Qiskit backend to transpile for.
+            optimization_level: Transpiler optimization level (0-3).
+            **kwargs: Additional arguments for qiskit.compiler.transpile.
+
+        Returns:
+            Transpiled qiskit.QuantumCircuit object.
+        """
+        self._ensure_imports()
+        qiskit_circuit = self.adapt(circuit)
+
+        if backend is not None:
+            return self._qiskit.compiler.transpile(
+                qiskit_circuit, backend=backend, optimization_level=optimization_level, **kwargs
+            )
+
+        return qiskit_circuit
+
+    def get_supported_gates(self) -> List[str]:
+        """Return the list of gate names supported by this adapter."""
+        return self.SUPPORTED_GATES.copy()

--- a/qpandalite/circuit_adapter.py
+++ b/qpandalite/circuit_adapter.py
@@ -121,7 +121,7 @@ class OriginQCircuitAdapter(CircuitAdapter[Any]):
 
     def _ensure_imports(self) -> None:
         """Lazily import pyqpanda3 modules."""
-        if self._pyqpanda3 is None:
+        if self._pyqpanda3 is None or self._convert_originir is None:
             try:
                 from pyqpanda3 import core as pyqpanda3_core
                 from pyqpanda3.intermediate_compiler import (

--- a/qpandalite/config.py
+++ b/qpandalite/config.py
@@ -132,8 +132,10 @@ def save_config(config: dict[str, Any], config_path: str | Path | None = None) -
         ConfigError: If configuration file cannot be written.
     """
     path = Path(config_path) if config_path else CONFIG_FILE
-    _ensure_config_dir()
-
+    
+    # Ensure parent directory exists (for both default and custom paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    
     try:
         with open(path, "w", encoding="utf-8") as f:
             yaml.dump(

--- a/qpandalite/config.py
+++ b/qpandalite/config.py
@@ -1,0 +1,396 @@
+"""QPanda-lite configuration management module.
+
+This module provides centralized configuration management for quantum cloud platforms
+including OriginQ (本源量子), Quafu (夸父), and IBM Quantum.
+
+Configuration file location: ~/.qpandalite/qpandalite.yml
+
+Example configuration structure:
+    default:
+      originq:
+        token: xxx
+        submit_url: xxx
+        query_url: xxx
+      quafu:
+        token: xxx
+      ibm:
+        token: xxx
+        proxy:
+          http: http://proxy:8080
+          https: https://proxy:8080
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Configuration file path
+CONFIG_DIR = Path.home() / ".qpandalite"
+CONFIG_FILE = CONFIG_DIR / "qpandalite.yml"
+
+# Default configuration template
+DEFAULT_CONFIG: dict[str, Any] = {
+    "default": {
+        "originq": {
+            "token": "",
+            "submit_url": "",
+            "query_url": "",
+            "available_qubits": [],
+            "available_topology": [],
+            "task_group_size": 200,
+        },
+        "quafu": {
+            "token": "",
+        },
+        "ibm": {
+            "token": "",
+            "proxy": {
+                "http": "",
+                "https": "",
+            },
+        },
+    }
+}
+
+# Supported platforms
+SUPPORTED_PLATFORMS = ["originq", "quafu", "ibm"]
+
+# Platform-specific required fields
+PLATFORM_REQUIRED_FIELDS = {
+    "originq": ["token", "submit_url", "query_url"],
+    "quafu": ["token"],
+    "ibm": ["token"],
+}
+
+
+class ConfigError(Exception):
+    """Configuration-related error."""
+    pass
+
+
+class ConfigValidationError(ConfigError):
+    """Configuration validation error."""
+    pass
+
+
+class PlatformNotFoundError(ConfigError):
+    """Platform configuration not found error."""
+    pass
+
+
+class ProfileNotFoundError(ConfigError):
+    """Profile not found error."""
+    pass
+
+
+def _ensure_config_dir() -> None:
+    """Ensure configuration directory exists."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_config(config_path: str | Path | None = None) -> dict[str, Any]:
+    """Load configuration from YAML file.
+
+    Args:
+        config_path: Path to configuration file. If None, uses default path.
+
+    Returns:
+        Configuration dictionary.
+
+    Raises:
+        ConfigError: If configuration file cannot be read.
+    """
+    path = Path(config_path) if config_path else CONFIG_FILE
+
+    if not path.exists():
+        return DEFAULT_CONFIG.copy()
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        if config is None:
+            return DEFAULT_CONFIG.copy()
+        return config
+    except yaml.YAMLError as e:
+        raise ConfigError(f"Failed to parse YAML configuration: {e}") from e
+    except IOError as e:
+        raise ConfigError(f"Failed to read configuration file: {e}") from e
+
+
+def save_config(config: dict[str, Any], config_path: str | Path | None = None) -> None:
+    """Save configuration to YAML file.
+
+    Args:
+        config: Configuration dictionary to save.
+        config_path: Path to configuration file. If None, uses default path.
+
+    Raises:
+        ConfigError: If configuration file cannot be written.
+    """
+    path = Path(config_path) if config_path else CONFIG_FILE
+    _ensure_config_dir()
+
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.dump(
+                config,
+                f,
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=False,
+            )
+    except IOError as e:
+        raise ConfigError(f"Failed to write configuration file: {e}") from e
+
+
+def get_platform_config(
+    platform_name: str,
+    profile: str = "default",
+    config_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Get configuration for a specific platform.
+
+    Args:
+        platform_name: Name of the quantum cloud platform (originq, quafu, ibm).
+        profile: Configuration profile name (default: "default").
+        config_path: Path to configuration file. If None, uses default path.
+
+    Returns:
+        Platform configuration dictionary.
+
+    Raises:
+        PlatformNotFoundError: If platform is not supported.
+        ProfileNotFoundError: If profile does not exist in configuration.
+        ConfigError: If platform configuration is not found within profile.
+    """
+    if platform_name not in SUPPORTED_PLATFORMS:
+        raise PlatformNotFoundError(
+            f"Unsupported platform: {platform_name}. "
+            f"Supported platforms: {', '.join(SUPPORTED_PLATFORMS)}"
+        )
+
+    config = load_config(config_path)
+
+    if profile not in config:
+        raise ProfileNotFoundError(
+            f"Profile '{profile}' not found in configuration. "
+            f"Available profiles: {', '.join(config.keys())}"
+        )
+
+    profile_config = config[profile]
+
+    if platform_name not in profile_config:
+        raise ConfigError(
+            f"Platform '{platform_name}' not found in profile '{profile}'"
+        )
+
+    return profile_config[platform_name]
+
+
+def validate_config(
+    config: dict[str, Any] | None = None,
+    config_path: str | Path | None = None,
+) -> list[str]:
+    """Validate configuration structure and required fields.
+
+    Args:
+        config: Configuration dictionary to validate. If None, loads from file.
+        config_path: Path to configuration file. Used if config is None.
+
+    Returns:
+        List of validation error messages. Empty list if valid.
+    """
+    errors: list[str] = []
+
+    try:
+        cfg = config if config is not None else load_config(config_path)
+    except ConfigError as e:
+        return [str(e)]
+
+    if not isinstance(cfg, dict):
+        return ["Configuration must be a dictionary"]
+
+    if not cfg:
+        return ["Configuration is empty"]
+
+    for profile_name, profile_config in cfg.items():
+        if not isinstance(profile_config, dict):
+            errors.append(f"Profile '{profile_name}' must be a dictionary")
+            continue
+
+        for platform_name in SUPPORTED_PLATFORMS:
+            if platform_name not in profile_config:
+                continue
+
+            platform_config = profile_config[platform_name]
+
+            if not isinstance(platform_config, dict):
+                errors.append(
+                    f"Platform '{platform_name}' in profile '{profile_name}' "
+                    "must be a dictionary"
+                )
+                continue
+
+            # Check required fields
+            required_fields = PLATFORM_REQUIRED_FIELDS.get(platform_name, [])
+            for field in required_fields:
+                if field not in platform_config:
+                    errors.append(
+                        f"Missing required field '{field}' for platform "
+                        f"'{platform_name}' in profile '{profile_name}'"
+                    )
+
+            # Validate proxy configuration for IBM
+            if platform_name == "ibm" and "proxy" in platform_config:
+                proxy = platform_config["proxy"]
+                if not isinstance(proxy, dict):
+                    errors.append(
+                        f"Proxy configuration for IBM in profile '{profile_name}' "
+                        "must be a dictionary"
+                    )
+                else:
+                    for proxy_type in ["http", "https"]:
+                        if proxy_type in proxy and not isinstance(proxy[proxy_type], str):
+                            errors.append(
+                                f"Proxy '{proxy_type}' for IBM in profile "
+                                f"'{profile_name}' must be a string"
+                            )
+
+    return errors
+
+
+def create_default_config(config_path: str | Path | None = None) -> None:
+    """Create default configuration file if it doesn't exist.
+
+    Args:
+        config_path: Path to configuration file. If None, uses default path.
+    """
+    path = Path(config_path) if config_path else CONFIG_FILE
+
+    if path.exists():
+        return
+
+    _ensure_config_dir()
+    save_config(DEFAULT_CONFIG, path)
+
+
+def update_platform_config(
+    platform_name: str,
+    platform_config: dict[str, Any],
+    profile: str = "default",
+    config_path: str | Path | None = None,
+) -> None:
+    """Update configuration for a specific platform.
+
+    Args:
+        platform_name: Name of the quantum cloud platform.
+        platform_config: Platform configuration dictionary.
+        profile: Configuration profile name (default: "default").
+        config_path: Path to configuration file. If None, uses default path.
+
+    Raises:
+        PlatformNotFoundError: If platform is not supported.
+    """
+    if platform_name not in SUPPORTED_PLATFORMS:
+        raise PlatformNotFoundError(
+            f"Unsupported platform: {platform_name}. "
+            f"Supported platforms: {', '.join(SUPPORTED_PLATFORMS)}"
+        )
+
+    config = load_config(config_path)
+
+    if profile not in config:
+        config[profile] = {}
+
+    config[profile][platform_name] = platform_config
+    save_config(config, config_path)
+
+
+def get_active_profile(config_path: str | Path | None = None) -> str:
+    """Get the active profile from configuration.
+
+    First checks QPANDALITE_PROFILE environment variable,
+    then falls back to 'default'.
+
+    Args:
+        config_path: Path to configuration file. If None, uses default path.
+
+    Returns:
+        Active profile name.
+    """
+    env_profile = os.environ.get("QPANDALITE_PROFILE")
+    if env_profile:
+        return env_profile
+
+    config = load_config(config_path)
+    if "active_profile" in config:
+        return config["active_profile"]
+
+    return "default"
+
+
+def set_active_profile(
+    profile: str,
+    config_path: str | Path | None = None,
+) -> None:
+    """Set the active profile in configuration.
+
+    Args:
+        profile: Profile name to set as active.
+        config_path: Path to configuration file. If None, uses default path.
+
+    Raises:
+        ProfileNotFoundError: If profile does not exist in configuration.
+    """
+    config = load_config(config_path)
+
+    if profile not in config:
+        raise ProfileNotFoundError(
+            f"Profile '{profile}' not found in configuration. "
+            f"Available profiles: {', '.join(k for k in config.keys() if k != 'active_profile')}"
+        )
+
+    config["active_profile"] = profile
+    save_config(config, config_path)
+
+
+# Convenience functions for specific platforms
+
+def get_originq_config(profile: str = "default") -> dict[str, Any]:
+    """Get OriginQ (本源量子) configuration.
+
+    Args:
+        profile: Configuration profile name (default: "default").
+
+    Returns:
+        OriginQ configuration dictionary.
+    """
+    return get_platform_config("originq", profile)
+
+
+def get_quafu_config(profile: str = "default") -> dict[str, Any]:
+    """Get Quafu (夸父) configuration.
+
+    Args:
+        profile: Configuration profile name (default: "default").
+
+    Returns:
+        Quafu configuration dictionary.
+    """
+    return get_platform_config("quafu", profile)
+
+
+def get_ibm_config(profile: str = "default") -> dict[str, Any]:
+    """Get IBM Quantum configuration.
+
+    Args:
+        profile: Configuration profile name (default: "default").
+
+    Returns:
+        IBM Quantum configuration dictionary.
+    """
+    return get_platform_config("ibm", profile)

--- a/qpandalite/exceptions.py
+++ b/qpandalite/exceptions.py
@@ -1,0 +1,305 @@
+"""Custom exceptions for QPanda-lite.
+
+This module defines all custom exceptions used throughout the QPanda-lite
+package, providing clear error types for different failure scenarios.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    # Base exception
+    "QPandaLiteError",
+    # Authentication errors
+    "AuthenticationError",
+    # Credit/Quota errors
+    "InsufficientCreditsError",
+    "QuotaExceededError",
+    # Network errors
+    "NetworkError",
+    # Task errors
+    "TaskFailedError",
+    "TaskTimeoutError",
+    "TaskNotFoundError",
+    # Backend errors
+    "BackendError",
+    "BackendNotAvailableError",
+    "BackendNotFoundError",
+    # Circuit errors
+    "CircuitError",
+    "CircuitTranslationError",
+    "UnsupportedGateError",
+]
+
+
+class QPandaLiteError(Exception):
+    """Base exception for all QPanda-lite errors."""
+    
+    def __init__(self, message: str, *, details: dict | None = None) -> None:
+        """Initialize the error.
+        
+        Args:
+            message: Human-readable error message.
+            details: Optional dictionary with additional error details.
+        """
+        super().__init__(message)
+        self.message = message
+        self.details = details or {}
+
+    def __str__(self) -> str:
+        if self.details:
+            return f"{self.message} (details: {self.details})"
+        return self.message
+
+
+# -----------------------------------------------------------------------------
+# Authentication Errors
+# -----------------------------------------------------------------------------
+
+class AuthenticationError(QPandaLiteError):
+    """Raised when authentication fails (invalid token, expired credentials, etc.).
+    
+    This error indicates that the provided API token or credentials are invalid,
+    expired, or do not have the required permissions.
+    """
+    pass
+
+
+# -----------------------------------------------------------------------------
+# Credit and Quota Errors
+# -----------------------------------------------------------------------------
+
+class InsufficientCreditsError(QPandaLiteError):
+    """Raised when the account has insufficient credits to run a task.
+    
+    This error indicates that the user's account balance is too low to
+    execute the requested quantum computation.
+    """
+    pass
+
+
+class QuotaExceededError(QPandaLiteError):
+    """Raised when the user has exceeded their usage quota.
+    
+    This error indicates that the user has reached their daily, monthly,
+    or total usage limit for the quantum computing service.
+    """
+    pass
+
+
+# -----------------------------------------------------------------------------
+# Network Errors
+# -----------------------------------------------------------------------------
+
+class NetworkError(QPandaLiteError):
+    """Raised when a network operation fails.
+    
+    This error covers connection failures, timeouts, DNS errors,
+    and other network-related issues when communicating with
+    quantum computing backends.
+    """
+    
+    def __init__(
+        self,
+        message: str,
+        *,
+        url: str | None = None,
+        status_code: int | None = None,
+        details: dict | None = None,
+    ) -> None:
+        """Initialize the network error.
+        
+        Args:
+            message: Human-readable error message.
+            url: The URL that was being accessed when the error occurred.
+            status_code: HTTP status code if applicable.
+            details: Optional dictionary with additional error details.
+        """
+        super().__init__(message, details=details)
+        self.url = url
+        self.status_code = status_code
+
+
+# -----------------------------------------------------------------------------
+# Task Errors
+# -----------------------------------------------------------------------------
+
+class TaskFailedError(QPandaLiteError):
+    """Raised when a quantum task fails on the backend.
+    
+    This error indicates that the task was submitted successfully but
+    failed during execution on the quantum computer or simulator.
+    """
+    
+    def __init__(
+        self,
+        message: str,
+        *,
+        task_id: str | None = None,
+        backend: str | None = None,
+        error_code: str | None = None,
+        details: dict | None = None,
+    ) -> None:
+        """Initialize the task failed error.
+        
+        Args:
+            message: Human-readable error message.
+            task_id: The ID of the failed task.
+            backend: The backend where the task failed.
+            error_code: Backend-specific error code if available.
+            details: Optional dictionary with additional error details.
+        """
+        super().__init__(message, details=details)
+        self.task_id = task_id
+        self.backend = backend
+        self.error_code = error_code
+
+
+class TaskTimeoutError(QPandaLiteError):
+    """Raised when waiting for a task result exceeds the timeout.
+    
+    This error indicates that the task did not complete within the
+    specified timeout period. The task may still be running.
+    """
+    
+    def __init__(
+        self,
+        message: str,
+        *,
+        task_id: str | None = None,
+        timeout: float | None = None,
+        details: dict | None = None,
+    ) -> None:
+        """Initialize the timeout error.
+        
+        Args:
+            message: Human-readable error message.
+            task_id: The ID of the task that timed out.
+            timeout: The timeout value in seconds.
+            details: Optional dictionary with additional error details.
+        """
+        super().__init__(message, details=details)
+        self.task_id = task_id
+        self.timeout = timeout
+
+
+class TaskNotFoundError(QPandaLiteError):
+    """Raised when a task cannot be found.
+    
+    This error indicates that the specified task ID does not exist
+    or the user does not have permission to access it.
+    """
+    
+    def __init__(
+        self,
+        message: str,
+        *,
+        task_id: str | None = None,
+        details: dict | None = None,
+    ) -> None:
+        """Initialize the task not found error.
+        
+        Args:
+            message: Human-readable error message.
+            task_id: The ID of the task that was not found.
+            details: Optional dictionary with additional error details.
+        """
+        super().__init__(message, details=details)
+        self.task_id = task_id
+
+
+# -----------------------------------------------------------------------------
+# Backend Errors
+# -----------------------------------------------------------------------------
+
+class BackendError(QPandaLiteError):
+    """Raised when a backend operation fails.
+    
+    This is the base class for all backend-related errors.
+    """
+    pass
+
+
+class BackendNotAvailableError(BackendError):
+    """Raised when a backend is not available.
+    
+    This error indicates that the backend is offline, not configured,
+    or cannot be accessed due to missing dependencies.
+    """
+    pass
+
+
+class BackendNotFoundError(BackendError):
+    """Raised when a requested backend is not found.
+    
+    This error indicates that the specified backend name is not
+    registered in the backend registry.
+    """
+    pass
+
+
+# -----------------------------------------------------------------------------
+# Circuit Errors
+# -----------------------------------------------------------------------------
+
+class CircuitError(QPandaLiteError):
+    """Raised when a circuit operation fails.
+    
+    This is the base class for all circuit-related errors.
+    """
+    pass
+
+
+class CircuitTranslationError(CircuitError):
+    """Raised when circuit translation fails.
+    
+    This error indicates that a circuit could not be converted
+    from OriginIR to the target backend's native format.
+    """
+    
+    def __init__(
+        self,
+        message: str,
+        *,
+        source_format: str | None = None,
+        target_format: str | None = None,
+        details: dict | None = None,
+    ) -> None:
+        """Initialize the translation error.
+        
+        Args:
+            message: Human-readable error message.
+            source_format: The source circuit format.
+            target_format: The target circuit format.
+            details: Optional dictionary with additional error details.
+        """
+        super().__init__(message, details=details)
+        self.source_format = source_format
+        self.target_format = target_format
+
+
+class UnsupportedGateError(CircuitError):
+    """Raised when a circuit contains an unsupported gate.
+    
+    This error indicates that the target backend does not support
+    one or more gates present in the circuit.
+    """
+    
+    def __init__(
+        self,
+        message: str,
+        *,
+        gate_name: str | None = None,
+        backend: str | None = None,
+        details: dict | None = None,
+    ) -> None:
+        """Initialize the unsupported gate error.
+        
+        Args:
+            message: Human-readable error message.
+            gate_name: The name of the unsupported gate.
+            backend: The backend that does not support this gate.
+            details: Optional dictionary with additional error details.
+        """
+        super().__init__(message, details=details)
+        self.gate_name = gate_name
+        self.backend = backend

--- a/qpandalite/network_utils.py
+++ b/qpandalite/network_utils.py
@@ -1,0 +1,284 @@
+"""Network utilities for proxy detection and connectivity testing.
+
+This module provides functions for:
+- Detecting system proxy settings
+- Testing proxy connectivity
+- Testing IBM Quantum connectivity with or without proxy
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "check_proxy_connectivity",
+    "detect_system_proxy",
+    "test_ibm_connectivity",
+]
+
+import os
+import socket
+from typing import Any
+from urllib.parse import urlparse
+
+
+def detect_system_proxy() -> dict[str, str | None]:
+    """Detect system proxy settings from environment variables.
+
+    Checks for both uppercase and lowercase environment variable names:
+    - HTTP_PROXY / http_proxy
+    - HTTPS_PROXY / https_proxy
+
+    Returns:
+        dict with keys 'http' and 'https', values are proxy URLs or None.
+
+    Example:
+        >>> proxies = detect_system_proxy()
+        >>> print(proxies)
+        {'http': 'http://proxy.example.com:8080', 'https': None}
+    """
+    http_proxy = os.getenv("HTTP_PROXY") or os.getenv("http_proxy")
+    https_proxy = os.getenv("HTTPS_PROXY") or os.getenv("https_proxy")
+
+    return {
+        "http": http_proxy,
+        "https": https_proxy,
+    }
+
+
+def _parse_proxy_url(proxy_url: str) -> tuple[str, int] | None:
+    """Parse proxy URL and extract host and port.
+
+    Args:
+        proxy_url: Proxy URL (e.g., 'http://proxy.example.com:8080')
+
+    Returns:
+        Tuple of (host, port) or None if parsing fails.
+    """
+    try:
+        parsed = urlparse(proxy_url)
+        host = parsed.hostname
+        port = parsed.port
+
+        if host is None:
+            return None
+
+        # Default ports for http and https
+        if port is None:
+            if parsed.scheme == "https":
+                port = 443
+            else:
+                port = 80
+
+        return (host, port)
+    except Exception:
+        return None
+
+
+def check_proxy_connectivity(
+    proxy_url: str,
+    test_url: str = "https://www.googleapis.com",
+    timeout: float = 10.0,
+) -> bool:
+    """Check if a proxy is reachable and can connect to a test URL.
+
+    Args:
+        proxy_url: The proxy URL to test (e.g., 'http://proxy.example.com:8080').
+        test_url: URL to test connectivity through the proxy (default: Google APIs).
+        timeout: Connection timeout in seconds (default: 10.0).
+
+    Returns:
+        True if the proxy is reachable, False otherwise.
+
+    Note:
+        This function performs a basic TCP connection check to the proxy
+        host and port. It does not perform an actual HTTP CONNECT request
+        or verify that the proxy can reach the test URL.
+
+    Example:
+        >>> is_available = check_proxy_connectivity(
+        ...     "http://proxy.example.com:8080"
+        ... )
+        >>> print(f"Proxy available: {is_available}")
+    """
+    proxy_info = _parse_proxy_url(proxy_url)
+    if proxy_info is None:
+        return False
+
+    host, port = proxy_info
+
+    try:
+        # Attempt TCP connection to the proxy
+        sock = socket.create_connection((host, port), timeout=timeout)
+        sock.close()
+        return True
+    except (socket.timeout, socket.error, OSError):
+        return False
+
+
+def _build_proxies_dict(
+    proxy: dict[str, str] | str | None,
+) -> dict[str, str] | None:
+    """Build a proxies dictionary for requests library.
+
+    Args:
+        proxy: Can be:
+            - None (uses system proxy)
+            - A proxy URL string
+            - A dict with 'http' and/or 'https' keys
+
+    Returns:
+        Dict suitable for requests library or None.
+    """
+    if proxy is None:
+        # Use system proxy
+        system_proxies = detect_system_proxy()
+        proxies = {}
+        if system_proxies.get("http"):
+            proxies["http"] = system_proxies["http"]
+        if system_proxies.get("https"):
+            proxies["https"] = system_proxies["https"]
+        return proxies if proxies else None
+
+    if isinstance(proxy, str):
+        return {"http": proxy, "https": proxy}
+
+    if isinstance(proxy, dict):
+        proxies = {}
+        if proxy.get("http"):
+            proxies["http"] = proxy["http"]
+        if proxy.get("https"):
+            proxies["https"] = proxy["https"]
+        return proxies if proxies else None
+
+    return None
+
+
+def test_ibm_connectivity(
+    token: str | None = None,
+    proxy: dict[str, str] | str | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Test connectivity to IBM Quantum services.
+
+    Args:
+        token: IBM Quantum API token. If None, tries to load from environment.
+        proxy: Proxy configuration. Can be:
+            - None: uses system proxy settings
+            - str: proxy URL (used for both http and https)
+            - dict: with 'http' and/or 'https' keys
+        timeout: Request timeout in seconds (default: 30.0).
+
+    Returns:
+        dict with connectivity test results:
+        {
+            'success': bool,
+            'message': str,
+            'proxy_used': dict | str | None,
+            'response_time_ms': float | None,
+        }
+
+    Example:
+        >>> result = test_ibm_connectivity(
+        ...     token="my_api_token",
+        ...     proxy={"https": "http://proxy.example.com:8080"}
+        ... )
+        >>> print(result["success"])
+    """
+    import time
+
+    # Get token if not provided
+    if token is None:
+        token = os.getenv("IBM_TOKEN")
+        if token is None:
+            return {
+                "success": False,
+                "message": "IBM token not provided and IBM_TOKEN env var not set",
+                "proxy_used": proxy,
+                "response_time_ms": None,
+            }
+
+    # Build proxy configuration
+    proxies = _build_proxies_dict(proxy)
+
+    # IBM Quantum API endpoint for authentication test
+    # Using IBM Quantum's jobs endpoint for a lightweight check
+    ibm_api_url = "https://auth.quantum-computing.ibm.com/api/version"
+
+    start_time = time.time()
+
+    try:
+        import urllib.request
+
+        # Build request
+        request = urllib.request.Request(
+            ibm_api_url,
+            headers={"Authorization": f"Bearer {token}"},
+            method="GET",
+        )
+
+        # Build proxy handler
+        proxy_handler = None
+        if proxies:
+            proxy_handler = urllib.request.ProxyHandler(proxies)
+            opener = urllib.request.build_opener(proxy_handler)
+        else:
+            opener = urllib.request.build_opener()
+
+        # Perform request
+        with opener.open(request, timeout=timeout) as response:
+            response_time = (time.time() - start_time) * 1000
+            status_code = response.getcode()
+
+            if 200 <= status_code < 300:
+                return {
+                    "success": True,
+                    "message": f"Successfully connected to IBM Quantum (status: {status_code})",
+                    "proxy_used": proxies or proxy,
+                    "response_time_ms": round(response_time, 2),
+                }
+            else:
+                return {
+                    "success": False,
+                    "message": f"Unexpected status code: {status_code}",
+                    "proxy_used": proxies or proxy,
+                    "response_time_ms": round(response_time, 2),
+                }
+
+    except Exception as e:
+        response_time = (time.time() - start_time) * 1000
+        return {
+            "success": False,
+            "message": f"Connection failed: {str(e)}",
+            "proxy_used": proxies or proxy,
+            "response_time_ms": round(response_time, 2),
+        }
+
+
+def get_ibm_proxy_from_config(config: dict[str, Any] | None = None) -> dict[str, str] | None:
+    """Extract IBM proxy configuration from qpandalite config.
+
+    Args:
+        config: IBM configuration dict. If None, loads from qpandalite config.
+
+    Returns:
+        Dict with 'http' and/or 'https' proxy URLs, or None if no proxy configured.
+
+    Example:
+        >>> from qpandalite.config import get_ibm_config
+        >>> config = get_ibm_config()
+        >>> proxy = get_ibm_proxy_from_config(config)
+    """
+    if config is None:
+        from qpandalite.config import get_ibm_config
+        config = get_ibm_config()
+
+    proxy_config = config.get("proxy")
+    if not proxy_config:
+        return None
+
+    proxies = {}
+    if proxy_config.get("http"):
+        proxies["http"] = proxy_config["http"]
+    if proxy_config.get("https"):
+        proxies["https"] = proxy_config["https"]
+
+    return proxies if proxies else None

--- a/qpandalite/network_utils.py
+++ b/qpandalite/network_utils.py
@@ -27,6 +27,8 @@ def detect_system_proxy() -> dict[str, str | None]:
     - HTTP_PROXY / http_proxy
     - HTTPS_PROXY / https_proxy
 
+    Uppercase variants take precedence over lowercase ones.
+
     Returns:
         dict with keys 'http' and 'https', values are proxy URLs or None.
 
@@ -35,8 +37,25 @@ def detect_system_proxy() -> dict[str, str | None]:
         >>> print(proxies)
         {'http': 'http://proxy.example.com:8080', 'https': None}
     """
-    http_proxy = os.getenv("HTTP_PROXY") or os.getenv("http_proxy")
-    https_proxy = os.getenv("HTTPS_PROXY") or os.getenv("https_proxy")
+    # Use os.environ keys to check case-sensitive existence
+    # This works correctly on both Unix (case-sensitive) and Windows (case-insensitive)
+    env_keys = set(os.environ.keys())
+
+    # Check for HTTP proxy - uppercase takes precedence
+    if "HTTP_PROXY" in env_keys:
+        http_proxy = os.environ["HTTP_PROXY"]
+    elif "http_proxy" in env_keys:
+        http_proxy = os.environ["http_proxy"]
+    else:
+        http_proxy = None
+
+    # Check for HTTPS proxy - uppercase takes precedence
+    if "HTTPS_PROXY" in env_keys:
+        https_proxy = os.environ["HTTPS_PROXY"]
+    elif "https_proxy" in env_keys:
+        https_proxy = os.environ["https_proxy"]
+    else:
+        https_proxy = None
 
     return {
         "http": http_proxy,

--- a/qpandalite/task/adapters/qiskit_adapter.py
+++ b/qpandalite/task/adapters/qiskit_adapter.py
@@ -25,19 +25,67 @@ if TYPE_CHECKING:
 
 
 class QiskitAdapter(QuantumAdapter):
-    """Adapter for IBM Quantum backends via Qiskit."""
+    """Adapter for IBM Quantum backends via Qiskit.
+
+    Proxy Configuration:
+        Proxies can be passed via the `proxy` parameter:
+        - Dict with 'http' and/or 'https' keys
+        - Or a single proxy URL string for both protocols
+
+    Example:
+        >>> adapter = QiskitAdapter(proxy={
+        ...     "http": "http://proxy.example.com:8080",
+        ...     "https": "https://proxy.example.com:8080"
+        ... })
+    """
 
     name = "ibm"
 
-    def __init__(self) -> None:
+    def __init__(self, proxy: dict[str, str] | str | None = None) -> None:
+        """Initialize the Qiskit adapter.
+
+        Args:
+            proxy: Optional proxy configuration.
+                - Dict with 'http' and/or 'https' keys
+                - Or a single proxy URL string
+        """
         config = load_ibm_config()
         self._api_token: str = config["api_token"]
+        self._proxy: dict[str, str] | str | None = proxy
 
         import qiskit_ibm_provider
+
+        # Set up proxy for qiskit-ibm-provider if proxy is configured
+        if proxy:
+            self._setup_proxy(proxy)
 
         qiskit_ibm_provider.IBMProvider.save_account(self._api_token)
         self._provider = qiskit_ibm_provider.IBMProvider(instance="ibm-q/open/main")
         self._backends = self._provider.backends()
+
+    def _setup_proxy(self, proxy: dict[str, str] | str) -> None:
+        """Configure proxy settings for Qiskit/IBM provider.
+
+        Args:
+            proxy: Proxy configuration dict or URL string.
+        """
+        import os
+
+        # Convert dict proxy to URL format if needed
+        if isinstance(proxy, dict):
+            https_proxy = proxy.get("https")
+            http_proxy = proxy.get("http")
+            # Prefer HTTPS proxy for IBM Quantum
+            proxy_url = https_proxy or http_proxy
+        else:
+            proxy_url = proxy
+
+        if proxy_url:
+            # Set environment variables for qiskit and underlying libraries
+            os.environ["HTTP_PROXY"] = proxy_url
+            os.environ["HTTPS_PROXY"] = proxy_url
+            os.environ["http_proxy"] = proxy_url
+            os.environ["https_proxy"] = proxy_url
 
     def is_available(self) -> bool:
         """Check if the Qiskit adapter is available (IBM provider initialized).

--- a/qpandalite/task_manager.py
+++ b/qpandalite/task_manager.py
@@ -1,0 +1,822 @@
+"""Task management with local caching for quantum computing backends.
+
+This module provides a unified interface for submitting quantum tasks,
+managing task lifecycle, and caching results locally.
+
+Usage:
+    from qpandalite.task_manager import submit_task, query_task, wait_for_result
+    from qpandalite.circuit_builder import Circuit
+    from qpandalite.backend import get_backend
+
+    # Create a circuit
+    circuit = Circuit()
+    circuit.h(0)
+    circuit.cnot(0, 1)
+    circuit.measure(0, 1)
+
+    # Submit task
+    task_id = submit_task(circuit, backend='quafu', shots=1000)
+
+    # Wait for result
+    result = wait_for_result(task_id, backend='quafu', timeout=300)
+
+    # Query task status
+    info = query_task(task_id, backend='quafu')
+    print(info['status'])  # 'running', 'success', or 'failed'
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    # Task submission
+    "submit_task",
+    "submit_batch",
+    # Task query
+    "query_task",
+    "wait_for_result",
+    # Cache management
+    "save_task",
+    "get_task",
+    "list_tasks",
+    "clear_completed_tasks",
+    "clear_cache",
+    # Classes
+    "TaskInfo",
+    "TaskManager",
+]
+
+import json
+import time
+import warnings
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from qpandalite.circuit_builder.qcircuit import Circuit
+
+from qpandalite import backend
+from qpandalite.circuit_adapter import (
+    CircuitAdapter,
+    OriginQCircuitAdapter,
+    QuafuCircuitAdapter,
+    IBMCircuitAdapter,
+)
+from qpandalite.exceptions import (
+    AuthenticationError,
+    BackendNotAvailableError,
+    BackendNotFoundError,
+    InsufficientCreditsError,
+    NetworkError,
+    QuotaExceededError,
+    TaskFailedError,
+    TaskNotFoundError,
+    TaskTimeoutError,
+)
+from qpandalite.task.adapters.base import (
+    TASK_STATUS_FAILED,
+    TASK_STATUS_RUNNING,
+    TASK_STATUS_SUCCESS,
+)
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+
+DEFAULT_CACHE_DIR = Path.home() / ".qpandalite" / "cache"
+TASKS_CACHE_FILE = "tasks.json"
+
+
+class TaskStatus(str, Enum):
+    """Enumeration of task statuses."""
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+# -----------------------------------------------------------------------------
+# Data Classes
+# -----------------------------------------------------------------------------
+
+@dataclass
+class TaskInfo:
+    """Information about a submitted task.
+    
+    Attributes:
+        task_id: Unique identifier for the task.
+        backend: The backend where the task was submitted.
+        status: Current status of the task.
+        result: Task result (if completed).
+        shots: Number of shots requested.
+        submit_time: ISO format timestamp of submission.
+        update_time: ISO format timestamp of last status update.
+        metadata: Additional metadata about the task.
+    """
+    task_id: str
+    backend: str
+    status: str = TaskStatus.PENDING
+    result: dict | None = None
+    shots: int = 1000
+    submit_time: str = field(default_factory=lambda: datetime.now().isoformat())
+    update_time: str = field(default_factory=lambda: datetime.now().isoformat())
+    metadata: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TaskInfo:
+        """Create from dictionary."""
+        return cls(**data)
+
+
+# -----------------------------------------------------------------------------
+# Circuit Adapter Mapping
+# -----------------------------------------------------------------------------
+
+ADAPTER_MAP: dict[str, type[CircuitAdapter]] = {
+    "originq": OriginQCircuitAdapter,
+    "quafu": QuafuCircuitAdapter,
+    "ibm": IBMCircuitAdapter,
+}
+
+
+def _get_adapter(backend_name: str) -> CircuitAdapter:
+    """Get the appropriate circuit adapter for a backend.
+    
+    Args:
+        backend_name: The name of the backend.
+        
+    Returns:
+        CircuitAdapter instance for the backend.
+        
+    Raises:
+        BackendNotFoundError: If no adapter exists for the backend.
+    """
+    if backend_name not in ADAPTER_MAP:
+        available = ", ".join(ADAPTER_MAP.keys())
+        raise BackendNotFoundError(
+            f"No circuit adapter for backend '{backend_name}'. "
+            f"Available adapters: {available}"
+        )
+    return ADAPTER_MAP[backend_name]()
+
+
+# -----------------------------------------------------------------------------
+# Cache Management
+# -----------------------------------------------------------------------------
+
+def _get_cache_file(cache_dir: Path | None = None) -> Path:
+    """Get the path to the tasks cache file.
+    
+    Args:
+        cache_dir: Optional custom cache directory.
+        
+    Returns:
+        Path to the tasks.json cache file.
+    """
+    cache_path = cache_dir or DEFAULT_CACHE_DIR
+    cache_path.mkdir(parents=True, exist_ok=True)
+    return cache_path / TASKS_CACHE_FILE
+
+
+def _load_tasks_cache(cache_dir: Path | None = None) -> dict[str, dict]:
+    """Load the tasks cache from disk.
+    
+    Args:
+        cache_dir: Optional custom cache directory.
+        
+    Returns:
+        Dictionary mapping task_id to task info dict.
+    """
+    cache_file = _get_cache_file(cache_dir)
+    if not cache_file.exists():
+        return {}
+    try:
+        with open(cache_file, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (IOError, json.JSONDecodeError) as e:
+        warnings.warn(f"Failed to load tasks cache: {e}")
+        return {}
+
+
+def _save_tasks_cache(tasks: dict[str, dict], cache_dir: Path | None = None) -> None:
+    """Save the tasks cache to disk.
+    
+    Args:
+        tasks: Dictionary mapping task_id to task info dict.
+        cache_dir: Optional custom cache directory.
+    """
+    cache_file = _get_cache_file(cache_dir)
+    try:
+        with open(cache_file, "w", encoding="utf-8") as f:
+            json.dump(tasks, f, indent=2, ensure_ascii=False)
+    except (IOError, OSError) as e:
+        warnings.warn(f"Failed to save tasks cache: {e}")
+
+
+def save_task(task_info: TaskInfo, cache_dir: Path | None = None) -> None:
+    """Save a task to the local cache.
+    
+    Args:
+        task_info: Task information to save.
+        cache_dir: Optional custom cache directory.
+    """
+    tasks = _load_tasks_cache(cache_dir)
+    task_info.update_time = datetime.now().isoformat()
+    tasks[task_info.task_id] = task_info.to_dict()
+    _save_tasks_cache(tasks, cache_dir)
+
+
+def get_task(task_id: str, cache_dir: Path | None = None) -> TaskInfo | None:
+    """Get a task from the local cache.
+    
+    Args:
+        task_id: The task identifier.
+        cache_dir: Optional custom cache directory.
+        
+    Returns:
+        TaskInfo if found, None otherwise.
+    """
+    tasks = _load_tasks_cache(cache_dir)
+    if task_id not in tasks:
+        return None
+    return TaskInfo.from_dict(tasks[task_id])
+
+
+def list_tasks(
+    status: str | None = None,
+    backend: str | None = None,
+    cache_dir: Path | None = None,
+) -> list[TaskInfo]:
+    """List tasks from the local cache.
+    
+    Args:
+        status: Filter by status (optional).
+        backend: Filter by backend (optional).
+        cache_dir: Optional custom cache directory.
+        
+    Returns:
+        List of TaskInfo objects matching the filters.
+    """
+    tasks = _load_tasks_cache(cache_dir)
+    results = []
+    for task_data in tasks.values():
+        task_info = TaskInfo.from_dict(task_data)
+        if status is not None and task_info.status != status:
+            continue
+        if backend is not None and task_info.backend != backend:
+            continue
+        results.append(task_info)
+    return results
+
+
+def clear_completed_tasks(cache_dir: Path | None = None) -> int:
+    """Remove completed tasks from the cache.
+    
+    Args:
+        cache_dir: Optional custom cache directory.
+        
+    Returns:
+        Number of tasks removed.
+    """
+    tasks = _load_tasks_cache(cache_dir)
+    completed_statuses = {TaskStatus.SUCCESS, TaskStatus.FAILED, TaskStatus.CANCELLED}
+    to_remove = [
+        task_id for task_id, data in tasks.items()
+        if data.get("status") in completed_statuses
+    ]
+    for task_id in to_remove:
+        del tasks[task_id]
+    if to_remove:
+        _save_tasks_cache(tasks, cache_dir)
+    return len(to_remove)
+
+
+def clear_cache(cache_dir: Path | None = None) -> None:
+    """Clear all tasks from the cache.
+    
+    Args:
+        cache_dir: Optional custom cache directory.
+    """
+    cache_file = _get_cache_file(cache_dir)
+    if cache_file.exists():
+        try:
+            cache_file.unlink()
+        except (IOError, OSError) as e:
+            warnings.warn(f"Failed to clear cache: {e}")
+
+
+# -----------------------------------------------------------------------------
+# Error Handling
+# -----------------------------------------------------------------------------
+
+def _map_adapter_error(error: Exception, backend_name: str) -> Exception:
+    """Map an adapter error to a QPandaLiteError.
+    
+    Args:
+        error: The original error from the adapter.
+        backend_name: The name of the backend.
+        
+    Returns:
+        A QPandaLiteError subclass or the original error.
+    """
+    error_message = str(error).lower()
+    
+    # Check for authentication errors
+    if any(keyword in error_message for keyword in ["unauthorized", "invalid token", "authentication", "auth"]):
+        return AuthenticationError(
+            f"Authentication failed for backend '{backend_name}'. "
+            "Please check your API token or credentials.",
+            details={"original_error": str(error)}
+        )
+    
+    # Check for credit/quota errors
+    if any(keyword in error_message for keyword in ["credit", "balance", "payment", "billing"]):
+        return InsufficientCreditsError(
+            f"Insufficient credits for backend '{backend_name}'. "
+            "Please top up your account.",
+            details={"original_error": str(error)}
+        )
+    
+    if any(keyword in error_message for keyword in ["quota", "limit exceeded", "rate limit"]):
+        return QuotaExceededError(
+            f"Quota exceeded for backend '{backend_name}'. "
+            "Please try again later or upgrade your plan.",
+            details={"original_error": str(error)}
+        )
+    
+    # Check for network errors
+    if any(keyword in error_message for keyword in ["connection", "timeout", "network", "dns", "refused"]):
+        return NetworkError(
+            f"Network error while communicating with backend '{backend_name}'.",
+            details={"original_error": str(error)}
+        )
+    
+    return error
+
+
+# -----------------------------------------------------------------------------
+# Task Submission
+# -----------------------------------------------------------------------------
+
+def submit_task(
+    circuit: Circuit,
+    backend: str,
+    shots: int = 1000,
+    metadata: dict | None = None,
+    **kwargs: Any,
+) -> str:
+    """Submit a single circuit to a quantum backend.
+    
+    This function converts the circuit to the backend's native format,
+    submits it, and caches the task information locally.
+    
+    Args:
+        circuit: The QPanda-lite Circuit to submit.
+        backend: The backend name (e.g., 'originq', 'quafu', 'ibm').
+        shots: Number of measurement shots.
+        metadata: Optional metadata to store with the task.
+        **kwargs: Additional backend-specific parameters.
+            - For Quafu: chip_id, auto_mapping
+            - For OriginQ: chip_id, circuit_optimize, measurement_amend
+            
+    Returns:
+        The task ID assigned by the backend.
+        
+    Raises:
+        BackendNotFoundError: If the backend is not recognized.
+        BackendNotAvailableError: If the backend is not available.
+        AuthenticationError: If authentication fails.
+        InsufficientCreditsError: If account has insufficient credits.
+        QuotaExceededError: If usage quota is exceeded.
+        NetworkError: If a network error occurs.
+        
+    Example:
+        >>> circuit = Circuit()
+        >>> circuit.h(0)
+        >>> circuit.measure(0)
+        >>> task_id = submit_task(circuit, backend='quafu', shots=1000, chip_id='ScQ-P10')
+    """
+    # Get backend instance
+    try:
+        backend_instance = backend.get_backend(backend)
+    except ValueError as e:
+        raise BackendNotFoundError(str(e)) from e
+    
+    # Check backend availability
+    if not backend_instance.is_available():
+        raise BackendNotAvailableError(
+            f"Backend '{backend}' is not available. "
+            "Please check your configuration and credentials."
+        )
+    
+    # Convert circuit using adapter
+    try:
+        adapter = _get_adapter(backend)
+        native_circuit = adapter.adapt(circuit)
+    except Exception as e:
+        raise _map_adapter_error(e, backend) from e
+    
+    # Submit to backend
+    try:
+        task_id = backend_instance.submit(native_circuit, shots=shots, **kwargs)
+    except Exception as e:
+        mapped_error = _map_adapter_error(e, backend)
+        raise mapped_error from e
+    
+    # Create and save task info
+    task_info = TaskInfo(
+        task_id=task_id,
+        backend=backend,
+        status=TaskStatus.RUNNING,
+        shots=shots,
+        metadata=metadata or {},
+    )
+    save_task(task_info)
+    
+    return task_id
+
+
+def submit_batch(
+    circuits: list[Circuit],
+    backend: str,
+    shots: int = 1000,
+    **kwargs: Any,
+) -> list[str]:
+    """Submit multiple circuits as a batch to a quantum backend.
+    
+    Args:
+        circuits: List of QPanda-lite Circuits to submit.
+        backend: The backend name.
+        shots: Number of measurement shots per circuit.
+        **kwargs: Additional backend-specific parameters.
+            - For Quafu: chip_id, auto_mapping, group_name
+            - For OriginQ: chip_id, circuit_optimize
+            
+    Returns:
+        List of task IDs assigned by the backend.
+        
+    Raises:
+        BackendNotFoundError: If the backend is not recognized.
+        BackendNotAvailableError: If the backend is not available.
+        AuthenticationError: If authentication fails.
+        InsufficientCreditsError: If account has insufficient credits.
+        QuotaExceededError: If usage quota is exceeded.
+        NetworkError: If a network error occurs.
+        
+    Example:
+        >>> circuits = [circuit1, circuit2, circuit3]
+        >>> task_ids = submit_batch(circuits, backend='quafu', shots=1000, chip_id='ScQ-P10')
+    """
+    # Get backend instance
+    try:
+        backend_instance = backend.get_backend(backend)
+    except ValueError as e:
+        raise BackendNotFoundError(str(e)) from e
+    
+    # Check backend availability
+    if not backend_instance.is_available():
+        raise BackendNotAvailableError(
+            f"Backend '{backend}' is not available. "
+            "Please check your configuration and credentials."
+        )
+    
+    # Convert circuits using adapter
+    try:
+        adapter = _get_adapter(backend)
+        native_circuits = adapter.adapt_batch(circuits)
+    except Exception as e:
+        raise _map_adapter_error(e, backend) from e
+    
+    # Submit batch to backend
+    try:
+        result = backend_instance.submit_batch(native_circuits, shots=shots, **kwargs)
+        # Handle both list of task IDs and single group ID
+        if isinstance(result, list):
+            task_ids = result
+        else:
+            task_ids = [result]
+    except Exception as e:
+        mapped_error = _map_adapter_error(e, backend)
+        raise mapped_error from e
+    
+    # Create and save task info for each task
+    for task_id in task_ids:
+        task_info = TaskInfo(
+            task_id=task_id,
+            backend=backend,
+            status=TaskStatus.RUNNING,
+            shots=shots,
+            metadata={"batch": True, "batch_size": len(circuits)},
+        )
+        save_task(task_info)
+    
+    return task_ids
+
+
+# -----------------------------------------------------------------------------
+# Task Query
+# -----------------------------------------------------------------------------
+
+def query_task(task_id: str, backend: str | None = None) -> TaskInfo:
+    """Query the status of a task.
+    
+    This function queries the backend for the current status of a task
+    and updates the local cache.
+    
+    Args:
+        task_id: The task identifier.
+        backend: The backend name. If None, attempts to look up from cache.
+        
+    Returns:
+        TaskInfo with current status and result if available.
+        
+    Raises:
+        TaskNotFoundError: If the task is not found locally or remotely.
+        BackendNotFoundError: If the backend is not recognized.
+        NetworkError: If a network error occurs.
+        
+    Example:
+        >>> info = query_task('task-123', backend='quafu')
+        >>> print(info.status)
+        'success'
+    """
+    # Try to get backend from cache if not provided
+    if backend is None:
+        cached_task = get_task(task_id)
+        if cached_task is None:
+            raise TaskNotFoundError(
+                f"Task '{task_id}' not found in local cache. "
+                "Please provide the backend parameter."
+            )
+        backend = cached_task.backend
+    
+    # Get backend instance
+    try:
+        backend_instance = backend.get_backend(backend)
+    except ValueError as e:
+        raise BackendNotFoundError(str(e)) from e
+    
+    # Query backend
+    try:
+        result = backend_instance.query(task_id)
+    except Exception as e:
+        mapped_error = _map_adapter_error(e, backend)
+        if isinstance(mapped_error, NetworkError):
+            raise mapped_error from e
+        # For other errors, try to use cached info
+        cached_task = get_task(task_id)
+        if cached_task is not None:
+            return cached_task
+        raise TaskNotFoundError(
+            f"Task '{task_id}' not found: {e}",
+            task_id=task_id,
+        ) from e
+    
+    # Map adapter status to TaskStatus
+    adapter_status = result.get("status", TASK_STATUS_RUNNING)
+    status_map = {
+        TASK_STATUS_SUCCESS: TaskStatus.SUCCESS,
+        TASK_STATUS_FAILED: TaskStatus.FAILED,
+        TASK_STATUS_RUNNING: TaskStatus.RUNNING,
+    }
+    task_status = status_map.get(adapter_status, TaskStatus.RUNNING)
+    
+    # Update task info
+    task_info = TaskInfo(
+        task_id=task_id,
+        backend=backend,
+        status=task_status,
+        result=result.get("result") if task_status == TaskStatus.SUCCESS else None,
+    )
+    
+    # Merge with existing metadata if available
+    cached_task = get_task(task_id)
+    if cached_task is not None:
+        task_info.submit_time = cached_task.submit_time
+        task_info.shots = cached_task.shots
+        task_info.metadata = cached_task.metadata
+    
+    save_task(task_info)
+    return task_info
+
+
+def wait_for_result(
+    task_id: str,
+    backend: str | None = None,
+    timeout: float = 300.0,
+    poll_interval: float = 5.0,
+    raise_on_failure: bool = True,
+) -> dict | None:
+    """Wait for a task to complete and return its result.
+    
+    This function polls the task status until it completes, fails, or
+    the timeout is reached.
+    
+    Args:
+        task_id: The task identifier.
+        backend: The backend name. If None, attempts to look up from cache.
+        timeout: Maximum time to wait in seconds.
+        poll_interval: Time between status checks in seconds.
+        raise_on_failure: If True, raises TaskFailedError on task failure.
+        
+    Returns:
+        The task result dictionary if successful, None if timed out.
+        
+    Raises:
+        TaskTimeoutError: If the timeout is reached before completion.
+        TaskFailedError: If the task fails and raise_on_failure is True.
+        TaskNotFoundError: If the task is not found.
+        NetworkError: If a network error occurs.
+        
+    Example:
+        >>> result = wait_for_result('task-123', backend='quafu', timeout=300)
+        >>> print(result['counts'])
+        {'00': 512, '11': 488}
+    """
+    start_time = time.time()
+    
+    while True:
+        # Query current status
+        task_info = query_task(task_id, backend)
+        
+        # Check if completed
+        if task_info.status == TaskStatus.SUCCESS:
+            return task_info.result
+        
+        # Check if failed
+        if task_info.status == TaskStatus.FAILED:
+            if raise_on_failure:
+                raise TaskFailedError(
+                    f"Task '{task_id}' failed on backend '{task_info.backend}'.",
+                    task_id=task_id,
+                    backend=task_info.backend,
+                )
+            return None
+        
+        # Check timeout
+        elapsed = time.time() - start_time
+        if elapsed >= timeout:
+            raise TaskTimeoutError(
+                f"Timeout waiting for task '{task_id}' to complete.",
+                task_id=task_id,
+                timeout=timeout,
+            )
+        
+        # Wait before next poll
+        time.sleep(poll_interval)
+
+
+# -----------------------------------------------------------------------------
+# TaskManager Class
+# -----------------------------------------------------------------------------
+
+class TaskManager:
+    """High-level task manager for quantum computing workflows.
+    
+    This class provides a convenient interface for managing quantum tasks
+    with persistent caching and batch operations.
+    
+    Example:
+        >>> manager = TaskManager()
+        >>> task_id = manager.submit(circuit, backend='quafu', shots=1000)
+        >>> result = manager.wait_for_result(task_id)
+        >>> print(result)
+    """
+    
+    def __init__(self, cache_dir: Path | str | None = None) -> None:
+        """Initialize the TaskManager.
+        
+        Args:
+            cache_dir: Optional custom cache directory.
+        """
+        self._cache_dir = Path(cache_dir) if cache_dir else None
+    
+    def submit(
+        self,
+        circuit: Circuit,
+        backend: str,
+        shots: int = 1000,
+        metadata: dict | None = None,
+        **kwargs: Any,
+    ) -> str:
+        """Submit a single circuit.
+        
+        Args:
+            circuit: The circuit to submit.
+            backend: The backend name.
+            shots: Number of shots.
+            metadata: Optional metadata.
+            **kwargs: Backend-specific parameters.
+            
+        Returns:
+            The task ID.
+        """
+        return submit_task(
+            circuit,
+            backend,
+            shots=shots,
+            metadata=metadata,
+            cache_dir=self._cache_dir,
+            **kwargs,
+        )
+    
+    def submit_batch(
+        self,
+        circuits: list[Circuit],
+        backend: str,
+        shots: int = 1000,
+        **kwargs: Any,
+    ) -> list[str]:
+        """Submit multiple circuits as a batch.
+        
+        Args:
+            circuits: List of circuits to submit.
+            backend: The backend name.
+            shots: Number of shots per circuit.
+            **kwargs: Backend-specific parameters.
+            
+        Returns:
+            List of task IDs.
+        """
+        return submit_batch(
+            circuits,
+            backend,
+            shots=shots,
+            cache_dir=self._cache_dir,
+            **kwargs,
+        )
+    
+    def query(self, task_id: str, backend: str | None = None) -> TaskInfo:
+        """Query a task's status.
+        
+        Args:
+            task_id: The task ID.
+            backend: Optional backend name.
+            
+        Returns:
+            TaskInfo with current status.
+        """
+        return query_task(task_id, backend)
+    
+    def wait_for_result(
+        self,
+        task_id: str,
+        backend: str | None = None,
+        timeout: float = 300.0,
+        poll_interval: float = 5.0,
+        raise_on_failure: bool = True,
+    ) -> dict | None:
+        """Wait for a task to complete.
+        
+        Args:
+            task_id: The task ID.
+            backend: Optional backend name.
+            timeout: Maximum wait time in seconds.
+            poll_interval: Time between status checks.
+            raise_on_failure: Whether to raise on task failure.
+            
+        Returns:
+            Task result if successful, None if timed out.
+        """
+        return wait_for_result(
+            task_id,
+            backend,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            raise_on_failure=raise_on_failure,
+        )
+    
+    def list_tasks(
+        self,
+        status: str | None = None,
+        backend: str | None = None,
+    ) -> list[TaskInfo]:
+        """List tasks from cache.
+        
+        Args:
+            status: Filter by status.
+            backend: Filter by backend.
+            
+        Returns:
+            List of matching tasks.
+        """
+        return list_tasks(status, backend, cache_dir=self._cache_dir)
+    
+    def clear_completed(self) -> int:
+        """Clear completed tasks from cache.
+        
+        Returns:
+            Number of tasks removed.
+        """
+        return clear_completed_tasks(cache_dir=self._cache_dir)
+    
+    def clear_cache(self) -> None:
+        """Clear all tasks from cache."""
+        clear_cache(cache_dir=self._cache_dir)

--- a/qpandalite/task_manager.py
+++ b/qpandalite/task_manager.py
@@ -585,8 +585,10 @@ def query_task(task_id: str, backend: str | None = None) -> TaskInfo:
         TASK_STATUS_SUCCESS: TaskStatus.SUCCESS,
         TASK_STATUS_FAILED: TaskStatus.FAILED,
         TASK_STATUS_RUNNING: TaskStatus.RUNNING,
+        "pending": TaskStatus.PENDING,
+        "cancelled": TaskStatus.CANCELLED,
     }
-    task_status = status_map.get(adapter_status, TaskStatus.RUNNING)
+    task_status = status_map.get(adapter_status, TaskStatus.PENDING)
     
     # Update task info
     task_info = TaskInfo(

--- a/qpandalite/test/test_circuit_adapter.py
+++ b/qpandalite/test/test_circuit_adapter.py
@@ -1,0 +1,159 @@
+"""Tests for circuit_adapter module."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from qpandalite.circuit_builder import Circuit
+from qpandalite.circuit_adapter import (
+    CircuitAdapter,
+    OriginQCircuitAdapter,
+    QuafuCircuitAdapter,
+    IBMCircuitAdapter,
+)
+
+
+class TestCircuitAdapterInterface(unittest.TestCase):
+    """Test the CircuitAdapter abstract base class interface."""
+
+    def test_abstract_methods(self):
+        """Test that CircuitAdapter cannot be instantiated directly."""
+        with self.assertRaises(TypeError):
+            CircuitAdapter()
+
+
+class TestOriginQCircuitAdapter(unittest.TestCase):
+    """Test OriginQCircuitAdapter."""
+
+    def test_get_supported_gates(self):
+        """Test that supported gates are returned."""
+        adapter = OriginQCircuitAdapter()
+        gates = adapter.get_supported_gates()
+        self.assertIsInstance(gates, list)
+        self.assertIn("H", gates)
+        self.assertIn("CNOT", gates)
+        self.assertIn("MEASURE", gates)
+
+    def test_adapt_without_pyqpanda3(self):
+        """Test that adapt raises RuntimeError when pyqpanda3 is not installed."""
+        adapter = OriginQCircuitAdapter()
+
+        # Mock _pyqpanda3 as None to simulate missing import
+        adapter._pyqpanda3 = None
+        adapter._convert_originir = None
+
+        circuit = Circuit()
+        circuit.h(0)
+
+        with patch.dict("sys.modules", {"pyqpanda3": None}):
+            with self.assertRaises(RuntimeError) as context:
+                adapter.adapt(circuit)
+            self.assertIn("pyqpanda3", str(context.exception))
+
+
+class TestQuafuCircuitAdapter(unittest.TestCase):
+    """Test QuafuCircuitAdapter."""
+
+    def test_get_supported_gates(self):
+        """Test that supported gates are returned."""
+        adapter = QuafuCircuitAdapter()
+        gates = adapter.get_supported_gates()
+        self.assertIsInstance(gates, list)
+        self.assertIn("H", gates)
+        self.assertIn("CNOT", gates)
+        self.assertIn("MEASURE", gates)
+
+    def test_adapt_without_quafu(self):
+        """Test that adapt raises RuntimeError when quafu is not installed."""
+        adapter = QuafuCircuitAdapter()
+
+        # Reset the imports to simulate missing package
+        adapter._quafu = None
+        adapter._QuantumCircuit = None
+
+        circuit = Circuit()
+        circuit.h(0)
+
+        with patch.dict("sys.modules", {"quafu": None}):
+            with self.assertRaises(RuntimeError) as context:
+                adapter.adapt(circuit)
+            self.assertIn("quafu", str(context.exception))
+
+
+class TestIBMCircuitAdapter(unittest.TestCase):
+    """Test IBMCircuitAdapter."""
+
+    def test_get_supported_gates(self):
+        """Test that supported gates are returned."""
+        adapter = IBMCircuitAdapter()
+        gates = adapter.get_supported_gates()
+        self.assertIsInstance(gates, list)
+        self.assertIn("H", gates)
+        self.assertIn("CNOT", gates)
+        self.assertIn("CX", gates)  # IBM uses CX for CNOT
+        self.assertIn("MEASURE", gates)
+
+    def test_adapt_single_circuit(self):
+        """Test adapting a single circuit."""
+        try:
+            import qiskit
+        except ImportError:
+            self.skipTest("qiskit not installed")
+
+        adapter = IBMCircuitAdapter()
+        circuit = Circuit()
+        circuit.h(0)
+        circuit.cnot(0, 1)
+        circuit.measure(0, 1)
+
+        qiskit_circuit = adapter.adapt(circuit)
+
+        self.assertEqual(qiskit_circuit.num_qubits, 2)
+        self.assertEqual(qiskit_circuit.num_clbits, 2)
+
+    def test_adapt_batch(self):
+        """Test batch adaptation of circuits."""
+        try:
+            import qiskit
+        except ImportError:
+            self.skipTest("qiskit not installed")
+
+        adapter = IBMCircuitAdapter()
+
+        circuit1 = Circuit()
+        circuit1.h(0)
+        circuit1.measure(0)
+
+        circuit2 = Circuit()
+        circuit2.x(0)
+        circuit2.measure(0)
+
+        qiskit_circuits = adapter.adapt_batch([circuit1, circuit2])
+
+        self.assertEqual(len(qiskit_circuits), 2)
+        for qc in qiskit_circuits:
+            self.assertEqual(qc.num_qubits, 1)
+            self.assertEqual(qc.num_clbits, 1)
+
+
+class TestGateCoverage(unittest.TestCase):
+    """Test that adapters cover the expected gate sets."""
+
+    def test_originq_covers_basic_gates(self):
+        """Test that OriginQ adapter covers basic quantum gates."""
+        adapter = OriginQCircuitAdapter()
+        gates = set(adapter.get_supported_gates())
+
+        basic_gates = {"H", "X", "Y", "Z", "CNOT", "CZ", "RX", "RY", "RZ"}
+        self.assertTrue(basic_gates.issubset(gates))
+
+    def test_ibm_covers_qasm_gates(self):
+        """Test that IBM adapter covers standard QASM gates."""
+        adapter = IBMCircuitAdapter()
+        gates = set(adapter.get_supported_gates())
+
+        qasm_gates = {"H", "X", "Y", "Z", "CNOT", "CX", "CZ"}
+        self.assertTrue(qasm_gates.issubset(gates))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qpandalite/test/test_cloud_platforms.py
+++ b/qpandalite/test/test_cloud_platforms.py
@@ -1,0 +1,1019 @@
+"""Comprehensive tests for unified cloud platform access layer.
+
+This module provides:
+1. Configuration loading tests
+2. Backend factory tests  
+3. Circuit adapter tests
+4. Mock tests (no real platform dependencies)
+5. Integration tests (skipped unless real credentials exist)
+6. End-to-end workflow tests
+
+Usage:
+    pytest qpandalite/test/test_cloud_platforms.py -v
+    
+Environment variables for integration tests:
+    - QPANDA_API_KEY: OriginQ API key
+    - QPANDA_SUBMIT_URL: OriginQ submit URL
+    - QPANDA_QUERY_URL: OriginQ query URL
+    - QUAFU_API_TOKEN: Quafu API token
+    - IBM_TOKEN: IBM Quantum token
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Custom Exceptions for Error Testing
+# ---------------------------------------------------------------------------
+
+
+class AuthenticationError(Exception):
+    """Raised when authentication fails (invalid token, etc.)."""
+    pass
+
+
+class InsufficientCreditsError(Exception):
+    """Raised when account has insufficient credits."""
+    pass
+
+
+class NetworkError(Exception):
+    """Raised when network communication fails."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Test Data
+# ---------------------------------------------------------------------------
+
+ORIGINIR_BELL = """
+QINIT 2
+CREG 2
+H q[0]
+CNOT q[0], q[1]
+MEASURE q[0], c[0]
+MEASURE q[1], c[1]
+""".strip()
+
+ORIGINIR_3Q = """
+QINIT 3
+CREG 3
+H q[0]
+H q[1]
+H q[2]
+CNOT q[0], q[1]
+CNOT q[1], q[2]
+MEASURE q[0], c[0]
+MEASURE q[1], c[1]
+MEASURE q[2], c[2]
+""".strip()
+
+ORIGINIR_SINGLE = """
+QINIT 1
+CREG 1
+X q[0]
+MEASURE q[0], c[0]
+""".strip()
+
+
+# ---------------------------------------------------------------------------
+# Configuration Loading Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigLoading:
+    """Tests for configuration loading from ~/.qpandalite/qpandalite.yml."""
+
+    def test_load_config_file_not_exists(self, tmp_path: Path) -> None:
+        """Test that default config is returned when file doesn't exist."""
+        from qpandalite.config import load_config, DEFAULT_CONFIG
+        
+        non_existent = tmp_path / "non_existent.yml"
+        result = load_config(non_existent)
+        assert result == DEFAULT_CONFIG
+
+    def test_load_existing_config(self, tmp_path: Path) -> None:
+        """Test loading an existing configuration file."""
+        from qpandalite.config import load_config, save_config
+        
+        config_file = tmp_path / "test_config.yml"
+        test_config = {
+            "default": {
+                "originq": {"token": "test_token_123", "submit_url": "http://submit.test", "query_url": "http://query.test"},
+                "quafu": {"token": "quafu_token_456"},
+                "ibm": {"token": "ibm_token_789", "proxy": {"http": "", "https": ""}},
+            }
+        }
+        save_config(test_config, config_file)
+        result = load_config(config_file)
+        assert result["default"]["originq"]["token"] == "test_token_123"
+        assert result["default"]["quafu"]["token"] == "quafu_token_456"
+        assert result["default"]["ibm"]["token"] == "ibm_token_789"
+
+    def test_load_config_all_platforms(self, tmp_path: Path) -> None:
+        """Test loading configuration for all three platforms."""
+        from qpandalite.config import (
+            load_config, save_config, 
+            get_platform_config, SUPPORTED_PLATFORMS
+        )
+        
+        config_file = tmp_path / "qpandalite.yml"
+        test_config = {
+            "default": {
+                "originq": {
+                    "token": "originq_test_token",
+                    "submit_url": "https://originq.example.com/submit",
+                    "query_url": "https://originq.example.com/query",
+                    "available_qubits": [0, 1, 2, 3, 4, 5],
+                    "available_topology": [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]],
+                    "task_group_size": 200,
+                },
+                "quafu": {
+                    "token": "quafu_test_token",
+                },
+                "ibm": {
+                    "token": "ibm_test_token",
+                    "proxy": {"http": "http://proxy.example.com:8080", "https": "https://proxy.example.com:8080"},
+                },
+            }
+        }
+        save_config(test_config, config_file)
+        
+        # Test each platform
+        for platform in SUPPORTED_PLATFORMS:
+            config = get_platform_config(platform, config_path=config_file)
+            assert "token" in config
+            assert config["token"] == f"{platform}_test_token"
+
+    def test_load_config_different_profiles(self, tmp_path: Path) -> None:
+        """Test loading configuration with different profiles."""
+        from qpandalite.config import load_config, save_config, get_platform_config
+        
+        config_file = tmp_path / "qpandalite.yml"
+        test_config = {
+            "default": {
+                "originq": {"token": "default_token", "submit_url": "http://default", "query_url": "http://default"},
+            },
+            "prod": {
+                "originq": {"token": "prod_token", "submit_url": "http://prod", "query_url": "http://prod"},
+            },
+            "dev": {
+                "originq": {"token": "dev_token", "submit_url": "http://dev", "query_url": "http://dev"},
+            },
+        }
+        save_config(test_config, config_file)
+        
+        default_config = get_platform_config("originq", profile="default", config_path=config_file)
+        assert default_config["token"] == "default_token"
+        
+        prod_config = get_platform_config("originq", profile="prod", config_path=config_file)
+        assert prod_config["token"] == "prod_token"
+        
+        dev_config = get_platform_config("originq", profile="dev", config_path=config_file)
+        assert dev_config["token"] == "dev_token"
+
+    def test_validate_config_valid(self) -> None:
+        """Test validating a valid configuration."""
+        from qpandalite.config import validate_config
+        
+        valid_config = {
+            "default": {
+                "originq": {"token": "t", "submit_url": "s", "query_url": "q"},
+                "quafu": {"token": "t"},
+                "ibm": {"token": "t", "proxy": {"http": "", "https": ""}},
+            }
+        }
+        errors = validate_config(valid_config)
+        assert errors == []
+
+    def test_validate_config_missing_required_fields(self) -> None:
+        """Test validating configuration with missing required fields."""
+        from qpandalite.config import validate_config
+        
+        invalid_config = {
+            "default": {
+                "originq": {"token": "t"},  # Missing submit_url and query_url
+            }
+        }
+        errors = validate_config(invalid_config)
+        assert len(errors) >= 2
+        assert any("submit_url" in e for e in errors)
+        assert any("query_url" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Backend Factory Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackendFactory:
+    """Tests for the Backend factory pattern (get_backend)."""
+
+    def test_get_backend_originq(self) -> None:
+        """Test getting OriginQ backend returns correct type."""
+        from qpandalite.backend import get_backend, OriginQBackend
+        
+        with patch("qpandalite.backend.OriginQBackend._create_adapter") as mock_create:
+            mock_adapter = MagicMock()
+            mock_create.return_value = mock_adapter
+            
+            backend = get_backend("originq", use_cache=False)
+            assert isinstance(backend, OriginQBackend)
+            assert backend.platform == "originq"
+
+    def test_get_backend_quafu(self) -> None:
+        """Test getting Quafu backend returns correct type."""
+        from qpandalite.backend import get_backend, QuafuBackend
+        
+        with patch("qpandalite.backend.QuafuBackend._create_adapter") as mock_create:
+            mock_adapter = MagicMock()
+            mock_create.return_value = mock_adapter
+            
+            backend = get_backend("quafu", use_cache=False)
+            assert isinstance(backend, QuafuBackend)
+            assert backend.platform == "quafu"
+
+    def test_get_backend_ibm(self) -> None:
+        """Test getting IBM backend returns correct type."""
+        from qpandalite.backend import get_backend, IBMBackend
+        
+        with patch("qpandalite.backend.IBMBackend._create_adapter") as mock_create:
+            mock_adapter = MagicMock()
+            mock_create.return_value = mock_adapter
+            
+            backend = get_backend("ibm", use_cache=False)
+            assert isinstance(backend, IBMBackend)
+            assert backend.platform == "ibm"
+
+    def test_get_backend_unknown_raises(self) -> None:
+        """Test that unknown backend name raises ValueError."""
+        from qpandalite.backend import get_backend
+        
+        with pytest.raises(ValueError, match="Unknown backend"):
+            get_backend("unknown_platform")
+
+    def test_list_backends(self) -> None:
+        """Test listing available backends."""
+        from qpandalite.backend import list_backends, BACKENDS
+        
+        backends = list_backends()
+        assert "originq" in backends
+        assert "quafu" in backends
+        assert "ibm" in backends
+        
+        for name, info in backends.items():
+            assert "platform" in info
+            assert "available" in info
+            assert "class" in info
+            assert info["platform"] == name
+            assert info["class"] == BACKENDS[name].__name__
+
+    def test_backend_caching(self) -> None:
+        """Test that backend instances are cached."""
+        from qpandalite.backend import get_backend, OriginQBackend
+        
+        with patch("qpandalite.backend.OriginQBackend._create_adapter") as mock_create:
+            mock_adapter = MagicMock()
+            mock_create.return_value = mock_adapter
+            
+            # First call should create new instance
+            backend1 = get_backend("originq", use_cache=True)
+            # Second call should return cached instance
+            backend2 = get_backend("originq", use_cache=True)
+            
+            assert backend1 is backend2
+
+
+# ---------------------------------------------------------------------------
+# Circuit Adapter Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitAdapters:
+    """Tests for CircuitAdapter implementations."""
+
+    def test_originq_adapter_supported_gates(self) -> None:
+        """Test OriginQ adapter returns supported gates."""
+        from qpandalite.circuit_adapter import OriginQCircuitAdapter
+        
+        adapter = OriginQCircuitAdapter()
+        gates = adapter.get_supported_gates()
+        
+        assert isinstance(gates, list)
+        assert "H" in gates
+        assert "X" in gates
+        assert "CNOT" in gates
+        assert "MEASURE" in gates
+
+    def test_quafu_adapter_supported_gates(self) -> None:
+        """Test Quafu adapter returns supported gates."""
+        from qpandalite.circuit_adapter import QuafuCircuitAdapter
+        
+        adapter = QuafuCircuitAdapter()
+        gates = adapter.get_supported_gates()
+        
+        assert isinstance(gates, list)
+        assert "H" in gates
+        assert "CNOT" in gates
+        assert "MEASURE" in gates
+
+    def test_ibm_adapter_supported_gates(self) -> None:
+        """Test IBM adapter returns supported gates."""
+        from qpandalite.circuit_adapter import IBMCircuitAdapter
+        
+        adapter = IBMCircuitAdapter()
+        gates = adapter.get_supported_gates()
+        
+        assert isinstance(gates, list)
+        assert "H" in gates
+        assert "CX" in gates  # IBM uses CX for CNOT
+        assert "MEASURE" in gates
+
+    def test_originq_adapter_without_pyqpanda3(self) -> None:
+        """Test OriginQ adapter raises error when pyqpanda3 not installed."""
+        from qpandalite.circuit_adapter import OriginQCircuitAdapter
+        from qpandalite.circuit_builder import Circuit
+        
+        adapter = OriginQCircuitAdapter()
+        adapter._pyqpanda3 = None  # Simulate missing import
+        adapter._convert_originir = None
+        
+        circuit = Circuit()
+        circuit.h(0)
+        
+        with pytest.raises(RuntimeError, match="pyqpanda3"):
+            adapter.adapt(circuit)
+
+    def test_quafu_adapter_without_quafu(self) -> None:
+        """Test Quafu adapter raises error when quafu not installed."""
+        from qpandalite.circuit_adapter import QuafuCircuitAdapter
+        from qpandalite.circuit_builder import Circuit
+        
+        adapter = QuafuCircuitAdapter()
+        adapter._quafu = None  # Simulate missing import
+        adapter._QuantumCircuit = None
+        
+        circuit = Circuit()
+        circuit.h(0)
+        
+        with pytest.raises(RuntimeError, match="quafu"):
+            adapter.adapt(circuit)
+
+    def test_ibm_adapter_adapt_batch(self) -> None:
+        """Test IBM adapter batch conversion."""
+        try:
+            import qiskit
+        except ImportError:
+            pytest.skip("qiskit not installed")
+        
+        from qpandalite.circuit_adapter import IBMCircuitAdapter
+        from qpandalite.circuit_builder import Circuit
+        
+        adapter = IBMCircuitAdapter()
+        
+        circuit1 = Circuit()
+        circuit1.h(0)
+        circuit1.measure(0)
+        
+        circuit2 = Circuit()
+        circuit2.x(0)
+        circuit2.measure(0)
+        
+        qiskit_circuits = adapter.adapt_batch([circuit1, circuit2])
+        
+        assert len(qiskit_circuits) == 2
+        for qc in qiskit_circuits:
+            assert hasattr(qc, "num_qubits")
+
+
+# ---------------------------------------------------------------------------
+# Mock Tests (No Real Platform Dependencies)
+# ---------------------------------------------------------------------------
+
+
+class TestMockSubmitTask:
+    """Mock tests for submit_task workflows."""
+
+    def test_originq_submit_task_mock(self) -> None:
+        """Test OriginQ submit task with mocked HTTP client."""
+        from qpandalite.task.adapters import OriginQAdapter
+        
+        with patch("qpandalite.task.adapters.originq_adapter.load_originq_config") as mock_config:
+            mock_config.return_value = {
+                "api_key": "test_key",
+                "submit_url": "https://test.com/submit",
+                "query_url": "https://test.com/query",
+                "task_group_size": 200,
+            }
+            
+            adapter = OriginQAdapter()
+            
+            with patch.object(adapter._client, "submit", return_value="task_abc123") as mock_submit:
+                task_id = adapter.submit(ORIGINIR_BELL, shots=1000)
+                
+                mock_submit.assert_called_once()
+                assert task_id == "task_abc123"
+
+    def test_originq_submit_batch_mock(self) -> None:
+        """Test OriginQ submit batch with mocked HTTP client."""
+        from qpandalite.task.adapters import OriginQAdapter
+        
+        with patch("qpandalite.task.adapters.originq_adapter.load_originq_config") as mock_config:
+            mock_config.return_value = {
+                "api_key": "test_key",
+                "submit_url": "https://test.com/submit",
+                "query_url": "https://test.com/query",
+                "task_group_size": 2,
+            }
+            
+            adapter = OriginQAdapter()
+            
+            with patch.object(adapter._client, "submit", return_value="task_xyz") as mock_submit:
+                circuits = [ORIGINIR_BELL] * 3
+                task_ids = adapter.submit_batch(circuits, shots=1000)
+                
+                # With group_size=2 and 3 circuits, should call submit twice
+                assert mock_submit.call_count == 2
+
+    def test_quafu_submit_task_mock(self) -> None:
+        """Test Quafu submit task with mocked SDK."""
+        from qpandalite.task.adapters import QuafuAdapter
+        
+        with patch("qpandalite.task.adapters.quafu_adapter.load_quafu_config") as mock_config:
+            mock_config.return_value = {"api_token": "test_token"}
+            
+            mock_quafu = MagicMock()
+            mock_task_result = MagicMock()
+            mock_task_result.taskid = "quafu_task_123"
+            mock_quafu.User.return_value = MagicMock()
+            mock_quafu.Task.return_value.send.return_value = mock_task_result
+            
+            with patch.dict(sys.modules, {"quafu": mock_quafu}):
+                adapter = QuafuAdapter.__new__(QuafuAdapter)
+                adapter._api_token = "test_token"
+                adapter._quafu = mock_quafu
+                adapter._QuantumCircuit = mock_quafu.QuantumCircuit
+                adapter._Task = mock_quafu.Task
+                adapter._User = mock_quafu.User
+                adapter._task_history = {}
+                adapter._history_order = []
+                adapter._MAX_HISTORY_GROUPS = 100
+                
+                mock_circuit = MagicMock()
+                task_id = adapter.submit(mock_circuit, shots=1000, chip_id="ScQ-P10")
+                
+                assert task_id == "quafu_task_123"
+
+
+class TestMockQueryTask:
+    """Mock tests for query_task workflows."""
+
+    def test_originq_query_task_success_mock(self) -> None:
+        """Test OriginQ query task success with mocked HTTP client."""
+        from qpandalite.task.adapters import OriginQAdapter, TASK_STATUS_SUCCESS
+        
+        with patch("qpandalite.task.adapters.originq_adapter.load_originq_config") as mock_config:
+            mock_config.return_value = {
+                "api_key": "test_key",
+                "submit_url": "https://test.com/submit",
+                "query_url": "https://test.com/query",
+                "task_group_size": 200,
+            }
+            
+            adapter = OriginQAdapter()
+            
+            mock_result = {
+                "taskid": "task_abc",
+                "status": TASK_STATUS_SUCCESS,
+                "result": [{"key": ["00", "11"], "value": [0.5, 0.5]}],
+            }
+            
+            with patch.object(adapter._client, "query_single", return_value=mock_result) as mock_query:
+                result = adapter.query("task_abc")
+                
+                mock_query.assert_called_once_with("task_abc")
+                assert result["status"] == TASK_STATUS_SUCCESS
+
+    def test_originq_query_task_running_mock(self) -> None:
+        """Test OriginQ query task running status with mocked HTTP client."""
+        from qpandalite.task.adapters import OriginQAdapter, TASK_STATUS_RUNNING
+        
+        with patch("qpandalite.task.adapters.originq_adapter.load_originq_config") as mock_config:
+            mock_config.return_value = {
+                "api_key": "test_key",
+                "submit_url": "https://test.com/submit",
+                "query_url": "https://test.com/query",
+                "task_group_size": 200,
+            }
+            
+            adapter = OriginQAdapter()
+            
+            mock_result = {
+                "taskid": "task_abc",
+                "status": TASK_STATUS_RUNNING,
+            }
+            
+            with patch.object(adapter._client, "query_single", return_value=mock_result):
+                result = adapter.query("task_abc")
+                assert result["status"] == TASK_STATUS_RUNNING
+
+    def test_originq_query_batch_mock(self) -> None:
+        """Test OriginQ query batch with mocked HTTP client."""
+        from qpandalite.task.adapters import OriginQAdapter, TASK_STATUS_SUCCESS
+        
+        with patch("qpandalite.task.adapters.originq_adapter.load_originq_config") as mock_config:
+            mock_config.return_value = {
+                "api_key": "test_key",
+                "submit_url": "https://test.com/submit",
+                "query_url": "https://test.com/query",
+                "task_group_size": 200,
+            }
+            
+            adapter = OriginQAdapter()
+            
+            mock_results = [
+                {"taskid": "task_1", "status": TASK_STATUS_SUCCESS, "result": [{"key": ["00"], "value": [1.0]}]},
+                {"taskid": "task_2", "status": TASK_STATUS_SUCCESS, "result": [{"key": ["11"], "value": [1.0]}]},
+            ]
+            
+            with patch.object(adapter._client, "query_single", side_effect=mock_results):
+                result = adapter.query_batch(["task_1", "task_2"])
+                assert result["status"] == TASK_STATUS_SUCCESS
+                assert len(result["result"]) == 2
+
+
+class TestMockErrorScenarios:
+    """Mock tests for error scenarios."""
+
+    def test_originq_authentication_error(self) -> None:
+        """Test OriginQ authentication error (invalid token)."""
+        from qpandalite.task.adapters import OriginQAdapter
+        
+        with patch("qpandalite.task.adapters.originq_adapter.load_originq_config") as mock_config:
+            mock_config.return_value = {
+                "api_key": "invalid_token",
+                "submit_url": "https://test.com/submit",
+                "query_url": "https://test.com/query",
+                "task_group_size": 200,
+            }
+            
+            adapter = OriginQAdapter()
+            
+            # Simulate authentication error response
+            with patch.object(
+                adapter._client, 
+                "submit", 
+                side_effect=RuntimeError("Authentication failed: Invalid API key")
+            ):
+                with pytest.raises(RuntimeError, match="Authentication"):
+                    adapter.submit(ORIGINIR_BELL)
+
+    def test_originq_insufficient_credits_error(self) -> None:
+        """Test OriginQ insufficient credits error."""
+        from qpandalite.task.adapters import OriginQAdapter
+        
+        with patch("qpandalite.task.adapters.originq_adapter.load_originq_config") as mock_config:
+            mock_config.return_value = {
+                "api_key": "valid_token",
+                "submit_url": "https://test.com/submit",
+                "query_url": "https://test.com/query",
+                "task_group_size": 200,
+            }
+            
+            adapter = OriginQAdapter()
+            
+            # Simulate insufficient credits error
+            with patch.object(
+                adapter._client, 
+                "submit", 
+                side_effect=RuntimeError("Insufficient credits")
+            ):
+                with pytest.raises(RuntimeError, match="Insufficient credits"):
+                    adapter.submit(ORIGINIR_BELL)
+
+    def test_originq_network_error(self) -> None:
+        """Test OriginQ network error."""
+        from qpandalite.task.adapters import OriginQAdapter
+        
+        with patch("qpandalite.task.adapters.originq_adapter.load_originq_config") as mock_config:
+            mock_config.return_value = {
+                "api_key": "valid_token",
+                "submit_url": "https://test.com/submit",
+                "query_url": "https://test.com/query",
+                "task_group_size": 200,
+            }
+            
+            adapter = OriginQAdapter()
+            
+            # Simulate network error
+            with patch.object(
+                adapter._client, 
+                "submit", 
+                side_effect=RuntimeError("Network error: Connection timeout")
+            ):
+                with pytest.raises(RuntimeError, match="Network error"):
+                    adapter.submit(ORIGINIR_BELL)
+
+    def test_quafu_authentication_error(self) -> None:
+        """Test Quafu authentication error."""
+        from qpandalite.task.adapters import QuafuAdapter
+        
+        with patch("qpandalite.task.adapters.quafu_adapter.load_quafu_config") as mock_config:
+            mock_config.return_value = {"api_token": "invalid_token"}
+            
+            mock_quafu = MagicMock()
+            mock_user = MagicMock()
+            mock_user.save_apitoken.side_effect = RuntimeError("Invalid API token")
+            mock_quafu.User.return_value = mock_user
+            
+            with patch.dict(sys.modules, {"quafu": mock_quafu}):
+                adapter = QuafuAdapter.__new__(QuafuAdapter)
+                adapter._api_token = "invalid_token"
+                adapter._quafu = mock_quafu
+                adapter._QuantumCircuit = mock_quafu.QuantumCircuit
+                adapter._Task = mock_quafu.Task
+                adapter._User = mock_quafu.User
+                adapter._task_history = {}
+                adapter._history_order = []
+                adapter._MAX_HISTORY_GROUPS = 100
+                
+                mock_circuit = MagicMock()
+                with pytest.raises(RuntimeError):
+                    adapter.submit(mock_circuit, chip_id="ScQ-P10")
+
+
+# ---------------------------------------------------------------------------
+# Integration Tests (Skipped unless real credentials exist)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("QPANDA_API_KEY"),
+    reason="QPANDA_API_KEY not set"
+)
+class TestOriginQIntegration:
+    """Integration tests for OriginQ (requires real credentials)."""
+
+    def test_originq_connection(self) -> None:
+        """Test real OriginQ connection."""
+        from qpandalite.backend import get_backend
+        
+        backend = get_backend("originq", use_cache=False)
+        assert backend.is_available()
+
+    def test_originq_submit_and_query(self) -> None:
+        """Test real OriginQ submit and query workflow."""
+        from qpandalite.backend import get_backend
+        
+        backend = get_backend("originq", use_cache=False)
+        
+        # Submit a simple circuit
+        task_id = backend.submit(ORIGINIR_SINGLE, shots=1000, chip_id=72)
+        assert task_id
+        
+        # Query the task
+        result = backend.query(task_id)
+        assert "status" in result
+
+
+@pytest.mark.skipif(
+    not os.environ.get("QUAFU_API_TOKEN"),
+    reason="QUAFU_API_TOKEN not set"
+)
+class TestQuafuIntegration:
+    """Integration tests for Quafu (requires real credentials)."""
+
+    def test_quafu_connection(self) -> None:
+        """Test real Quafu connection."""
+        from qpandalite.backend import get_backend
+        
+        backend = get_backend("quafu", use_cache=False)
+        # Note: is_available might require quafu package to be installed
+
+    def test_quafu_translate_circuit(self) -> None:
+        """Test real Quafu circuit translation."""
+        try:
+            import quafu
+        except ImportError:
+            pytest.skip("quafu not installed")
+        
+        from qpandalite.task.adapters import QuafuAdapter
+        
+        adapter = QuafuAdapter()
+        circuit = adapter.translate_circuit(ORIGINIR_BELL)
+        assert circuit is not None
+
+
+@pytest.mark.skipif(
+    not os.environ.get("IBM_TOKEN"),
+    reason="IBM_TOKEN not set"
+)
+class TestIBMIntegration:
+    """Integration tests for IBM Quantum (requires real credentials)."""
+
+    def test_ibm_connection(self) -> None:
+        """Test real IBM Quantum connection."""
+        from qpandalite.backend import get_backend
+        
+        backend = get_backend("ibm", use_cache=False)
+        # Note: is_available might require qiskit packages
+
+    def test_ibm_translate_circuit(self) -> None:
+        """Test real IBM circuit translation."""
+        try:
+            import qiskit
+        except ImportError:
+            pytest.skip("qiskit not installed")
+        
+        from qpandalite.task.adapters import QiskitAdapter
+        
+        adapter = QiskitAdapter()
+        circuit = adapter.translate_circuit(ORIGINIR_BELL)
+        assert circuit is not None
+        assert hasattr(circuit, "num_qubits")
+
+
+# ---------------------------------------------------------------------------
+# End-to-End Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndWorkflow:
+    """End-to-end tests: Circuit → adapt → submit → query → result."""
+
+    def test_e2e_originq_mock(self) -> None:
+        """End-to-end test with mocked OriginQ backend."""
+        from qpandalite.circuit_builder import Circuit
+        from qpandalite.circuit_adapter import OriginQCircuitAdapter
+        from qpandalite.backend import OriginQBackend
+        
+        # Step 1: Create circuit
+        circuit = Circuit()
+        circuit.h(0)
+        circuit.cnot(0, 1)
+        circuit.measure(0, 1)
+        
+        # Step 2: Adapt circuit (mocked since pyqpanda3 may not be installed)
+        adapter = OriginQCircuitAdapter()
+        
+        # Step 3-5: Mock the backend operations
+        with patch("qpandalite.backend.OriginQBackend._create_adapter") as mock_create:
+            mock_backend_adapter = MagicMock()
+            mock_create.return_value = mock_backend_adapter
+            
+            backend = OriginQBackend()
+            
+            # Mock submit
+            mock_backend_adapter.submit.return_value = "e2e_task_123"
+            task_id = backend.submit(circuit, shots=1000)
+            assert task_id == "e2e_task_123"
+            
+            # Mock query
+            mock_backend_adapter.query.return_value = {
+                "status": "success",
+                "result": [{"00": 512, "11": 488}],
+            }
+            result = backend.query(task_id)
+            assert result["status"] == "success"
+
+    def test_e2e_quafu_mock(self) -> None:
+        """End-to-end test with mocked Quafu backend."""
+        from qpandalite.circuit_builder import Circuit
+        from qpandalite.backend import QuafuBackend
+        
+        # Step 1: Create circuit
+        circuit = Circuit()
+        circuit.h(0)
+        circuit.cnot(0, 1)
+        circuit.measure(0, 1)
+        
+        # Step 2-5: Mock the backend operations
+        with patch("qpandalite.backend.QuafuBackend._create_adapter") as mock_create:
+            mock_backend_adapter = MagicMock()
+            mock_create.return_value = mock_backend_adapter
+            
+            backend = QuafuBackend()
+            
+            # Mock translate
+            mock_translated_circuit = MagicMock()
+            mock_backend_adapter.translate_circuit.return_value = mock_translated_circuit
+            
+            # Mock submit
+            mock_backend_adapter.submit.return_value = "quafu_e2e_task_123"
+            task_id = backend.submit(mock_translated_circuit, shots=1000, chip_id="ScQ-P10")
+            assert task_id == "quafu_e2e_task_123"
+            
+            # Mock query
+            mock_backend_adapter.query.return_value = {
+                "status": "success",
+                "result": {"counts": {"00": 512, "11": 488}},
+            }
+            result = backend.query(task_id)
+            assert result["status"] == "success"
+
+    def test_e2e_ibm_mock(self) -> None:
+        """End-to-end test with mocked IBM backend."""
+        from qpandalite.circuit_builder import Circuit
+        from qpandalite.backend import IBMBackend
+        
+        # Step 1: Create circuit
+        circuit = Circuit()
+        circuit.h(0)
+        circuit.cnot(0, 1)
+        circuit.measure(0, 1)
+        
+        # Step 2-5: Mock the backend operations
+        with patch("qpandalite.backend.IBMBackend._create_adapter") as mock_create:
+            mock_backend_adapter = MagicMock()
+            mock_create.return_value = mock_backend_adapter
+            
+            backend = IBMBackend()
+            
+            # Mock translate
+            mock_translated_circuit = MagicMock()
+            mock_backend_adapter.translate_circuit.return_value = mock_translated_circuit
+            
+            # Mock submit
+            mock_backend_adapter.submit.return_value = "ibm_e2e_job_123"
+            task_id = backend.submit(mock_translated_circuit, shots=1000, chip_id="ibm_perth")
+            assert task_id == "ibm_e2e_job_123"
+            
+            # Mock query
+            mock_backend_adapter.query.return_value = {
+                "status": "success",
+                "result": [{"00": 512, "11": 488}],
+                "time": "Mon 01 Jan 2024, 12:00PM",
+                "backend_name": "ibm_perth",
+            }
+            result = backend.query(task_id)
+            assert result["status"] == "success"
+            assert "backend_name" in result
+
+    def test_complete_workflow_all_platforms_mock(self) -> None:
+        """Test complete workflow for all three platforms with mocks."""
+        from qpandalite.circuit_builder import Circuit
+        from qpandalite.backend import get_backend, BACKENDS
+        
+        # Create test circuit
+        circuit = Circuit()
+        circuit.h(0)
+        circuit.cnot(0, 1)
+        circuit.measure(0, 1)
+        
+        for platform_name in ["originq", "quafu", "ibm"]:
+            backend_class = BACKENDS[platform_name]
+            
+            with patch.object(backend_class, "_create_adapter") as mock_create:
+                mock_adapter = MagicMock()
+                mock_create.return_value = mock_adapter
+                
+                backend = get_backend(platform_name, use_cache=False)
+                
+                # Mock submit and query
+                mock_adapter.submit.return_value = f"{platform_name}_task_123"
+                mock_adapter.query.return_value = {
+                    "status": "success",
+                    "result": [{"00": 500, "11": 500}],
+                }
+                
+                # Execute workflow
+                task_id = backend.submit(circuit, shots=1000)
+                result = backend.query(task_id)
+                
+                assert task_id == f"{platform_name}_task_123"
+                assert result["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# Compatibility Tests with Existing Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompatibilityWithExistingTests:
+    """Ensure compatibility with existing test files."""
+
+    def test_config_imports(self) -> None:
+        """Test that config module imports work correctly."""
+        from qpandalite import config
+        from qpandalite.config import (
+            load_config,
+            save_config,
+            get_platform_config,
+            validate_config,
+            create_default_config,
+            DEFAULT_CONFIG,
+        )
+        
+        assert callable(load_config)
+        assert callable(save_config)
+        assert callable(get_platform_config)
+        assert callable(validate_config)
+        assert callable(create_default_config)
+        assert isinstance(DEFAULT_CONFIG, dict)
+
+    def test_circuit_adapter_imports(self) -> None:
+        """Test that circuit_adapter module imports work correctly."""
+        from qpandalite import circuit_adapter
+        from qpandalite.circuit_adapter import (
+            CircuitAdapter,
+            OriginQCircuitAdapter,
+            QuafuCircuitAdapter,
+            IBMCircuitAdapter,
+        )
+        
+        assert issubclass(OriginQCircuitAdapter, CircuitAdapter)
+        assert issubclass(QuafuCircuitAdapter, CircuitAdapter)
+        assert issubclass(IBMCircuitAdapter, CircuitAdapter)
+
+    def test_backend_imports(self) -> None:
+        """Test that backend module imports work correctly."""
+        from qpandalite.backend import (
+            QuantumBackend,
+            OriginQBackend,
+            QuafuBackend,
+            IBMBackend,
+            get_backend,
+            list_backends,
+            BACKENDS,
+        )
+        
+        assert callable(get_backend)
+        assert callable(list_backends)
+        assert isinstance(BACKENDS, dict)
+        assert "originq" in BACKENDS
+        assert "quafu" in BACKENDS
+        assert "ibm" in BACKENDS
+
+    def test_task_adapters_imports(self) -> None:
+        """Test that task.adapters module imports work correctly."""
+        from qpandalite.task.adapters import (
+            QuantumAdapter,
+            OriginQAdapter,
+            QuafuAdapter,
+            QiskitAdapter,
+            TASK_STATUS_SUCCESS,
+            TASK_STATUS_FAILED,
+            TASK_STATUS_RUNNING,
+        )
+        
+        assert TASK_STATUS_SUCCESS == "success"
+        assert TASK_STATUS_FAILED == "failed"
+        assert TASK_STATUS_RUNNING == "running"
+
+
+# ---------------------------------------------------------------------------
+# Cache Management Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCacheManagement:
+    """Tests for backend cache management."""
+
+    def test_save_and_load_cache(self, tmp_path: Path) -> None:
+        """Test saving and loading backend cache."""
+        from qpandalite.backend import OriginQBackend, _get_cache_file_path
+        
+        cache_dir = tmp_path / "cache"
+        backend = OriginQBackend(cache_dir=cache_dir, config={"test": "value"})
+        backend.name = "test_backend"
+        
+        # Save to cache
+        backend.save_to_cache()
+        
+        # Verify cache file exists
+        cache_file = _get_cache_file_path("originq", cache_dir)
+        assert cache_file.exists()
+
+    def test_clear_cache(self, tmp_path: Path) -> None:
+        """Test clearing backend cache."""
+        from qpandalite.backend import OriginQBackend, _get_cache_file_path
+        
+        cache_dir = tmp_path / "cache"
+        backend = OriginQBackend(cache_dir=cache_dir)
+        
+        # Save and verify
+        backend.save_to_cache()
+        cache_file = _get_cache_file_path("originq", cache_dir)
+        assert cache_file.exists()
+        
+        # Clear and verify
+        backend.clear_cache()
+        assert not cache_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/qpandalite/test/test_cloud_platforms.py
+++ b/qpandalite/test/test_cloud_platforms.py
@@ -343,16 +343,23 @@ class TestCircuitAdapters:
         """Test OriginQ adapter raises error when pyqpanda3 not installed."""
         from qpandalite.circuit_adapter import OriginQCircuitAdapter
         from qpandalite.circuit_builder import Circuit
+        from unittest.mock import patch
         
+        # Create a fresh adapter instance with cleared imports
         adapter = OriginQCircuitAdapter()
-        adapter._pyqpanda3 = None  # Simulate missing import
+        adapter._pyqpanda3 = None
         adapter._convert_originir = None
         
         circuit = Circuit()
         circuit.h(0)
         
-        with pytest.raises(RuntimeError, match="pyqpanda3"):
-            adapter.adapt(circuit)
+        # Mock the import to raise ImportError
+        def mock_import(*args, **kwargs):
+            raise ImportError("No module named 'pyqpanda3'")
+        
+        with patch('builtins.__import__', side_effect=mock_import):
+            with pytest.raises(RuntimeError, match="pyqpanda3"):
+                adapter.adapt(circuit)
 
     def test_quafu_adapter_without_quafu(self) -> None:
         """Test Quafu adapter raises error when quafu not installed."""

--- a/qpandalite/test/test_config.py
+++ b/qpandalite/test/test_config.py
@@ -1,0 +1,417 @@
+"""Tests for qpandalite.config module."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from qpandalite import config
+from qpandalite.config import (
+    DEFAULT_CONFIG,
+    ConfigError,
+    ConfigValidationError,
+    PlatformNotFoundError,
+    ProfileNotFoundError,
+    create_default_config,
+    get_active_profile,
+    get_ibm_config,
+    get_originq_config,
+    get_platform_config,
+    get_quafu_config,
+    load_config,
+    save_config,
+    set_active_profile,
+    update_platform_config,
+    validate_config,
+)
+
+
+class TestLoadConfig:
+    """Tests for load_config function."""
+
+    def test_load_default_when_file_not_exists(self, tmp_path: Path) -> None:
+        """Test that default config is returned when file doesn't exist."""
+        non_existent = tmp_path / "non_existent.yml"
+        result = load_config(non_existent)
+        assert result == DEFAULT_CONFIG
+
+    def test_load_existing_config(self, tmp_path: Path) -> None:
+        """Test loading an existing configuration file."""
+        config_file = tmp_path / "test_config.yml"
+        test_config = {
+            "default": {
+                "originq": {"token": "test_token"},
+            }
+        }
+        save_config(test_config, config_file)
+        result = load_config(config_file)
+        assert result == test_config
+
+    def test_load_empty_file_returns_default(self, tmp_path: Path) -> None:
+        """Test that empty file returns default config."""
+        config_file = tmp_path / "empty.yml"
+        config_file.write_text("")
+        result = load_config(config_file)
+        assert result == DEFAULT_CONFIG
+
+    def test_load_invalid_yaml_raises_error(self, tmp_path: Path) -> None:
+        """Test that invalid YAML raises ConfigError."""
+        config_file = tmp_path / "invalid.yml"
+        config_file.write_text("invalid: yaml: [")
+        with pytest.raises(ConfigError):
+            load_config(config_file)
+
+
+class TestSaveConfig:
+    """Tests for save_config function."""
+
+    def test_save_config_creates_file(self, tmp_path: Path) -> None:
+        """Test that save_config creates the configuration file."""
+        config_file = tmp_path / "config.yml"
+        test_config = {"default": {"originq": {"token": "test"}}}
+        save_config(test_config, config_file)
+        assert config_file.exists()
+
+    def test_save_config_creates_directory(self, tmp_path: Path) -> None:
+        """Test that save_config creates parent directories."""
+        config_file = tmp_path / "nested" / "dir" / "config.yml"
+        test_config = {"default": {"originq": {"token": "test"}}}
+        save_config(test_config, config_file)
+        assert config_file.exists()
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        """Test that saved config can be loaded back correctly."""
+        config_file = tmp_path / "config.yml"
+        test_config = {
+            "default": {
+                "originq": {"token": "originq_token", "submit_url": "http://submit"},
+                "quafu": {"token": "quafu_token"},
+                "ibm": {"token": "ibm_token", "proxy": {"http": "http://proxy"}},
+            },
+            "prod": {
+                "originq": {"token": "prod_token"},
+            },
+        }
+        save_config(test_config, config_file)
+        loaded = load_config(config_file)
+        assert loaded == test_config
+
+
+class TestGetPlatformConfig:
+    """Tests for get_platform_config function."""
+
+    def test_get_originq_config(self, tmp_path: Path) -> None:
+        """Test getting OriginQ configuration."""
+        config_file = tmp_path / "config.yml"
+        test_config = {
+            "default": {
+                "originq": {
+                    "token": "originq_token",
+                    "submit_url": "http://submit",
+                    "query_url": "http://query",
+                },
+            }
+        }
+        save_config(test_config, config_file)
+        result = get_platform_config("originq", config_path=config_file)
+        assert result["token"] == "originq_token"
+        assert result["submit_url"] == "http://submit"
+
+    def test_get_quafu_config(self, tmp_path: Path) -> None:
+        """Test getting Quafu configuration."""
+        config_file = tmp_path / "config.yml"
+        test_config = {"default": {"quafu": {"token": "quafu_token"}}}
+        save_config(test_config, config_file)
+        result = get_platform_config("quafu", config_path=config_file)
+        assert result["token"] == "quafu_token"
+
+    def test_get_ibm_config_with_proxy(self, tmp_path: Path) -> None:
+        """Test getting IBM configuration with proxy."""
+        config_file = tmp_path / "config.yml"
+        test_config = {
+            "default": {
+                "ibm": {
+                    "token": "ibm_token",
+                    "proxy": {"http": "http://proxy:8080", "https": "https://proxy:8080"},
+                },
+            }
+        }
+        save_config(test_config, config_file)
+        result = get_platform_config("ibm", config_path=config_file)
+        assert result["token"] == "ibm_token"
+        assert result["proxy"]["http"] == "http://proxy:8080"
+
+    def test_get_config_with_different_profile(self, tmp_path: Path) -> None:
+        """Test getting configuration with different profile."""
+        config_file = tmp_path / "config.yml"
+        test_config = {
+            "default": {"originq": {"token": "default_token"}},
+            "prod": {"originq": {"token": "prod_token"}},
+        }
+        save_config(test_config, config_file)
+        result = get_platform_config("originq", profile="prod", config_path=config_file)
+        assert result["token"] == "prod_token"
+
+    def test_get_config_unsupported_platform_raises(self, tmp_path: Path) -> None:
+        """Test that unsupported platform raises PlatformNotFoundError."""
+        config_file = tmp_path / "config.yml"
+        save_config(DEFAULT_CONFIG, config_file)
+        with pytest.raises(PlatformNotFoundError):
+            get_platform_config("unsupported", config_path=config_file)
+
+    def test_get_config_missing_profile_raises(self, tmp_path: Path) -> None:
+        """Test that missing profile raises ProfileNotFoundError."""
+        config_file = tmp_path / "config.yml"
+        save_config(DEFAULT_CONFIG, config_file)
+        with pytest.raises(ProfileNotFoundError):
+            get_platform_config("originq", profile="nonexistent", config_path=config_file)
+
+    def test_get_config_missing_platform_raises(self, tmp_path: Path) -> None:
+        """Test that missing platform in profile raises ConfigError."""
+        config_file = tmp_path / "config.yml"
+        test_config = {"default": {}}  # No platforms configured
+        save_config(test_config, config_file)
+        with pytest.raises(ConfigError):
+            get_platform_config("originq", config_path=config_file)
+
+
+class TestValidateConfig:
+    """Tests for validate_config function."""
+
+    def test_validate_valid_config(self) -> None:
+        """Test validating a valid configuration."""
+        valid_config = {
+            "default": {
+                "originq": {"token": "t", "submit_url": "s", "query_url": "q"},
+                "quafu": {"token": "t"},
+                "ibm": {"token": "t"},
+            }
+        }
+        errors = validate_config(valid_config)
+        assert errors == []
+
+    def test_validate_empty_config(self) -> None:
+        """Test validating empty configuration."""
+        errors = validate_config({})
+        assert len(errors) == 1
+        assert "empty" in errors[0].lower()
+
+    def test_validate_non_dict_config(self) -> None:
+        """Test validating non-dictionary configuration."""
+        errors = validate_config("not a dict")
+        assert len(errors) == 1
+        assert "dictionary" in errors[0].lower()
+
+    def test_validate_missing_required_fields(self) -> None:
+        """Test validating configuration with missing required fields."""
+        invalid_config = {
+            "default": {
+                "originq": {"token": "t"},  # Missing submit_url and query_url
+            }
+        }
+        errors = validate_config(invalid_config)
+        assert len(errors) == 2
+        assert any("submit_url" in e for e in errors)
+        assert any("query_url" in e for e in errors)
+
+    def test_validate_invalid_proxy_config(self) -> None:
+        """Test validating IBM configuration with invalid proxy."""
+        invalid_config = {
+            "default": {
+                "ibm": {"token": "t", "proxy": "not a dict"},
+            }
+        }
+        errors = validate_config(invalid_config)
+        assert len(errors) == 1
+        assert "proxy" in errors[0].lower()
+
+    def test_validate_profile_not_dict(self) -> None:
+        """Test validating configuration where profile is not a dict."""
+        invalid_config = {"default": "not a dict"}
+        errors = validate_config(invalid_config)
+        assert len(errors) == 1
+        assert "dictionary" in errors[0].lower()
+
+
+class TestCreateDefaultConfig:
+    """Tests for create_default_config function."""
+
+    def test_create_default_config(self, tmp_path: Path) -> None:
+        """Test creating default configuration file."""
+        config_file = tmp_path / "config.yml"
+        create_default_config(config_file)
+        assert config_file.exists()
+        loaded = load_config(config_file)
+        assert loaded == DEFAULT_CONFIG
+
+    def test_create_default_config_does_not_overwrite(self, tmp_path: Path) -> None:
+        """Test that create_default_config doesn't overwrite existing file."""
+        config_file = tmp_path / "config.yml"
+        custom_config = {"custom": {"key": "value"}}
+        save_config(custom_config, config_file)
+        create_default_config(config_file)
+        loaded = load_config(config_file)
+        assert loaded == custom_config
+
+
+class TestUpdatePlatformConfig:
+    """Tests for update_platform_config function."""
+
+    def test_update_existing_platform(self, tmp_path: Path) -> None:
+        """Test updating an existing platform configuration."""
+        config_file = tmp_path / "config.yml"
+        create_default_config(config_file)
+
+        new_config = {"token": "new_token", "submit_url": "http://new"}
+        update_platform_config("originq", new_config, config_path=config_file)
+
+        result = get_platform_config("originq", config_path=config_file)
+        assert result["token"] == "new_token"
+        assert result["submit_url"] == "http://new"
+
+    def test_update_create_new_profile(self, tmp_path: Path) -> None:
+        """Test update creates new profile if it doesn't exist."""
+        config_file = tmp_path / "config.yml"
+        create_default_config(config_file)
+
+        new_config = {"token": "test_token"}
+        update_platform_config("quafu", new_config, profile="test", config_path=config_file)
+
+        result = get_platform_config("quafu", profile="test", config_path=config_file)
+        assert result["token"] == "test_token"
+
+    def test_update_unsupported_platform_raises(self, tmp_path: Path) -> None:
+        """Test that updating unsupported platform raises PlatformNotFoundError."""
+        config_file = tmp_path / "config.yml"
+        create_default_config(config_file)
+        with pytest.raises(PlatformNotFoundError):
+            update_platform_config("unsupported", {}, config_path=config_file)
+
+
+class TestActiveProfile:
+    """Tests for get_active_profile and set_active_profile functions."""
+
+    def test_get_active_profile_default(self, tmp_path: Path) -> None:
+        """Test getting default active profile."""
+        config_file = tmp_path / "config.yml"
+        create_default_config(config_file)
+        result = get_active_profile(config_file)
+        assert result == "default"
+
+    def test_get_active_profile_from_env(self, tmp_path: Path) -> None:
+        """Test getting active profile from environment variable."""
+        config_file = tmp_path / "config.yml"
+        create_default_config(config_file)
+        with mock.patch.dict(os.environ, {"QPANDALITE_PROFILE": "prod"}):
+            result = get_active_profile(config_file)
+            assert result == "prod"
+
+    def test_get_active_profile_from_config(self, tmp_path: Path) -> None:
+        """Test getting active profile from configuration file."""
+        config_file = tmp_path / "config.yml"
+        config = {"active_profile": "staging", "default": {}}
+        save_config(config, config_file)
+        result = get_active_profile(config_file)
+        assert result == "staging"
+
+    def test_env_overrides_config(self, tmp_path: Path) -> None:
+        """Test that environment variable overrides config file."""
+        config_file = tmp_path / "config.yml"
+        config = {"active_profile": "staging", "default": {}}
+        save_config(config, config_file)
+        with mock.patch.dict(os.environ, {"QPANDALITE_PROFILE": "prod"}):
+            result = get_active_profile(config_file)
+            assert result == "prod"
+
+    def test_set_active_profile(self, tmp_path: Path) -> None:
+        """Test setting active profile."""
+        config_file = tmp_path / "config.yml"
+        config = {"default": {}, "prod": {}}
+        save_config(config, config_file)
+        set_active_profile("prod", config_file)
+        result = get_active_profile(config_file)
+        assert result == "prod"
+
+    def test_set_active_profile_invalid_raises(self, tmp_path: Path) -> None:
+        """Test that setting non-existent active profile raises error."""
+        config_file = tmp_path / "config.yml"
+        create_default_config(config_file)
+        with pytest.raises(ProfileNotFoundError):
+            set_active_profile("nonexistent", config_file)
+
+
+class TestConvenienceFunctions:
+    """Tests for convenience functions (get_originq_config, etc.)."""
+
+    def test_get_originq_config(self, tmp_path: Path) -> None:
+        """Test get_originq_config convenience function."""
+        config_file = tmp_path / "config.yml"
+        test_config = {"default": {"originq": {"token": "test_token"}}}
+        save_config(test_config, config_file)
+
+        with mock.patch.object(config, "CONFIG_FILE", config_file):
+            result = get_originq_config()
+            assert result["token"] == "test_token"
+
+    def test_get_quafu_config(self, tmp_path: Path) -> None:
+        """Test get_quafu_config convenience function."""
+        config_file = tmp_path / "config.yml"
+        test_config = {"default": {"quafu": {"token": "test_token"}}}
+        save_config(test_config, config_file)
+
+        with mock.patch.object(config, "CONFIG_FILE", config_file):
+            result = get_quafu_config()
+            assert result["token"] == "test_token"
+
+    def test_get_ibm_config(self, tmp_path: Path) -> None:
+        """Test get_ibm_config convenience function."""
+        config_file = tmp_path / "config.yml"
+        test_config = {"default": {"ibm": {"token": "test_token"}}}
+        save_config(test_config, config_file)
+
+        with mock.patch.object(config, "CONFIG_FILE", config_file):
+            result = get_ibm_config()
+            assert result["token"] == "test_token"
+
+
+class TestDefaultConfig:
+    """Tests for DEFAULT_CONFIG constant."""
+
+    def test_default_config_structure(self) -> None:
+        """Test that DEFAULT_CONFIG has expected structure."""
+        assert "default" in DEFAULT_CONFIG
+        assert "originq" in DEFAULT_CONFIG["default"]
+        assert "quafu" in DEFAULT_CONFIG["default"]
+        assert "ibm" in DEFAULT_CONFIG["default"]
+
+    def test_originq_default_fields(self) -> None:
+        """Test OriginQ default configuration fields."""
+        originq = DEFAULT_CONFIG["default"]["originq"]
+        assert "token" in originq
+        assert "submit_url" in originq
+        assert "query_url" in originq
+        assert "available_qubits" in originq
+        assert "available_topology" in originq
+        assert "task_group_size" in originq
+        assert originq["task_group_size"] == 200
+
+    def test_quafu_default_fields(self) -> None:
+        """Test Quafu default configuration fields."""
+        quafu = DEFAULT_CONFIG["default"]["quafu"]
+        assert "token" in quafu
+
+    def test_ibm_default_fields(self) -> None:
+        """Test IBM default configuration fields."""
+        ibm = DEFAULT_CONFIG["default"]["ibm"]
+        assert "token" in ibm
+        assert "proxy" in ibm
+        assert "http" in ibm["proxy"]
+        assert "https" in ibm["proxy"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/qpandalite/test/test_network_utils.py
+++ b/qpandalite/test/test_network_utils.py
@@ -23,25 +23,22 @@ class TestDetectSystemProxy(unittest.TestCase):
 
     def test_detect_no_proxy(self):
         """Test detection when no proxy is set."""
-        # Clear all proxy env vars using mock
-        with patch.dict(os.environ, {}, clear=False):
-            for key in ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"]:
-                os.environ.pop(key, None)
-
+        # Use clear=True to completely isolate the test environment
+        with patch.dict(os.environ, {}, clear=True):
             result = detect_system_proxy()
             self.assertIsNone(result["http"])
             self.assertIsNone(result["https"])
 
     def test_detect_http_proxy(self):
         """Test detection of HTTP proxy."""
-        with patch.dict(os.environ, {"HTTP_PROXY": "http://proxy.example.com:8080"}, clear=False):
+        with patch.dict(os.environ, {"HTTP_PROXY": "http://proxy.example.com:8080"}, clear=True):
             result = detect_system_proxy()
             self.assertEqual(result["http"], "http://proxy.example.com:8080")
             self.assertIsNone(result["https"])
 
     def test_detect_https_proxy(self):
         """Test detection of HTTPS_PROXY."""
-        with patch.dict(os.environ, {"HTTPS_PROXY": "https://proxy.example.com:8080"}, clear=False):
+        with patch.dict(os.environ, {"HTTPS_PROXY": "https://proxy.example.com:8080"}, clear=True):
             result = detect_system_proxy()
             self.assertEqual(result["https"], "https://proxy.example.com:8080")
 
@@ -51,7 +48,7 @@ class TestDetectSystemProxy(unittest.TestCase):
             "HTTP_PROXY": "http://http-proxy.example.com:8080",
             "HTTPS_PROXY": "https://https-proxy.example.com:8443"
         }
-        with patch.dict(os.environ, env_vars, clear=False):
+        with patch.dict(os.environ, env_vars, clear=True):
             result = detect_system_proxy()
             self.assertEqual(result["http"], "http://http-proxy.example.com:8080")
             self.assertEqual(result["https"], "https://https-proxy.example.com:8443")
@@ -59,10 +56,7 @@ class TestDetectSystemProxy(unittest.TestCase):
     @unittest.skipIf(platform.system() == "Windows", "Windows env vars are case-insensitive")
     def test_detect_http_proxy_lowercase(self):
         """Test detection of http_proxy (lowercase) - Unix only."""
-        with patch.dict(os.environ, {"http_proxy": "http://proxy.example.com:8080"}, clear=False):
-            # Ensure uppercase is not set
-            os.environ.pop("HTTP_PROXY", None)
-
+        with patch.dict(os.environ, {"http_proxy": "http://proxy.example.com:8080"}, clear=True):
             result = detect_system_proxy()
             self.assertEqual(result["http"], "http://proxy.example.com:8080")
 
@@ -73,7 +67,7 @@ class TestDetectSystemProxy(unittest.TestCase):
             "HTTP_PROXY": "http://uppercase.example.com:8080",
             "http_proxy": "http://lowercase.example.com:9090"
         }
-        with patch.dict(os.environ, env_vars, clear=False):
+        with patch.dict(os.environ, env_vars, clear=True):
             result = detect_system_proxy()
             self.assertEqual(result["http"], "http://uppercase.example.com:8080")
 

--- a/qpandalite/test/test_network_utils.py
+++ b/qpandalite/test/test_network_utils.py
@@ -20,74 +20,65 @@ from qpandalite.network_utils import (
 class TestDetectSystemProxy(unittest.TestCase):
     """Tests for detect_system_proxy function."""
 
-    def setUp(self):
-        """Save original environment variables."""
-        self.original_env = {
-            "HTTP_PROXY": os.environ.get("HTTP_PROXY"),
-            "http_proxy": os.environ.get("http_proxy"),
-            "HTTPS_PROXY": os.environ.get("HTTPS_PROXY"),
-            "https_proxy": os.environ.get("https_proxy"),
-        }
-
-    def tearDown(self):
-        """Restore original environment variables."""
-        for key, value in self.original_env.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
-
     def test_detect_no_proxy(self):
         """Test detection when no proxy is set."""
-        # Clear all proxy env vars
-        for key in ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"]:
-            os.environ.pop(key, None)
+        # Clear all proxy env vars using mock
+        with patch.dict(os.environ, {}, clear=False):
+            for key in ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"]:
+                os.environ.pop(key, None)
 
-        result = detect_system_proxy()
-        self.assertIsNone(result["http"])
-        self.assertIsNone(result["https"])
+            result = detect_system_proxy()
+            self.assertIsNone(result["http"])
+            self.assertIsNone(result["https"])
 
     def test_detect_http_proxy_uppercase(self):
         """Test detection of HTTP_PROXY (uppercase)."""
-        os.environ["HTTP_PROXY"] = "http://proxy.example.com:8080"
-        os.environ.pop("http_proxy", None)
+        with patch.dict(os.environ, {"HTTP_PROXY": "http://proxy.example.com:8080"}, clear=False):
+            # Ensure lowercase is not set
+            os.environ.pop("http_proxy", None)
 
-        result = detect_system_proxy()
-        self.assertEqual(result["http"], "http://proxy.example.com:8080")
-        self.assertIsNone(result["https"])
+            result = detect_system_proxy()
+            self.assertEqual(result["http"], "http://proxy.example.com:8080")
+            self.assertIsNone(result["https"])
 
     def test_detect_http_proxy_lowercase(self):
         """Test detection of http_proxy (lowercase)."""
-        os.environ["http_proxy"] = "http://proxy.example.com:8080"
-        os.environ.pop("HTTP_PROXY", None)
+        with patch.dict(os.environ, {"http_proxy": "http://proxy.example.com:8080"}, clear=False):
+            # Ensure uppercase is not set
+            os.environ.pop("HTTP_PROXY", None)
 
-        result = detect_system_proxy()
-        self.assertEqual(result["http"], "http://proxy.example.com:8080")
+            result = detect_system_proxy()
+            self.assertEqual(result["http"], "http://proxy.example.com:8080")
 
     def test_detect_https_proxy(self):
         """Test detection of HTTPS_PROXY."""
-        os.environ["HTTPS_PROXY"] = "https://proxy.example.com:8080"
-        os.environ.pop("https_proxy", None)
+        with patch.dict(os.environ, {"HTTPS_PROXY": "https://proxy.example.com:8080"}, clear=False):
+            # Ensure lowercase is not set
+            os.environ.pop("https_proxy", None)
 
-        result = detect_system_proxy()
-        self.assertEqual(result["https"], "https://proxy.example.com:8080")
+            result = detect_system_proxy()
+            self.assertEqual(result["https"], "https://proxy.example.com:8080")
 
     def test_detect_both_proxies(self):
         """Test detection of both HTTP and HTTPS proxies."""
-        os.environ["HTTP_PROXY"] = "http://http-proxy.example.com:8080"
-        os.environ["HTTPS_PROXY"] = "https://https-proxy.example.com:8443"
-
-        result = detect_system_proxy()
-        self.assertEqual(result["http"], "http://http-proxy.example.com:8080")
-        self.assertEqual(result["https"], "https://https-proxy.example.com:8443")
+        env_vars = {
+            "HTTP_PROXY": "http://http-proxy.example.com:8080",
+            "HTTPS_PROXY": "https://https-proxy.example.com:8443"
+        }
+        with patch.dict(os.environ, env_vars, clear=False):
+            result = detect_system_proxy()
+            self.assertEqual(result["http"], "http://http-proxy.example.com:8080")
+            self.assertEqual(result["https"], "https://https-proxy.example.com:8443")
 
     def test_uppercase_takes_precedence(self):
         """Test that uppercase env vars take precedence over lowercase."""
-        os.environ["HTTP_PROXY"] = "http://uppercase.example.com:8080"
-        os.environ["http_proxy"] = "http://lowercase.example.com:9090"
-
-        result = detect_system_proxy()
-        self.assertEqual(result["http"], "http://uppercase.example.com:8080")
+        env_vars = {
+            "HTTP_PROXY": "http://uppercase.example.com:8080",
+            "http_proxy": "http://lowercase.example.com:9090"
+        }
+        with patch.dict(os.environ, env_vars, clear=False):
+            result = detect_system_proxy()
+            self.assertEqual(result["http"], "http://uppercase.example.com:8080")
 
 
 class TestCheckProxyConnectivity(unittest.TestCase):

--- a/qpandalite/test/test_network_utils.py
+++ b/qpandalite/test/test_network_utils.py
@@ -6,6 +6,7 @@ This module tests the proxy detection and connectivity checking utilities.
 from __future__ import annotations
 
 import os
+import platform
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -31,31 +32,16 @@ class TestDetectSystemProxy(unittest.TestCase):
             self.assertIsNone(result["http"])
             self.assertIsNone(result["https"])
 
-    def test_detect_http_proxy_uppercase(self):
-        """Test detection of HTTP_PROXY (uppercase)."""
+    def test_detect_http_proxy(self):
+        """Test detection of HTTP proxy."""
         with patch.dict(os.environ, {"HTTP_PROXY": "http://proxy.example.com:8080"}, clear=False):
-            # Ensure lowercase is not set
-            os.environ.pop("http_proxy", None)
-
             result = detect_system_proxy()
             self.assertEqual(result["http"], "http://proxy.example.com:8080")
             self.assertIsNone(result["https"])
 
-    def test_detect_http_proxy_lowercase(self):
-        """Test detection of http_proxy (lowercase)."""
-        with patch.dict(os.environ, {"http_proxy": "http://proxy.example.com:8080"}, clear=False):
-            # Ensure uppercase is not set
-            os.environ.pop("HTTP_PROXY", None)
-
-            result = detect_system_proxy()
-            self.assertEqual(result["http"], "http://proxy.example.com:8080")
-
     def test_detect_https_proxy(self):
         """Test detection of HTTPS_PROXY."""
         with patch.dict(os.environ, {"HTTPS_PROXY": "https://proxy.example.com:8080"}, clear=False):
-            # Ensure lowercase is not set
-            os.environ.pop("https_proxy", None)
-
             result = detect_system_proxy()
             self.assertEqual(result["https"], "https://proxy.example.com:8080")
 
@@ -70,8 +56,19 @@ class TestDetectSystemProxy(unittest.TestCase):
             self.assertEqual(result["http"], "http://http-proxy.example.com:8080")
             self.assertEqual(result["https"], "https://https-proxy.example.com:8443")
 
+    @unittest.skipIf(platform.system() == "Windows", "Windows env vars are case-insensitive")
+    def test_detect_http_proxy_lowercase(self):
+        """Test detection of http_proxy (lowercase) - Unix only."""
+        with patch.dict(os.environ, {"http_proxy": "http://proxy.example.com:8080"}, clear=False):
+            # Ensure uppercase is not set
+            os.environ.pop("HTTP_PROXY", None)
+
+            result = detect_system_proxy()
+            self.assertEqual(result["http"], "http://proxy.example.com:8080")
+
+    @unittest.skipIf(platform.system() == "Windows", "Windows env vars are case-insensitive")
     def test_uppercase_takes_precedence(self):
-        """Test that uppercase env vars take precedence over lowercase."""
+        """Test that uppercase env vars take precedence over lowercase - Unix only."""
         env_vars = {
             "HTTP_PROXY": "http://uppercase.example.com:8080",
             "http_proxy": "http://lowercase.example.com:9090"

--- a/qpandalite/test/test_network_utils.py
+++ b/qpandalite/test/test_network_utils.py
@@ -1,0 +1,302 @@
+"""Tests for network_utils module.
+
+This module tests the proxy detection and connectivity checking utilities.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from qpandalite.network_utils import (
+    check_proxy_connectivity,
+    detect_system_proxy,
+    get_ibm_proxy_from_config,
+    test_ibm_connectivity,
+)
+
+
+class TestDetectSystemProxy(unittest.TestCase):
+    """Tests for detect_system_proxy function."""
+
+    def setUp(self):
+        """Save original environment variables."""
+        self.original_env = {
+            "HTTP_PROXY": os.environ.get("HTTP_PROXY"),
+            "http_proxy": os.environ.get("http_proxy"),
+            "HTTPS_PROXY": os.environ.get("HTTPS_PROXY"),
+            "https_proxy": os.environ.get("https_proxy"),
+        }
+
+    def tearDown(self):
+        """Restore original environment variables."""
+        for key, value in self.original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_detect_no_proxy(self):
+        """Test detection when no proxy is set."""
+        # Clear all proxy env vars
+        for key in ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"]:
+            os.environ.pop(key, None)
+
+        result = detect_system_proxy()
+        self.assertIsNone(result["http"])
+        self.assertIsNone(result["https"])
+
+    def test_detect_http_proxy_uppercase(self):
+        """Test detection of HTTP_PROXY (uppercase)."""
+        os.environ["HTTP_PROXY"] = "http://proxy.example.com:8080"
+        os.environ.pop("http_proxy", None)
+
+        result = detect_system_proxy()
+        self.assertEqual(result["http"], "http://proxy.example.com:8080")
+        self.assertIsNone(result["https"])
+
+    def test_detect_http_proxy_lowercase(self):
+        """Test detection of http_proxy (lowercase)."""
+        os.environ["http_proxy"] = "http://proxy.example.com:8080"
+        os.environ.pop("HTTP_PROXY", None)
+
+        result = detect_system_proxy()
+        self.assertEqual(result["http"], "http://proxy.example.com:8080")
+
+    def test_detect_https_proxy(self):
+        """Test detection of HTTPS_PROXY."""
+        os.environ["HTTPS_PROXY"] = "https://proxy.example.com:8080"
+        os.environ.pop("https_proxy", None)
+
+        result = detect_system_proxy()
+        self.assertEqual(result["https"], "https://proxy.example.com:8080")
+
+    def test_detect_both_proxies(self):
+        """Test detection of both HTTP and HTTPS proxies."""
+        os.environ["HTTP_PROXY"] = "http://http-proxy.example.com:8080"
+        os.environ["HTTPS_PROXY"] = "https://https-proxy.example.com:8443"
+
+        result = detect_system_proxy()
+        self.assertEqual(result["http"], "http://http-proxy.example.com:8080")
+        self.assertEqual(result["https"], "https://https-proxy.example.com:8443")
+
+    def test_uppercase_takes_precedence(self):
+        """Test that uppercase env vars take precedence over lowercase."""
+        os.environ["HTTP_PROXY"] = "http://uppercase.example.com:8080"
+        os.environ["http_proxy"] = "http://lowercase.example.com:9090"
+
+        result = detect_system_proxy()
+        self.assertEqual(result["http"], "http://uppercase.example.com:8080")
+
+
+class TestCheckProxyConnectivity(unittest.TestCase):
+    """Tests for check_proxy_connectivity function."""
+
+    @patch("socket.create_connection")
+    def test_proxy_connectivity_success(self, mock_create_connection):
+        """Test successful proxy connectivity check."""
+        mock_socket = MagicMock()
+        mock_create_connection.return_value = mock_socket
+
+        result = check_proxy_connectivity("http://proxy.example.com:8080")
+
+        self.assertTrue(result)
+        mock_create_connection.assert_called_once()
+        mock_socket.close.assert_called_once()
+
+    @patch("socket.create_connection")
+    def test_proxy_connectivity_failure(self, mock_create_connection):
+        """Test failed proxy connectivity check."""
+        mock_create_connection.side_effect = OSError("Connection refused")
+
+        result = check_proxy_connectivity("http://proxy.example.com:8080")
+
+        self.assertFalse(result)
+
+    def test_proxy_connectivity_invalid_url(self):
+        """Test connectivity check with invalid URL."""
+        result = check_proxy_connectivity("not-a-valid-url")
+        self.assertFalse(result)
+
+    def test_proxy_connectivity_default_port(self):
+        """Test connectivity check with URL without port."""
+        with patch("socket.create_connection") as mock_create_connection:
+            mock_socket = MagicMock()
+            mock_create_connection.return_value = mock_socket
+
+            result = check_proxy_connectivity("http://proxy.example.com")
+
+            self.assertTrue(result)
+            # Should use default port 80 for http
+            call_args = mock_create_connection.call_args
+            self.assertEqual(call_args[0][0][1], 80)
+
+
+class TestGetIbmProxyFromConfig(unittest.TestCase):
+    """Tests for get_ibm_proxy_from_config function."""
+
+    def test_no_proxy_config(self):
+        """Test with no proxy configuration."""
+        config = {"token": "test_token"}
+        result = get_ibm_proxy_from_config(config)
+        self.assertIsNone(result)
+
+    def test_empty_proxy_config(self):
+        """Test with empty proxy configuration."""
+        config = {"token": "test_token", "proxy": {}}
+        result = get_ibm_proxy_from_config(config)
+        self.assertIsNone(result)
+
+    def test_http_proxy_only(self):
+        """Test with only HTTP proxy configured."""
+        config = {
+            "token": "test_token",
+            "proxy": {"http": "http://proxy.example.com:8080"}
+        }
+        result = get_ibm_proxy_from_config(config)
+        self.assertEqual(result, {"http": "http://proxy.example.com:8080"})
+
+    def test_https_proxy_only(self):
+        """Test with only HTTPS proxy configured."""
+        config = {
+            "token": "test_token",
+            "proxy": {"https": "https://proxy.example.com:8443"}
+        }
+        result = get_ibm_proxy_from_config(config)
+        self.assertEqual(result, {"https": "https://proxy.example.com:8443"})
+
+    def test_both_proxies(self):
+        """Test with both HTTP and HTTPS proxies configured."""
+        config = {
+            "token": "test_token",
+            "proxy": {
+                "http": "http://http-proxy.example.com:8080",
+                "https": "https://https-proxy.example.com:8443"
+            }
+        }
+        result = get_ibm_proxy_from_config(config)
+        self.assertEqual(result, {
+            "http": "http://http-proxy.example.com:8080",
+            "https": "https://https-proxy.example.com:8443"
+        })
+
+    def test_empty_proxy_values(self):
+        """Test with empty proxy values."""
+        config = {
+            "token": "test_token",
+            "proxy": {
+                "http": "",
+                "https": ""
+            }
+        }
+        result = get_ibm_proxy_from_config(config)
+        self.assertIsNone(result)
+
+
+class TestTestIbmConnectivity(unittest.TestCase):
+    """Tests for test_ibm_connectivity function."""
+
+    def setUp(self):
+        """Save original environment variables."""
+        self.original_token = os.environ.get("IBM_TOKEN")
+
+    def tearDown(self):
+        """Restore original environment variables."""
+        if self.original_token is None:
+            os.environ.pop("IBM_TOKEN", None)
+        else:
+            os.environ["IBM_TOKEN"] = self.original_token
+
+    def test_no_token_provided_and_no_env_var(self):
+        """Test when no token is provided and no env var is set."""
+        os.environ.pop("IBM_TOKEN", None)
+
+        result = test_ibm_connectivity()
+
+        self.assertFalse(result["success"])
+        self.assertIn("token not provided", result["message"])
+        self.assertIsNone(result["response_time_ms"])
+
+    def test_uses_env_var_token(self):
+        """Test that IBM_TOKEN env var is used when token not provided."""
+        os.environ["IBM_TOKEN"] = "env_token_123"
+
+        # Mock the actual HTTP request to avoid network calls
+        with patch("urllib.request.OpenerDirector.open") as mock_open:
+            mock_response = MagicMock()
+            mock_response.getcode.return_value = 200
+            mock_open.return_value.__enter__ = MagicMock(return_value=mock_response)
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = test_ibm_connectivity()
+
+            # Should attempt to connect (actual result depends on mock)
+            self.assertIsNotNone(result)
+
+    def test_with_explicit_proxy(self):
+        """Test with explicit proxy configuration."""
+        proxy = {"https": "http://proxy.example.com:8080"}
+
+        result = test_ibm_connectivity(
+            token="test_token",
+            proxy=proxy
+        )
+
+        # Verify proxy is recorded in result
+        self.assertEqual(result["proxy_used"], proxy)
+
+    def test_with_string_proxy(self):
+        """Test with string proxy configuration."""
+        with patch("urllib.request.OpenerDirector.open") as mock_open:
+            mock_response = MagicMock()
+            mock_response.getcode.return_value = 200
+            mock_open.return_value.__enter__ = MagicMock(return_value=mock_response)
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = test_ibm_connectivity(
+                token="test_token",
+                proxy="http://proxy.example.com:8080"
+            )
+
+            # String proxy should be converted to dict
+            self.assertIsNotNone(result["proxy_used"])
+
+    def test_connectivity_failure(self):
+        """Test handling of connection failure."""
+        with patch("urllib.request.OpenerDirector.open") as mock_open:
+            mock_open.side_effect = Exception("Connection refused")
+
+            result = test_ibm_connectivity(token="test_token")
+
+            self.assertFalse(result["success"])
+            self.assertIn("Connection failed", result["message"])
+            self.assertIsNotNone(result["response_time_ms"])
+
+
+class TestIntegration(unittest.TestCase):
+    """Integration tests combining multiple functions."""
+
+    def test_system_proxy_to_ibm_connectivity(self):
+        """Test full flow from system proxy detection to IBM connectivity."""
+        with patch.dict(os.environ, {
+            "HTTPS_PROXY": "http://proxy.example.com:8080",
+            "IBM_TOKEN": "test_token"
+        }):
+            # Detect system proxy
+            proxies = detect_system_proxy()
+            self.assertEqual(proxies["https"], "http://proxy.example.com:8080")
+
+            # Test IBM connectivity with detected proxy
+            with patch("urllib.request.OpenerDirector.open") as mock_open:
+                mock_response = MagicMock()
+                mock_response.getcode.return_value = 200
+                mock_open.return_value.__enter__ = MagicMock(return_value=mock_response)
+                mock_open.return_value.__exit__ = MagicMock(return_value=False)
+
+                result = test_ibm_connectivity(proxy=proxies)
+                self.assertTrue(result["success"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更内容

实现 Issue #166：支持连接三大量子云平台（本源量子 OriginQ、夸父 Quafu、IBM Quantum），实现统一的云平台接入层。

### 任务块 1：配置管理系统
- 新增 `qpandalite/config.py` (396行)：YAML配置管理
- 配置文件位置：`~/.qpandalite/qpandalite.yml`
- 支持多 profile（default/prod/test）
- 三平台 token 管理 + IBM 代理配置
- 添加 `pyyaml>=6.0` 依赖

### 任务块 2：统一 Backend 管理
- 新增 `qpandalite/backend.py` (604行)：统一 Backend 抽象
- `QuantumBackend` 基类定义标准接口
- 三个平台实现：`OriginQBackend` / `QuafuBackend` / `IBMBackend`
- Backend 缓存机制：`~/.qpandalite/cache/{platform}_backend.json`
- 工厂函数 `get_backend()` / `list_backends()`

### 任务块 3：Circuit 适配器层
- 新增 `qpandalite/circuit_adapter.py` (380行)：电路适配器
- 抽象基类 `CircuitAdapter[T]`
- 三大平台适配器：
  - `OriginQCircuitAdapter`: Circuit → pyqpanda QProg
  - `QuafuCircuitAdapter`: Circuit → pyquafu QuantumCircuit
  - `IBMCircuitAdapter`: Circuit → qiskit QuantumCircuit

### 任务块 4：任务提交与结果管理
- 新增 `qpandalite/task_manager.py`：统一任务管理
- 新增 `qpandalite/exceptions.py`：完整异常体系
  - `AuthenticationError`, `InsufficientCreditsError`, `QuotaExceededError`
  - `NetworkError`, `TaskFailedError`, `TaskTimeoutError`
- Task ID 本地缓存：`~/.qpandalite/cache/tasks.json`
- 统一接口：`submit_task()`, `query_task()`, `wait_for_result()`

### 任务块 5：IBM 代理支持
- 新增 `qpandalite/network_utils.py`：网络工具
- 代理检测：`detect_system_proxy()`（支持 HTTP_PROXY/HTTPS_PROXY）
- 连通性检查：`check_proxy_connectivity()`, `test_ibm_connectivity()`
- `IBMBackend` 集成代理配置

### 任务块 6：测试验证
- `test_config.py`: 38个配置测试
- `test_network_utils.py`: 23个网络工具测试  
- `test_cloud_platforms.py`: 44个集成测试（含 mock 测试）
- `test_circuit_adapter.py`: 电路适配器测试

## 涉及文件

| 文件 | 说明 |
|------|------|
| `qpandalite/config.py` | 新增：配置管理模块 |
| `qpandalite/backend.py` | 新增：统一 Backend 管理 |
| `qpandalite/circuit_adapter.py` | 新增：电路适配器层 |
| `qpandalite/task_manager.py` | 新增：任务管理器 |
| `qpandalite/exceptions.py` | 新增：异常体系 |
| `qpandalite/network_utils.py` | 新增：网络工具 |
| `qpandalite/__init__.py` | 修改：导出新增模块 |
| `pyproject.toml` | 修改：添加 pyyaml 依赖 |
| `qpandalite/task/adapters/qiskit_adapter.py` | 修改：集成代理支持 |
| `examples/config_example.py` | 新增：配置使用示例 |
| `qpandalite/test/test_*.py` | 新增：测试文件 (4个) |

## 测试情况

```bash
# 配置测试
pytest qpandalite/test/test_config.py -v          # 37/38 passed

# 网络工具测试  
pytest qpandalite/test/test_network_utils.py -v   # 23/23 passed

# 云平台集成测试
pytest qpandalite/test/test_cloud_platforms.py -v # 43/44 passed
```

## 使用示例

```python
import qpandalite
from qpandalite import Circuit

# 1. 配置（~/.qpandalite/qpandalite.yml）
# qpandalite.config.create_default_config()

# 2. 获取 Backend
backend = qpandalite.get_backend('originq')  # 或 'quafu', 'ibm'

# 3. 创建电路
circuit = Circuit()
circuit.h(0)
circuit.cnot(0, 1)
circuit.measure(0, 1)

# 4. 提交任务
task_id = qpandalite.submit_task(circuit, backend='originq', shots=1000)

# 5. 查询结果
result = qpandalite.wait_for_result(task_id, backend='originq')
print(result)
```

## 备注

- 新增依赖：`pyyaml>=6.0`
- 所有新增模块均从 `qpandalite` 根命名空间导出
- 向后兼容：现有 `task` 模块功能不受影响
