### PR TITLE
feat: add CLI for quantum computing operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,15 @@ dependencies = [
     "pyyaml>=6.0",
     "sympy>=1.12",
     "typing-extensions>=4.0",
+    "typer>=0.9.0",
+    "rich>=13.0.0",
 ]
 
 [project.urls]
 "Source Code" = "https://github.com/Agony5757/QPanda-Lite.git"
+
+[project.scripts]
+qpandalite = "qpandalite.cli.main:app"
 
 [project.optional-dependencies]
 quafu = ["pyquafu>=0.4.0"]
@@ -55,6 +60,7 @@ all = ["qpandalite[quafu,qiskit,originq,simulation,visualization,analysis,pytorc
 zip-safe = false
 packages = [
     "qpandalite",
+    "qpandalite.cli",
     "qpandalite.algorithmics",
     "qpandalite.algorithmics.ansatz",
     "qpandalite.algorithmics.circuits",

--- a/qpandalite/__main__.py
+++ b/qpandalite/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for python -m qpandalite."""
+
+from qpandalite.cli.main import app
+
+if __name__ == "__main__":
+    app()

--- a/qpandalite/cli/__init__.py
+++ b/qpandalite/cli/__init__.py
@@ -1,0 +1,5 @@
+"""QPanda-lite CLI module."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/qpandalite/cli/__main__.py
+++ b/qpandalite/cli/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for python -m qpandalite."""
+
+from .main import app
+
+if __name__ == "__main__":
+    app()

--- a/qpandalite/cli/circuit.py
+++ b/qpandalite/cli/circuit.py
@@ -1,0 +1,103 @@
+"""Circuit format conversion subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .output import console, print_error, print_info, print_table, write_output
+
+app = typer.Typer(help="Circuit format conversion (OriginIR <-> QASM)")
+
+
+def _detect_format(content: str) -> str:
+    """Detect circuit format from content."""
+    stripped = content.strip()
+    if stripped.startswith("QINIT") or "ORIGINIR" in stripped.upper():
+        return "originir"
+    if stripped.startswith("OPENQASM") or "qelib1.inc" in stripped:
+        return "qasm"
+    return "unknown"
+
+
+@app.callback(invoke_without_command=True)
+def convert(
+    input_file: Path = typer.Argument(..., help="Input circuit file (OriginIR or QASM)", exists=True),
+    format: Optional[str] = typer.Option(None, "--format", "-f", help="Output format: originir/qasm"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file (default: stdout)"),
+    info: bool = typer.Option(False, "--info", help="Show circuit statistics"),
+):
+    """Convert circuit between OriginIR and QASM formats."""
+    content = input_file.read_text(encoding="utf-8")
+    source_format = _detect_format(content)
+
+    if source_format == "unknown":
+        print_error(f"Cannot detect format of {input_file}. Use --format to specify.")
+        raise typer.Exit(1)
+
+    if format is None:
+        format = "qasm" if source_format == "originir" else "originir"
+
+    if format == source_format:
+        print_error(f"Input is already in {format} format. Specify a different --format.")
+        raise typer.Exit(1)
+
+    if source_format == "originir" and format == "qasm":
+        result_content = _originir_to_qasm(content)
+    elif source_format == "qasm" and format == "originir":
+        result_content = _qasm_to_originir(content)
+    else:
+        print_error(f"Unsupported conversion: {source_format} -> {format}")
+        raise typer.Exit(1)
+
+    if info:
+        _print_info(content, source_format)
+
+    write_output(result_content, str(output) if output else None)
+
+
+def _originir_to_qasm(originir: str) -> str:
+    """Convert OriginIR to QASM."""
+    from qpandalite.originir import OriginIR_BaseParser
+
+    parser = OriginIR_BaseParser()
+    parser.parse(originir)
+    return parser.to_qasm()
+
+
+def _qasm_to_originir(qasm: str) -> str:
+    """Convert QASM to OriginIR."""
+    from qpandalite.qasm import QASM_Parser
+
+    parser = QASM_Parser()
+    parser.parse(qasm)
+    return parser.originir
+
+
+def _print_info(content: str, fmt: str) -> None:
+    """Print circuit statistics."""
+    if fmt == "originir":
+        from qpandalite.originir import OriginIR_BaseParser
+
+        parser = OriginIR_BaseParser()
+        parser.parse(content)
+        circuit = parser.to_circuit()
+    else:
+        from qpandalite.qasm import QASM_Parser
+
+        parser = QASM_Parser()
+        parser.parse(content)
+        circuit = parser.to_circuit()
+
+    print_table(
+        "Circuit Info",
+        ["Property", "Value"],
+        [
+            ["Qubits", str(circuit.qubit_num)],
+            ["Cbits", str(circuit.cbit_num)],
+            ["Depth", str(circuit.depth)],
+            ["Gates", str(len(circuit.opcodes))],
+        ],
+    )

--- a/qpandalite/cli/config_cmd.py
+++ b/qpandalite/cli/config_cmd.py
@@ -1,0 +1,186 @@
+"""Configuration management subcommand."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+
+from .output import console, print_error, print_info, print_json, print_success, print_table
+
+app = typer.Typer(help="Manage API key and configuration")
+
+
+@app.command()
+def init():
+    """Initialize configuration file with default values."""
+    from qpandalite.config import create_default_config
+
+    create_default_config()
+    print_success("Configuration file created at ~/.qpandalite/qpandalite.yml")
+
+
+@app.command()
+def set(
+    key: str = typer.Argument(..., help="Configuration key (e.g., originq.token)"),
+    value: str = typer.Argument(..., help="Configuration value"),
+    profile: str = typer.Option("default", "--profile", "-p", help="Profile name"),
+):
+    """Set a configuration value."""
+    parts = key.split(".")
+    if len(parts) != 2:
+        print_error("Key must be in format 'platform.field' (e.g., originq.token)")
+        raise typer.Exit(1)
+
+    platform_name, field = parts
+    platform_name = platform_name.lower()
+
+    if platform_name not in ("originq", "quafu", "ibm"):
+        print_error(f"Unknown platform: {platform_name}. Use originq/quafu/ibm.")
+        raise typer.Exit(1)
+
+    from qpandalite.config import update_platform_config
+
+    update_platform_config(platform_name, {field: value}, profile=profile)
+    print_success(f"Set {key} = {value[:8]}...")
+
+
+@app.command()
+def get(
+    platform: str = typer.Argument(..., help="Platform name: originq/quafu/ibm"),
+    profile: str = typer.Option("default", "--profile", "-p", help="Profile name"),
+):
+    """Get configuration for a platform."""
+    from qpandalite.config import get_platform_config
+
+    platform = platform.lower()
+    config = get_platform_config(platform, profile=profile)
+
+    if not config:
+        print_error(f"No configuration found for {platform} (profile: {profile})")
+        raise typer.Exit(1)
+
+    rows = []
+    for key, value in config.items():
+        if key == "token" and value:
+            display = f"{value[:8]}..." if len(value) > 8 else value
+        elif isinstance(value, list):
+            display = ", ".join(map(str, value)) if value else "(empty)"
+        elif isinstance(value, dict):
+            display = str(value) if value else "(empty)"
+        else:
+            display = str(value) if value else "(not set)"
+        rows.append([key, display])
+
+    print_table(f"{platform.upper()} Configuration", ["Field", "Value"], rows)
+
+
+@app.command("list")
+def list_config(
+    profile: str = typer.Option("default", "--profile", "-p", help="Profile name"),
+    format: str = typer.Option("table", "--format", "-f", help="Output format: table/json"),
+):
+    """List all platform configurations."""
+    from qpandalite.config import PLATFORM_REQUIRED_FIELDS, load_config
+
+    config = load_config()
+
+    if profile not in config:
+        print_error(f"Profile '{profile}' not found")
+        raise typer.Exit(1)
+
+    profile_config = config[profile]
+    results = []
+
+    for platform in ("originq", "quafu", "ibm"):
+        platform_config = profile_config.get(platform, {})
+        token = platform_config.get("token", "")
+        required = PLATFORM_REQUIRED_FIELDS.get(platform, [])
+
+        if token:
+            status = "[green]✓ Configured[/green]"
+        else:
+            status = "[red]✗ Missing token[/red]"
+
+        missing = [f for f in required if not platform_config.get(f)]
+        if missing and token:
+            status = f"[yellow]⚠ Missing: {', '.join(missing)}[/yellow]"
+
+        results.append(
+            {
+                "platform": platform,
+                "status": status,
+                "has_token": bool(token),
+            }
+        )
+
+    if format == "json":
+        print_json(results)
+    else:
+        rows = [[r["platform"], r["status"]] for r in results]
+        print_table("Platform Configuration Status", ["Platform", "Status"], rows)
+
+
+@app.command()
+def validate(
+    profile: str = typer.Option("default", "--profile", "-p", help="Profile name"),
+):
+    """Validate current configuration."""
+    from qpandalite.config import validate_config
+
+    errors = validate_config()
+
+    if not errors:
+        print_success("Configuration is valid")
+    else:
+        print_error("Configuration has errors:")
+        for err in errors:
+            console.print(f"  - {err}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def profile(
+    action: str = typer.Argument(..., help="Action: list/use/create"),
+    name: Optional[str] = typer.Argument(None, help="Profile name"),
+):
+    """Manage configuration profiles."""
+    from qpandalite.config import get_active_profile, load_config, set_active_profile
+
+    if action == "list":
+        config = load_config()
+        active = get_active_profile()
+        rows = []
+        for profile_name in config.keys():
+            marker = "[green]*[/green]" if profile_name == active else " "
+            rows.append([marker, profile_name])
+        print_table("Profiles", ["Active", "Name"], rows)
+
+    elif action == "use":
+        if not name:
+            print_error("Profile name required")
+            raise typer.Exit(1)
+        set_active_profile(name)
+        print_success(f"Switched to profile '{name}'")
+
+    elif action == "create":
+        if not name:
+            print_error("Profile name required")
+            raise typer.Exit(1)
+        from qpandalite.config import CONFIG_FILE, load_config, save_config
+
+        config = load_config()
+        if name in config:
+            print_error(f"Profile '{name}' already exists")
+            raise typer.Exit(1)
+        config[name] = {
+            "originq": {"token": "", "submit_url": "", "query_url": ""},
+            "quafu": {"token": ""},
+            "ibm": {"token": "", "proxy": {"http": "", "https": ""}},
+        }
+        save_config(config)
+        print_success(f"Created profile '{name}'")
+
+    else:
+        print_error(f"Unknown action: {action}. Use list/use/create.")
+        raise typer.Exit(1)

--- a/qpandalite/cli/main.py
+++ b/qpandalite/cli/main.py
@@ -1,0 +1,33 @@
+"""Main CLI entry point for QPanda-lite."""
+
+from __future__ import annotations
+
+import typer
+
+app = typer.Typer(
+    name="qpandalite",
+    help="QPanda-lite - A lightweight quantum computing framework",
+    no_args_is_help=True,
+)
+
+
+@app.callback()
+def main():
+    """QPanda-lite CLI - Quantum computing from the command line."""
+    pass
+
+
+# Import and register subcommands
+from . import circuit
+from . import simulate
+from . import submit
+from . import result
+from . import config_cmd as config
+from . import task
+
+app.add_typer(circuit.app, name="circuit")
+app.add_typer(simulate.app, name="simulate")
+app.add_typer(submit.app, name="submit")
+app.add_typer(result.app, name="result")
+app.add_typer(config.app, name="config")
+app.add_typer(task.app, name="task")

--- a/qpandalite/cli/output.py
+++ b/qpandalite/cli/output.py
@@ -1,0 +1,64 @@
+"""Output formatting utilities for CLI."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def print_table(
+    title: str,
+    columns: list[str],
+    rows: list[list[Any]],
+) -> None:
+    """Print a rich table to console."""
+    table = Table(title=title)
+    for col in columns:
+        table.add_column(col)
+    for row in rows:
+        table.add_row(*[str(v) for v in row])
+    console.print(table)
+
+
+def print_json(data: dict[str, Any] | list[Any]) -> None:
+    """Print data as JSON to stdout."""
+    console.print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def print_error(message: str) -> None:
+    """Print error message to stderr."""
+    err_console.print(f"[red]Error:[/red] {message}")
+
+
+def print_success(message: str) -> None:
+    """Print success message."""
+    console.print(f"[green]✓[/green] {message}")
+
+
+def print_info(message: str) -> None:
+    """Print info message."""
+    console.print(f"[blue]ℹ[/blue] {message}")
+
+
+def format_prob(value: float) -> str:
+    """Format probability as percentage string."""
+    return f"{value * 100:.1f}%"
+
+
+def write_output(content: str, output: str | None = None) -> None:
+    """Write content to file or stdout."""
+    if output:
+        with open(output, "w") as f:
+            f.write(content)
+        print_success(f"Output written to {output}")
+    else:
+        sys.stdout.write(content)
+        if not content.endswith("\n"):
+            sys.stdout.write("\n")

--- a/qpandalite/cli/result.py
+++ b/qpandalite/cli/result.py
@@ -1,0 +1,92 @@
+"""Result query subcommand."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+
+from .output import format_prob, print_error, print_json, print_table
+
+app = typer.Typer(help="Query task results from quantum cloud platforms")
+
+
+@app.callback(invoke_without_command=True)
+def result(
+    task_id: str = typer.Argument(..., help="Task ID to query"),
+    platform: Optional[str] = typer.Option(None, "--platform", "-p", help="Platform: originq/quafu/ibm"),
+    wait: bool = typer.Option(False, "--wait", "-w", help="Wait for task completion"),
+    timeout: float = typer.Option(300.0, "--timeout", help="Timeout in seconds"),
+    format: str = typer.Option("table", "--format", "-f", help="Output format: table/json"),
+):
+    """Query result of a submitted task."""
+    show_result(task_id, platform=platform, wait=wait, timeout=timeout, format=format)
+
+
+def show_result(
+    task_id: str,
+    platform: str | None = None,
+    wait: bool = False,
+    timeout: float = 300.0,
+    format: str = "table",
+) -> None:
+    """Show task result."""
+    try:
+        if wait:
+            result_data = _wait_for_result(task_id, platform, timeout)
+        else:
+            result_data = _query_result(task_id, platform)
+    except Exception as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+    if result_data is None:
+        print_error(f"No result available for task {task_id}")
+        raise typer.Exit(1)
+
+    if format == "json":
+        print_json(result_data)
+    else:
+        _print_result_table(task_id, result_data)
+
+
+def _query_result(task_id: str, platform: str | None) -> dict | None:
+    """Query task result."""
+    if platform == "originq":
+        from qpandalite.task.origin_qcloud import task as oq_task
+
+        return oq_task.query_by_taskid(task_id)
+    elif platform == "quafu":
+        from qpandalite.task.quafu import task as quafu_task
+
+        return quafu_task.query_by_taskid(task_id)
+    elif platform == "ibm":
+        from qpandalite.task.ibm import task as ibm_task
+
+        return ibm_task.query_by_taskid(task_id)
+    else:
+        from qpandalite.task_manager import query_task
+
+        task_info = query_task(task_id, backend=platform)
+        if task_info and task_info.result:
+            return task_info.result
+        return None
+
+
+def _wait_for_result(task_id: str, platform: str | None, timeout: float) -> dict | None:
+    """Wait for task result."""
+    from qpandalite.task_manager import wait_for_result
+
+    return wait_for_result(task_id, backend=platform, timeout=timeout)
+
+
+def _print_result_table(task_id: str, result_data: dict) -> None:
+    """Print result as a table."""
+    print_table(
+        f"Result for {task_id}",
+        ["State", "Count", "Probability"],
+        [
+            [state, str(count), format_prob(count / sum(result_data.values()))]
+            for state, count in sorted(result_data.items(), key=lambda x: x[1], reverse=True)
+        ],
+    )

--- a/qpandalite/cli/result.py
+++ b/qpandalite/cli/result.py
@@ -82,11 +82,20 @@ def _wait_for_result(task_id: str, platform: str | None, timeout: float) -> dict
 
 def _print_result_table(task_id: str, result_data: dict) -> None:
     """Print result as a table."""
-    print_table(
-        f"Result for {task_id}",
-        ["State", "Count", "Probability"],
-        [
-            [state, str(count), format_prob(count / sum(result_data.values()))]
-            for state, count in sorted(result_data.items(), key=lambda x: x[1], reverse=True)
-        ],
-    )
+    total = sum(result_data.values())
+    if total == 0:
+        # Handle empty result case to avoid division by zero
+        print_table(
+            f"Result for {task_id}",
+            ["State", "Count", "Probability"],
+            [[state, str(count), "0.0%"] for state, count in sorted(result_data.items())],
+        )
+    else:
+        print_table(
+            f"Result for {task_id}",
+            ["State", "Count", "Probability"],
+            [
+                [state, str(count), format_prob(count / total)]
+                for state, count in sorted(result_data.items(), key=lambda x: x[1], reverse=True)
+            ],
+        )

--- a/qpandalite/cli/simulate.py
+++ b/qpandalite/cli/simulate.py
@@ -1,0 +1,79 @@
+"""Local simulation subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .output import console, format_prob, print_error, print_json, print_table, write_output
+
+app = typer.Typer(help="Local circuit simulation")
+
+
+@app.callback(invoke_without_command=True)
+def simulate(
+    input_file: Path = typer.Argument(..., help="Circuit file (OriginIR or QASM)", exists=True),
+    backend: str = typer.Option("statevector", "--backend", "-b", help="Backend type: statevector/density"),
+    shots: int = typer.Option(1024, "--shots", "-s", help="Number of measurement shots"),
+    format: str = typer.Option("table", "--format", "-f", help="Output format: table/json"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file"),
+):
+    """Simulate a quantum circuit locally."""
+    content = input_file.read_text(encoding="utf-8")
+
+    if backend not in ("statevector", "density"):
+        print_error(f"Unknown backend: {backend}. Use 'statevector' or 'density'.")
+        raise typer.Exit(1)
+
+    try:
+        result = _run_simulation(content, backend, shots)
+    except Exception as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+    if format == "json":
+        data = {"backend": backend, "shots": shots, "results": result}
+        write_output(
+            __import__("json").dumps(data, indent=2, ensure_ascii=False),
+            str(output) if output else None,
+        )
+    else:
+        _print_results_table(result, shots)
+        if output:
+            import json
+
+            data = {"backend": backend, "shots": shots, "results": result}
+            output.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+            console.print(f"\n[dim]Results saved to {output}[/dim]")
+
+
+def _run_simulation(content: str, backend: str, shots: int) -> dict[str, float]:
+    """Run simulation and return measurement results."""
+    from qpandalite.simulator import OriginIR_Simulator
+
+    sim = OriginIR_Simulator(backend_type=backend)
+    if backend == "statevector":
+        probs = sim.simulate_pmeasure(content)
+        results = {state: prob for state, prob in probs.items() if prob > 1e-10}
+    else:
+        counts = sim.simulate_shots(content, shots=shots)
+        total = sum(counts.values())
+        results = {state: count / total for state, count in counts.items()}
+    return results
+
+
+def _print_results_table(results: dict[str, float], shots: int) -> None:
+    """Print simulation results as a table."""
+    sorted_results = sorted(results.items(), key=lambda x: x[1], reverse=True)
+    rows = []
+    for state, prob in sorted_results:
+        count = int(prob * shots)
+        rows.append([state, str(count), format_prob(prob)])
+
+    print_table(
+        "Simulation Results",
+        ["State", "Count", "Probability"],
+        rows,
+    )

--- a/qpandalite/cli/submit.py
+++ b/qpandalite/cli/submit.py
@@ -1,0 +1,115 @@
+"""Cloud task submission subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .output import console, print_error, print_json, print_success, print_table
+
+app = typer.Typer(help="Submit circuits to quantum cloud platforms")
+
+
+@app.callback(invoke_without_command=True)
+def submit(
+    input_files: list[Path] = typer.Argument(..., help="Circuit file(s) to submit", exists=True),
+    platform: str = typer.Option(..., "--platform", "-p", help="Platform: originq/quafu/ibm/dummy"),
+    chip_id: Optional[str] = typer.Option(None, "--chip-id", help="Chip ID for the target platform"),
+    shots: int = typer.Option(1000, "--shots", "-s", help="Number of measurement shots"),
+    name: Optional[str] = typer.Option(None, "--name", help="Task name"),
+    wait: bool = typer.Option(False, "--wait", "-w", help="Wait for result after submission"),
+    timeout: float = typer.Option(300.0, "--timeout", help="Timeout in seconds when waiting"),
+    format: str = typer.Option("table", "--format", "-f", help="Output format: table/json"),
+):
+    """Submit circuit(s) to a quantum cloud platform."""
+    if platform not in ("originq", "quafu", "ibm", "dummy"):
+        print_error(f"Unknown platform: {platform}. Use originq/quafu/ibm/dummy.")
+        raise typer.Exit(1)
+
+    circuits = []
+    for path in input_files:
+        circuits.append(path.read_text(encoding="utf-8"))
+
+    try:
+        if len(circuits) == 1:
+            task_id = _submit_single(circuits[0], platform, chip_id, shots, name)
+            if format == "json":
+                print_json({"task_id": task_id, "platform": platform, "shots": shots})
+            else:
+                print_success(f"Task submitted: {task_id}")
+        else:
+            task_ids = _submit_batch(circuits, platform, chip_id, shots, name)
+            if format == "json":
+                print_json({"task_ids": task_ids, "platform": platform, "shots": shots})
+            else:
+                print_table(
+                    "Submitted Tasks",
+                    ["#", "Task ID"],
+                    [[str(i + 1), tid] for i, tid in enumerate(task_ids)],
+                )
+    except Exception as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+
+    if wait and len(circuits) == 1:
+        _wait_and_show(task_id, platform, timeout, format)
+
+
+def _submit_single(circuit: str, platform: str, chip_id: str | None, shots: int, name: str | None) -> str:
+    """Submit a single circuit."""
+    if platform == "dummy":
+        from qpandalite.task.originq_dummy import task as dummy_task
+
+        return dummy_task.submit_task(circuit, shots=shots)
+    elif platform == "originq":
+        from qpandalite.task.origin_qcloud import task as oq_task
+
+        kwargs = {"shots": shots}
+        if chip_id:
+            kwargs["chip_id"] = int(chip_id)
+        if name:
+            kwargs["task_name"] = name
+        return oq_task.submit_task(circuit, **kwargs)
+    elif platform == "quafu":
+        from qpandalite.task.quafu import task as quafu_task
+
+        kwargs = {"shots": shots}
+        if chip_id:
+            kwargs["chip_id"] = chip_id
+        return quafu_task.submit_task(circuit, **kwargs)
+    elif platform == "ibm":
+        from qpandalite.task.ibm import task as ibm_task
+
+        kwargs = {"shots": shots}
+        if chip_id:
+            kwargs["chip_id"] = chip_id
+        return ibm_task.submit_task(circuit, **kwargs)
+    raise ValueError(f"Unsupported platform: {platform}")
+
+
+def _submit_batch(circuits: list[str], platform: str, chip_id: str | None, shots: int, name: str | None) -> list[str]:
+    """Submit multiple circuits."""
+    if platform == "dummy":
+        from qpandalite.task.originq_dummy import task as dummy_task
+
+        return [dummy_task.submit_task(c, shots=shots) for c in circuits]
+    elif platform == "originq":
+        from qpandalite.task.origin_qcloud import task as oq_task
+
+        result = oq_task.submit_task(circuits, shots=shots, **({"chip_id": int(chip_id)} if chip_id else {}))
+        return result if isinstance(result, list) else [result]
+    elif platform == "quafu":
+        from qpandalite.task.quafu import task as quafu_task
+
+        result = quafu_task.submit_task(circuits, shots=shots, **({"chip_id": chip_id} if chip_id else {}))
+        return result if isinstance(result, list) else [result]
+    raise ValueError(f"Batch submission not supported for platform: {platform}")
+
+
+def _wait_and_show(task_id: str, platform: str, timeout: float, format: str) -> None:
+    """Wait for task result and display it."""
+    from .result import show_result
+
+    show_result(task_id, platform=platform, wait=True, timeout=timeout, format=format)

--- a/qpandalite/cli/submit.py
+++ b/qpandalite/cli/submit.py
@@ -91,6 +91,12 @@ def _submit_single(circuit: str, platform: str, chip_id: str | None, shots: int,
 
 def _submit_batch(circuits: list[str], platform: str, chip_id: str | None, shots: int, name: str | None) -> list[str]:
     """Submit multiple circuits."""
+    # Note: name parameter is reserved for future use in batch submission
+    # Currently, most platforms don't support task names for batch submissions
+    if name:
+        from .output import print_warning
+        print_warning("Task name is not supported for batch submissions yet. Ignoring --name option.")
+
     if platform == "dummy":
         from qpandalite.task.originq_dummy import task as dummy_task
 
@@ -98,12 +104,18 @@ def _submit_batch(circuits: list[str], platform: str, chip_id: str | None, shots
     elif platform == "originq":
         from qpandalite.task.origin_qcloud import task as oq_task
 
-        result = oq_task.submit_task(circuits, shots=shots, **({"chip_id": int(chip_id)} if chip_id else {}))
+        kwargs = {"shots": shots}
+        if chip_id:
+            kwargs["chip_id"] = int(chip_id)
+        result = oq_task.submit_task(circuits, **kwargs)
         return result if isinstance(result, list) else [result]
     elif platform == "quafu":
         from qpandalite.task.quafu import task as quafu_task
 
-        result = quafu_task.submit_task(circuits, shots=shots, **({"chip_id": chip_id} if chip_id else {}))
+        kwargs = {"shots": shots}
+        if chip_id:
+            kwargs["chip_id"] = chip_id
+        result = quafu_task.submit_task(circuits, **kwargs)
         return result if isinstance(result, list) else [result]
     raise ValueError(f"Batch submission not supported for platform: {platform}")
 

--- a/qpandalite/cli/task.py
+++ b/qpandalite/cli/task.py
@@ -1,0 +1,124 @@
+"""Task management subcommand."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+
+from .output import console, format_prob, print_error, print_json, print_success, print_table
+
+app = typer.Typer(help="Manage submitted tasks")
+
+
+@app.command("list")
+def list_tasks(
+    status: Optional[str] = typer.Option(None, "--status", help="Filter by status: pending/running/success/failed"),
+    platform: Optional[str] = typer.Option(None, "--platform", "-p", help="Filter by platform"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Maximum number of tasks to show"),
+    format: str = typer.Option("table", "--format", "-f", help="Output format: table/json"),
+):
+    """List submitted tasks."""
+    from qpandalite.task_manager import list_tasks as _list_tasks
+
+    tasks = _list_tasks(status=status, backend=platform)
+
+    if not tasks:
+        print_info("No tasks found")
+        return
+
+    tasks = tasks[:limit]
+
+    if format == "json":
+        print_json([task_to_dict(t) for t in tasks])
+    else:
+        rows = []
+        for task in tasks:
+            rows.append(
+                [
+                    task.task_id,
+                    task.backend,
+                    task.status,
+                    str(task.shots),
+                    task.submit_time[:19] if task.submit_time else "N/A",
+                ]
+            )
+        print_table("Tasks", ["Task ID", "Platform", "Status", "Shots", "Submit Time"], rows)
+
+
+@app.command()
+def show(
+    task_id: str = typer.Argument(..., help="Task ID to show"),
+    format: str = typer.Option("table", "--format", "-f", help="Output format: table/json"),
+):
+    """Show details of a specific task."""
+    from qpandalite.task_manager import get_task, query_task
+
+    task_info = get_task(task_id)
+
+    if not task_info:
+        task_info = query_task(task_id)
+
+    if not task_info:
+        print_error(f"Task {task_id} not found")
+        raise typer.Exit(1)
+
+    if format == "json":
+        print_json(task_to_dict(task_info))
+    else:
+        print_table(
+            f"Task {task_id}",
+            ["Property", "Value"],
+            [
+                ["Task ID", task_info.task_id],
+                ["Backend", task_info.backend],
+                ["Status", task_info.status],
+                ["Shots", str(task_info.shots)],
+                ["Submit Time", task_info.submit_time or "N/A"],
+                ["Update Time", task_info.update_time or "N/A"],
+            ],
+        )
+
+        if task_info.result:
+            console.print("\n[bold]Results:[/bold]")
+            total = sum(task_info.result.values())
+            rows = [
+                [state, str(count), format_prob(count / total)]
+                for state, count in sorted(task_info.result.items(), key=lambda x: x[1], reverse=True)
+            ]
+            print_table("Measurement Results", ["State", "Count", "Probability"], rows)
+
+
+@app.command()
+def clear(
+    status: Optional[str] = typer.Option(None, "--status", help="Clear tasks with this status"),
+    force: bool = typer.Option(False, "--force", help="Force clear without confirmation"),
+):
+    """Clear completed or failed tasks from cache."""
+    from qpandalite.task_manager import clear_completed_tasks, clear_cache
+
+    if status:
+        count = clear_completed_tasks()
+    else:
+        if not force:
+            confirm = typer.confirm("Clear all cached tasks?")
+            if not confirm:
+                print_info("Cancelled")
+                return
+        count = clear_cache()
+
+    print_success(f"Cleared {count} tasks from cache")
+
+
+def task_to_dict(task_info) -> dict:
+    """Convert TaskInfo to dictionary."""
+    return {
+        "task_id": task_info.task_id,
+        "backend": task_info.backend,
+        "status": task_info.status,
+        "shots": task_info.shots,
+        "submit_time": task_info.submit_time,
+        "update_time": task_info.update_time,
+        "result": task_info.result,
+        "metadata": task_info.metadata,
+    }


### PR DESCRIPTION
## Summary

Add a comprehensive CLI for QPanda-lite covering the core workflow:
- Circuit format conversion
- Local simulation
- Cloud task submission
- Result query
- Configuration management
- Task management

## Commands

### `qpandalite circuit`
```bash
qpandalite circuit input.ir --format qasm --output circuit.qasm
qpandalite circuit input.ir --info
```

### `qpandalite simulate`
```bash
qpandalite simulate circuit.ir --backend statevector --shots 1024
qpandalite simulate circuit.ir --format json --output result.json
```

### `qpandalite submit`
```bash
qpandalite submit circuit.ir --platform originq --chip-id 72 --shots 1000
qpandalite submit circuit.ir --platform dummy --wait
```

### `qpandalite result`
```bash
qpandalite result TASK_ID --platform originq
qpandalite result TASK_ID --wait --timeout 300
```

### `qpandalite config`
```bash
qpandalite config init
qpandalite config set originq.token YOUR_TOKEN
qpandalite config list
qpandalite config validate
```

### `qpandalite task`
```bash
qpandalite task list
qpandalite task show TASK_ID
qpandalite task clear --status completed
```

## Dependencies

- `typer>=0.9.0` - CLI framework
- `rich>=13.0.0` - Table output

## Test plan

- [x] `python -m qpandalite --help` shows all commands
- [x] `qpandalite config init` creates config file
- [x] `qpandalite config set/list` works correctly
- [ ] `qpandalite circuit` format conversion (requires C++ extension)
- [ ] `qpandalite simulate` (requires C++ extension)
- [ ] End-to-end test with dummy backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)