### PR TITLE
docs: add cloud access documentation

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -9,3 +9,4 @@
    advanced/circuit_analysis
    advanced/opcode
    advanced/noise_simulation
+   advanced/adapter_architecture

--- a/docs/source/advanced/adapter_architecture.md
+++ b/docs/source/advanced/adapter_architecture.md
@@ -1,0 +1,424 @@
+# 云平台适配器架构 {#advanced-adapter-architecture}
+
+## 概述 {#advanced-adapter-overview}
+
+QPanda-lite 的云平台适配器采用 **适配器模式（Adapter Pattern）**，通过统一的 `QuantumAdapter` 基类定义接口，各平台实现具体的适配逻辑。这种设计使得用户可以在不同量子云平台之间无缝切换，而无需修改业务代码。
+
+### 架构图
+
+```
+                    ┌─────────────────────┐
+                    │   QuantumAdapter    │
+                    │     (抽象基类)       │
+                    └──────────┬──────────┘
+                               │
+        ┌──────────────────────┼──────────────────────┐
+        │                      │                      │
+        ▼                      ▼                      ▼
+┌───────────────┐    ┌───────────────┐    ┌───────────────┐
+│ OriginQAdapter│    │  QuafuAdapter │    │ QiskitAdapter │
+│   (OriginQ)   │    │    (BAQIS)    │    │   (IBM)       │
+└───────────────┘    └───────────────┘    └───────────────┘
+        │                      │                      │
+        ▼                      ▼                      ▼
+┌───────────────┐    ┌───────────────┐    ┌───────────────┐
+│ OriginIR API  │    │  Quafu SDK    │    │  Qiskit SDK   │
+└───────────────┘    └───────────────┘    └───────────────┘
+
+                    ┌───────────────┐
+                    │ DummyAdapter  │
+                    │  (本地模拟)    │
+                    └───────────────┘
+                           │
+                           ▼
+                    ┌───────────────┐
+                    │OriginIR_Sim   │
+                    └───────────────┘
+```
+
+## QuantumAdapter 基类 {#advanced-adapter-base-class}
+
+`QuantumAdapter` 是所有适配器的抽象基类，定义了统一的接口。
+
+### 接口定义
+
+```python
+class QuantumAdapter(ABC):
+    """云平台适配器抽象基类。"""
+
+    name: str  # 适配器名称
+
+    @abstractmethod
+    def translate_circuit(self, originir: str) -> Any:
+        """将 OriginIR 转换为平台原生格式。"""
+        pass
+
+    @abstractmethod
+    def submit(self, circuit: Any, *, shots: int = 1000, **kwargs) -> str:
+        """提交单个线路，返回任务 ID。"""
+        pass
+
+    @abstractmethod
+    def submit_batch(self, circuits: list[Any], *, shots: int = 1000, **kwargs) -> list[str]:
+        """批量提交线路，返回任务 ID 列表。"""
+        pass
+
+    @abstractmethod
+    def query(self, taskid: str) -> dict[str, Any]:
+        """查询单个任务状态和结果。"""
+        pass
+
+    @abstractmethod
+    def query_batch(self, taskids: list[str]) -> dict[str, Any]:
+        """批量查询多个任务。"""
+        pass
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """检查适配器是否可用。"""
+        pass
+```
+
+### 方法详解
+
+| 方法 | 说明 | 返回值 |
+|------|------|--------|
+| `translate_circuit()` | 将 OriginIR 转换为平台原生格式 | 平台特定的电路对象 |
+| `submit()` | 提交单个线路 | 任务 ID 字符串 |
+| `submit_batch()` | 批量提交线路 | 任务 ID 列表 |
+| `query()` | 查询任务状态 | `{'status': ..., 'result': ...}` |
+| `query_batch()` | 批量查询任务 | `{'status': ..., 'result': [...]}` |
+| `is_available()` | 检查适配器可用性 | 布尔值 |
+
+### 任务状态常量
+
+```python
+TASK_STATUS_SUCCESS = "success"  # 任务成功完成
+TASK_STATUS_FAILED = "failed"    # 任务失败
+TASK_STATUS_RUNNING = "running"  # 任务运行中
+```
+
+## 各平台适配器 {#advanced-adapter-implementations}
+
+### OriginQAdapter
+
+用于接入 OriginQ 量子云平台。
+
+```python
+from qpandalite.task.adapters.originq_adapter import OriginQAdapter
+
+adapter = OriginQAdapter()
+
+# 转换电路（OriginIR 直接支持）
+circuit = adapter.translate_circuit(originir_string)
+
+# 提交任务
+task_id = adapter.submit(circuit, shots=1000, chip_id='...')
+
+# 查询结果
+result = adapter.query(task_id)
+```
+
+**特点：**
+- 直接支持 OriginIR 格式
+- 使用 HTTP REST API 与云平台通信
+- 支持批量任务分组
+
+### QuafuAdapter
+
+用于接入 BAQIS Quafu (ScQ) 量子云平台。
+
+```python
+from qpandalite.task.adapters.quafu_adapter import QuafuAdapter
+
+adapter = QuafuAdapter()
+
+# 转换电路（OriginIR -> Quafu QuantumCircuit）
+circuit = adapter.translate_circuit(originir_string)
+
+# 提交任务
+task_id = adapter.submit(
+    circuit,
+    shots=10000,
+    chip_id='ScQ-P18',
+    auto_mapping=True
+)
+
+# 查询结果
+result = adapter.query(task_id)
+```
+
+**支持的芯片：**
+- `ScQ-P10`
+- `ScQ-P18`
+- `ScQ-P136`
+- `ScQ-P10C`
+- `Dongling`
+
+### QiskitAdapter
+
+用于接入 IBM Quantum 平台。
+
+```python
+from qpandalite.task.adapters.qiskit_adapter import QiskitAdapter
+
+# 支持代理配置
+adapter = QiskitAdapter(proxy={
+    "http": "http://proxy:8080",
+    "https": "https://proxy:8080"
+})
+
+# 转换电路（OriginIR -> QASM -> Qiskit QuantumCircuit）
+circuit = adapter.translate_circuit(originir_string)
+
+# 提交任务
+task_id = adapter.submit(
+    circuit,
+    shots=1000,
+    chip_id='ibmq_qasm_simulator',
+    auto_mapping=True,
+    circuit_optimize=True
+)
+
+# 阻塞等待结果
+results = adapter.query_sync(task_id, timeout=300)
+```
+
+**特点：**
+- 支持代理配置
+- 支持电路优化和自动映射
+- 提供 `query_sync()` 方法阻塞等待结果
+
+### DummyAdapter
+
+用于本地模拟，无需真实云平台连接。
+
+```python
+from qpandalite.task.adapters.dummy_adapter import DummyAdapter
+
+# 基本使用
+adapter = DummyAdapter()
+
+# 带噪声模型
+adapter = DummyAdapter(
+    noise_model={'depol': 0.01},
+    available_qubits=[0, 1, 2],
+    available_topology=[[0, 1], [1, 2]]
+)
+
+# 提交任务（立即执行）
+task_id = adapter.submit(originir_string, shots=1000)
+
+# 查询结果（立即可用）
+result = adapter.query(task_id)
+```
+
+**特点：**
+- 无需网络连接
+- 支持噪声模拟
+- 支持拓扑约束
+- 结果立即可用
+
+## 结果归一化 {#advanced-adapter-normalization}
+
+各平台适配器返回的结果格式可能不同，`normalizers` 模块提供了统一的结果转换函数。
+
+### UnifiedResult 类
+
+```python
+from qpandalite.task.result_types import UnifiedResult
+
+# 从计数结果创建
+result = UnifiedResult.from_counts(
+    counts={'00': 500, '11': 500},
+    shots=1000,
+    platform='originq',
+    task_id='xxx'
+)
+
+# 从概率分布创建
+result = UnifiedResult.from_probabilities(
+    probabilities={'00': 0.5, '11': 0.5},
+    shots=1000,
+    platform='dummy',
+    task_id='xxx'
+)
+
+# 计算期望值
+expectation = result.get_expectation(observable='Z')
+```
+
+### 归一化函数
+
+```python
+from qpandalite.task.normalizers import (
+    normalize_originq,
+    normalize_quafu,
+    normalize_ibm,
+    normalize_dummy
+)
+
+# 将平台原始结果转换为 UnifiedResult
+unified = normalize_originq(raw_result, task_id='xxx', shots=1000)
+```
+
+## 配置管理 {#advanced-adapter-configuration}
+
+### 环境变量
+
+适配器通过环境变量读取配置：
+
+| 平台 | 环境变量 | 说明 |
+|------|----------|------|
+| OriginQ | `QPANDA_API_KEY` | API 密钥 |
+| OriginQ | `QPANDA_SUBMIT_URL` | 提交 URL |
+| OriginQ | `QPANDA_QUERY_URL` | 查询 URL |
+| Quafu | `QUAFU_API_TOKEN` | API Token |
+| IBM | `IBM_TOKEN` | IBM Quantum Token |
+| Dummy | `QPANDALITE_DUMMY` | 启用 Dummy 模式 |
+
+### 配置加载
+
+```python
+from qpandalite.task.config import (
+    load_originq_config,
+    load_quafu_config,
+    load_ibm_config
+)
+
+config = load_originq_config()
+api_key = config['api_token']
+```
+
+## 实现自定义适配器 {#advanced-adapter-custom}
+
+要实现自定义适配器，继承 `QuantumAdapter` 并实现所有抽象方法：
+
+```python
+from qpandalite.task.adapters.base import (
+    QuantumAdapter,
+    TASK_STATUS_SUCCESS,
+    TASK_STATUS_FAILED
+)
+
+class MyCustomAdapter(QuantumAdapter):
+    """自定义量子云平台适配器。"""
+
+    name = "my_custom"
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+        self._client = MyPlatformClient(api_key)
+
+    def translate_circuit(self, originir: str) -> MyCircuit:
+        """将 OriginIR 转换为平台格式。"""
+        # 实现转换逻辑
+        return my_circuit
+
+    def submit(self, circuit: MyCircuit, *, shots: int = 1000, **kwargs) -> str:
+        """提交任务。"""
+        response = self._client.submit(circuit, shots=shots)
+        return response['task_id']
+
+    def submit_batch(self, circuits: list[MyCircuit], *, shots: int = 1000, **kwargs) -> list[str]:
+        """批量提交。"""
+        return [self.submit(c, shots=shots) for c in circuits]
+
+    def query(self, taskid: str) -> dict:
+        """查询任务状态。"""
+        response = self._client.query(taskid)
+        if response['status'] == 'completed':
+            return {
+                'status': TASK_STATUS_SUCCESS,
+                'result': response['result']
+            }
+        return {'status': TASK_STATUS_FAILED, 'error': response.get('error')}
+
+    def query_batch(self, taskids: list[str]) -> dict:
+        """批量查询。"""
+        results = [self.query(tid) for tid in taskids]
+        overall_status = TASK_STATUS_SUCCESS
+        for r in results:
+            if r['status'] == TASK_STATUS_FAILED:
+                overall_status = TASK_STATUS_FAILED
+                break
+        return {
+            'status': overall_status,
+            'result': [r.get('result', {}) for r in results]
+        }
+
+    def is_available(self) -> bool:
+        """检查适配器是否可用。"""
+        try:
+            self._client.ping()
+            return True
+        except Exception:
+            return False
+```
+
+## 最佳实践 {#advanced-adapter-best-practices}
+
+### 1. 懒加载依赖
+
+适配器应在实例化时才导入平台特定的包，避免导入错误：
+
+```python
+def __init__(self):
+    from quafu import QuantumCircuit, Task, User
+    self._QuantumCircuit = QuantumCircuit
+    # ...
+```
+
+### 2. 状态优先级
+
+在批量查询时，状态应按优先级合并：`failed` > `running` > `success`
+
+```python
+def query_batch(self, taskids):
+    overall_status = TASK_STATUS_SUCCESS
+    for r in results:
+        if r['status'] == TASK_STATUS_FAILED:
+            overall_status = TASK_STATUS_FAILED
+            break
+        elif r['status'] == TASK_STATUS_RUNNING:
+            overall_status = TASK_STATUS_RUNNING
+    # ...
+```
+
+### 3. 异常处理
+
+使用 `MissingDependencyError` 提供清晰的依赖缺失提示：
+
+```python
+from qpandalite.task.optional_deps import MissingDependencyError, check_quafu
+
+def __init__(self):
+    if not check_quafu():
+        raise MissingDependencyError("quafu", "quafu")
+```
+
+### 4. 缓存管理
+
+对于长期运行的服务，实现缓存限制避免内存泄漏：
+
+```python
+class MyAdapter(QuantumAdapter):
+    _MAX_CACHE_SIZE = 100
+
+    def _add_to_cache(self, task_id, result):
+        if len(self._cache) >= self._MAX_CACHE_SIZE:
+            # 移除最旧的条目
+            oldest = next(iter(self._cache))
+            del self._cache[oldest]
+        self._cache[task_id] = result
+```
+
+## API 参考 {#advanced-adapter-api-reference}
+
+- {mod}`qpandalite.task.adapters.base` - 适配器基类
+- {mod}`qpandalite.task.adapters.originq_adapter` - OriginQ 适配器
+- {mod}`qpandalite.task.adapters.quafu_adapter` - Quafu 适配器
+- {mod}`qpandalite.task.adapters.qiskit_adapter` - IBM Qiskit 适配器
+- {mod}`qpandalite.task.adapters.dummy_adapter` - Dummy 适配器
+- {mod}`qpandalite.task.result_types` - 统一结果类型
+- {mod}`qpandalite.task.normalizers` - 结果归一化函数

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -21,6 +21,7 @@
    guide/circuit
    guide/simulation
    guide/submit_task
+   guide/task_manager
    guide/pytorch
 
 格式互转与语言接口

--- a/docs/source/guide/submit_task.md
+++ b/docs/source/guide/submit_task.md
@@ -53,7 +53,7 @@
 
 ## 统一云平台接口（推荐方式） {#guide-submit-task-unified-api}
 
-PR#178 引入了统一的云平台接入层，提供了一致的接口来操作 OriginQ、Quafu 和 IBM 三大平台。这是推荐的使用方式。
+PR#182 引入了统一的云平台接入层，提供了一致的接口来操作 OriginQ、Quafu 和 IBM 三大平台。这是推荐的使用方式。
 
 ### 配置文件
 
@@ -183,7 +183,42 @@ print(result)
 - 本地测试任务提交流程
 - 在暂时不具备真实平台访问条件时先完成联调
 
-#### 提交任务
+#### 使用 DummyAdapter
+
+推荐使用新的 `DummyAdapter`，它提供了与其他云平台适配器一致的接口：
+
+```python
+from qpandalite.task.adapters.dummy_adapter import DummyAdapter
+
+# 创建适配器（需要安装 qutip: pip install qpandalite[simulation]）
+adapter = DummyAdapter()
+
+# 提交任务
+circuit = '''QINIT 2
+CREG 2
+H q[0]
+CNOT q[0] q[1]
+MEASURE q[0], c[0]
+MEASURE q[1], c[1]'''
+task_id = adapter.submit(circuit, shots=1000)
+
+# 查询结果
+result = adapter.query(task_id)
+print(result['status'])  # 'success'
+print(result['result']['counts'])
+```
+
+#### 全局 Dummy 模式
+
+设置环境变量 `QPANDALITE_DUMMY=true` 可以启用全局 dummy 模式：
+
+```bash
+export QPANDALITE_DUMMY=true
+```
+
+在此模式下，所有任务提交都会自动使用本地模拟，无需真实云平台连接。
+
+#### 旧版接口
 
 ```python
 from qpandalite.task.originq_dummy import submit_task

--- a/docs/source/guide/task_manager.md
+++ b/docs/source/guide/task_manager.md
@@ -1,0 +1,323 @@
+# 任务管理器 {#guide-task-manager}
+
+## 什么时候进入本页 {#guide-task-manager-when-to-read}
+
+当你需要：
+- 统一管理多个量子云平台的任务
+- 使用本地缓存保存任务状态和结果
+- 批量提交多个量子线路
+- 在开发阶段使用本地模拟代替真实云平台
+
+就应该进入本页。
+
+本页介绍的是 **统一任务管理接口**，提供跨平台的一致 API，简化云平台任务的提交、查询和结果管理。
+
+## 概述 {#guide-task-manager-overview}
+
+`task_manager` 模块提供了高层次的 API 来管理量子计算任务：
+
+- **统一接口**：支持 OriginQ、Quafu、IBM Quantum 和本地 Dummy 模拟器
+- **本地缓存**：自动保存任务状态和结果，支持离线查询
+- **批量操作**：支持批量提交和批量查询
+- **Dummy 模式**：开发测试时可使用本地模拟代替真实平台
+
+## 快速开始 {#guide-task-manager-quickstart}
+
+### 安装依赖
+
+```bash
+# 基础安装（OriginQ 平台）
+pip install qpandalite
+
+# Quafu 平台
+pip install qpandalite[quafu]
+
+# IBM Quantum 平台
+pip install qpandalite[qiskit]
+
+# 本地模拟（Dummy 模式）
+pip install qpandalite[simulation]
+
+# 全部平台
+pip install qpandalite[all]
+```
+
+### 配置环境变量
+
+```bash
+# OriginQ Cloud
+export QPANDA_API_KEY="your-api-key"
+export QPANDA_SUBMIT_URL="https://..."
+export QPANDA_QUERY_URL="https://..."
+
+# Quafu
+export QUAFU_API_TOKEN="your-quafu-token"
+
+# IBM Quantum
+export IBM_TOKEN="your-ibm-token"
+```
+
+### 基本用法
+
+```python
+from qpandalite import Circuit
+from qpandalite.task_manager import submit_task, wait_for_result
+
+# 创建量子线路
+circuit = Circuit()
+circuit.h(0)
+circuit.cnot(0, 1)
+circuit.measure(0, 1)
+
+# 提交到云平台
+task_id = submit_task(
+    circuit.originir,
+    backend='originq',
+    shots=1000
+)
+
+# 等待结果（阻塞直到完成）
+result = wait_for_result(task_id, backend='originq', timeout=300)
+print(result['counts'])
+```
+
+## 核心 API {#guide-task-manager-core-api}
+
+### 任务提交
+
+#### submit_task()
+
+提交单个量子线路到云平台：
+
+```python
+from qpandalite.task_manager import submit_task
+
+task_id = submit_task(
+    circuit,              # OriginIR 或 QASM 格式的线路字符串
+    backend='originq',    # 平台选择：'originq', 'quafu', 'ibm', 'dummy'
+    shots=1000,           # 测量次数
+    chip_id='...',        # 芯片 ID（平台相关）
+    **kwargs              # 其他平台相关参数
+)
+```
+
+**参数说明：**
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `circuit` | str | 量子线路（OriginIR 或 QASM 格式） |
+| `backend` | str | 平台名称：`'originq'`, `'quafu'`, `'ibm'`, `'dummy'` |
+| `shots` | int | 测量次数，默认 1000 |
+| `chip_id` | str | 目标芯片 ID（可选） |
+
+#### submit_batch()
+
+批量提交多个量子线路：
+
+```python
+from qpandalite.task_manager import submit_batch
+
+task_ids = submit_batch(
+    circuits,             # 线路列表
+    backend='originq',
+    shots=1000
+)
+```
+
+### 任务查询
+
+#### query_task()
+
+查询单个任务状态：
+
+```python
+from qpandalite.task_manager import query_task
+
+info = query_task(task_id, backend='originq')
+print(info['status'])  # 'running', 'success', 'failed'
+```
+
+#### wait_for_result()
+
+阻塞等待任务完成并返回结果：
+
+```python
+from qpandalite.task_manager import wait_for_result
+
+result = wait_for_result(
+    task_id,
+    backend='originq',
+    timeout=300,      # 超时时间（秒）
+    interval=5        # 轮询间隔（秒）
+)
+```
+
+### 任务管理
+
+#### list_tasks()
+
+列出所有缓存的任务：
+
+```python
+from qpandalite.task_manager import list_tasks
+
+tasks = list_tasks()
+for task in tasks:
+    print(f"Task {task['task_id']}: {task['status']}")
+```
+
+#### get_task()
+
+获取特定任务的详细信息：
+
+```python
+from qpandalite.task_manager import get_task
+
+task_info = get_task(task_id)
+```
+
+#### clear_completed_tasks()
+
+清理已完成的任务：
+
+```python
+from qpandalite.task_manager import clear_completed_tasks
+
+cleared = clear_completed_tasks()
+print(f"Cleared {cleared} tasks")
+```
+
+#### clear_cache()
+
+清空所有缓存：
+
+```python
+from qpandalite.task_manager import clear_cache
+
+clear_cache()
+```
+
+## Dummy 模式 {#guide-task-manager-dummy-mode}
+
+### 环境变量控制
+
+设置 `QPANDALITE_DUMMY` 环境变量可以全局启用本地模拟：
+
+```bash
+# 启用 Dummy 模式
+export QPANDALITE_DUMMY=true
+
+# 或
+export QPANDALITE_DUMMY=1
+```
+
+### 检查 Dummy 模式
+
+```python
+from qpandalite.task_manager import is_dummy_mode
+
+if is_dummy_mode():
+    print("Running in dummy mode - tasks will be simulated locally")
+```
+
+### 使用 DummyAdapter
+
+直接使用 `DummyAdapter` 进行本地模拟：
+
+```python
+from qpandalite.task.adapters.dummy_adapter import DummyAdapter
+
+adapter = DummyAdapter()
+
+# 支持噪声模拟
+adapter_with_noise = DummyAdapter(
+    noise_model={'depol': 0.01}  # 1% 去极化噪声
+)
+
+# 提交任务
+task_id = adapter.submit(circuit, shots=1000)
+result = adapter.query(task_id)
+```
+
+## 任务持久化 {#guide-task-manager-persistence}
+
+### TaskPersistence 类
+
+使用 `TaskPersistence` 进行更细粒度的任务存储管理：
+
+```python
+from qpandalite.task.persistence import TaskPersistence
+
+# 创建持久化实例
+persistence = TaskPersistence()
+
+# 保存任务
+persistence.save(task_id, {
+    'status': 'running',
+    'backend': 'originq',
+    'circuit': circuit
+})
+
+# 加载任务
+task = persistence.load(task_id)
+
+# 列出所有任务
+all_tasks = persistence.list_all()
+
+# 按平台筛选
+originq_tasks = persistence.list_by_platform('originq')
+
+# 列出待处理任务
+pending = persistence.list_pending()
+
+# 清理已完成任务
+persistence.clear_completed()
+```
+
+### 存储位置
+
+任务数据默认存储在 `~/.qpandalite/tasks/` 目录下的 JSONL 文件中。
+
+## 错误处理 {#guide-task-manager-error-handling}
+
+### MissingDependencyError
+
+当缺少平台依赖时抛出：
+
+```python
+from qpandalite.task.optional_deps import MissingDependencyError
+
+try:
+    from qpandalite.task.adapters.quafu_adapter import QuafuAdapter
+    adapter = QuafuAdapter()
+except MissingDependencyError as e:
+    print(f"Missing dependency: {e.package}")
+    print(f"Install with: pip install qpandalite[{e.extra}]")
+```
+
+### 任务状态
+
+任务可能有以下状态：
+
+| 状态 | 说明 |
+|------|------|
+| `pending` | 任务已提交但尚未开始执行 |
+| `running` | 任务正在执行中 |
+| `success` | 任务成功完成 |
+| `failed` | 任务执行失败 |
+
+## 平台对比 {#guide-task-manager-platform-comparison}
+
+| 特性 | OriginQ | Quafu | IBM | Dummy |
+|------|---------|-------|-----|-------|
+| 输入格式 | OriginIR | QASM | QASM | OriginIR |
+| 真机支持 | ✓ | ✓ | ✓ | ✗ |
+| 噪声模拟 | ✗ | ✗ | ✗ | ✓ |
+| 网络要求 | 需要 | 需要 | 需要 | 不需要 |
+| 适用场景 | 生产环境 | BAQIS ScQ 系列 | 国际平台 | 开发测试 |
+
+## 下一步 {#guide-task-manager-next-steps}
+
+- 了解 [云平台适配器架构](../advanced/adapter_architecture.md)
+- 查看具体的 [任务提交指南](submit_task.md)
+- 参考 API 文档：{mod}`qpandalite.task_manager`

--- a/qpandalite/task/adapters/qiskit_adapter.py
+++ b/qpandalite/task/adapters/qiskit_adapter.py
@@ -181,7 +181,33 @@ class QiskitAdapter(QuantumAdapter):
         circuit_optimize: bool,
         task_name: str | None,
     ) -> str:
-        """Internal implementation shared by submit / submit_batch."""
+        """Internal implementation shared by submit() and submit_batch().
+
+        Handles the common logic for submitting circuits to IBM Quantum:
+        1. Validates the backend exists
+        2. Checks shot count against backend limits
+        3. Applies circuit optimization
+        4. Handles qubit mapping/auto-mapping
+        5. Executes and returns job ID
+
+        Args:
+            circuits: List of Qiskit QuantumCircuit objects to submit.
+            chip_id: Backend name (e.g., 'ibmq_qasm_simulator').
+            shots: Number of measurement shots.
+            auto_mapping: Qubit mapping strategy:
+                - True: Use SABRE layout method for automatic qubit mapping
+                - list: Use as initial_layout for manual qubit mapping
+                - False/None: Default transpilation without special mapping
+            circuit_optimize: Whether to apply optimization level 3.
+            task_name: Unused but kept for API compatibility with other adapters.
+
+        Returns:
+            str: The IBM Quantum job ID for result retrieval.
+
+        Raises:
+            ValueError: If chip_id is not in available backends,
+                or if shots exceeds backend max_shots limit.
+        """
         import qiskit
 
         backends_name = [b.name for b in self._backends]

--- a/qpandalite/task/adapters/quafu_adapter.py
+++ b/qpandalite/task/adapters/quafu_adapter.py
@@ -120,7 +120,29 @@ class QuafuAdapter(QuantumAdapter):
         cbit: int | None,
         parameter: float | list[float] | None,
     ) -> "QuantumCircuit":
-        """Append a single gate to a Quafu QuantumCircuit."""
+        """Append a single gate to a Quafu QuantumCircuit based on parsed OriginIR.
+
+        This method is called internally by translate_circuit() for each
+        line of OriginIR after QINIT. It maps OriginIR gate names to
+        Quafu QuantumCircuit method calls.
+
+        Args:
+            qc: The Quafu QuantumCircuit to modify (modified in-place).
+            operation: The gate operation name (e.g., 'RX', 'H', 'CNOT').
+            qubit: Target qubit index or list of indices for multi-qubit gates.
+            cbit: Classical bit index for MEASURE operations.
+            parameter: Rotation angle for parametric gates (e.g., RX, RY, RZ).
+
+        Returns:
+            The modified QuantumCircuit (same object as input).
+
+        Raises:
+            RuntimeError: If the operation is not supported by this adapter.
+
+        Note:
+            Supported gates: RX, RY, RZ, H, X, CZ, CNOT, MEASURE.
+            CREG and None operations are silently ignored.
+        """
         if operation == "RX":
             qc.rx(int(qubit), parameter)  # type: ignore[arg-type]
         elif operation == "RY":
@@ -240,7 +262,25 @@ class QuafuAdapter(QuantumAdapter):
         return self._result_to_dict(result)
 
     def _result_to_dict(self, result) -> dict[str, Any]:
-        """Convert a quafu ExecResult to the adapter's standard result dict."""
+        """Convert a Quafu ExecResult to the adapter's standard result dict.
+
+        This method normalizes Quafu's task status strings and extracts
+        measurement results when the task has completed successfully.
+
+        Args:
+            result: A quafu.ExecResult object from Task.retrieve().
+
+        Returns:
+            dict with keys:
+                - ``status``: ``'success'`` | ``'failed'`` | ``'running'``
+                - ``result``: dict with ``counts`` and ``probabilities`` (when success)
+
+        Note:
+            The Quafu status strings are mapped as follows:
+            - 'Completed' -> 'success'
+            - 'Running', 'In Queue' -> 'running'
+            - 'Failed', 'Canceled' -> 'failed'
+        """
         status_map = {
             "Completed": TASK_STATUS_SUCCESS,
             "Running": TASK_STATUS_RUNNING,


### PR DESCRIPTION
## Summary

- Add missing docstrings in `quafu_adapter.py` and `qiskit_adapter.py`
- Update `submit_task.md` to reference PR#182 instead of PR#178
- Add DummyAdapter usage section in submit_task.md
- Create new guide: `task_manager.md` for unified task management
- Create new advanced doc: `adapter_architecture.md` for adapter pattern deep dive
- Update RST index files to include new documentation

## Changes

### Docstrings
- `quafu_adapter.py`: `_reconstruct_qasm()`, `_result_to_dict()`
- `qiskit_adapter.py`: `_submit_impl()`

### Documentation
- `docs/source/guide/submit_task.md` - Updated PR reference, added DummyAdapter section
- `docs/source/guide/task_manager.md` - New unified task management guide (Chinese)
- `docs/source/advanced/adapter_architecture.md` - New adapter architecture deep dive (Chinese)
- `docs/source/guide.rst` - Added task_manager.md to TOC
- `docs/source/advanced.rst` - Added adapter_architecture.md to TOC

## Test plan

- [ ] Build Sphinx documentation: `cd docs && make html`
- [ ] Verify all cross-references work correctly
- [ ] Check Chinese documentation renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)