### PR TITLE
docs: 按模块划分算法示例目录

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,17 @@ QPanda-lite 是一个 Python 原生、轻量且强调透明性的量子计算框
 
 **算法示例**
 
-:doc:`Grover 搜索 <source/algorithm/search/grover>` | :doc:`VQE <source/algorithm/variational/vqe>` | :doc:`QAOA <source/algorithm/variational/qaoa>` | :doc:`QPE <source/algorithm/phase/qpe>` | :doc:`影子层析 <source/algorithm/measurement/shadow_tomography>`
+**变分算法** :doc:`VQE <source/algorithm/variational/vqe>` | :doc:`QAOA <source/algorithm/variational/qaoa>` | :doc:`VQD <source/algorithm/variational/vqd>`
+
+**搜索算法** :doc:`Grover 搜索 <source/algorithm/search/grover>` | :doc:`Grover Oracle <source/algorithm/search/grover_oracle>`
+
+**相位估计** :doc:`QPE <source/algorithm/phase/qpe>` | :doc:`QFT <source/algorithm/phase/qft>`
+
+**Oracle 算法** :doc:`振幅估计 <source/algorithm/oracle/amplitude_estimation>` | :doc:`Deutsch-Jozsa <source/algorithm/oracle/deutsch-jozsa>`
+
+**态制备** :doc:`纠缠态 <source/algorithm/state/entangled_states>` | :doc:`Dicke 态 <source/algorithm/state/dicke_state>` | :doc:`热态 <source/algorithm/state/thermal_state>`
+
+**测量** :doc:`影子层析 <source/algorithm/measurement/shadow_tomography>` | :doc:`态层析 <source/algorithm/measurement/state_tomography>`
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Summary

- 将首页"算法示例"快速入口按模块分类展示，与 `docs/source/algorithm/` 目录结构对应
- 新增 6 个分类：变分算法、搜索算法、相位估计、Oracle 算法、态制备、测量
- 补充了原有遗漏的算法文档链接（VQD、Grover Oracle、QFT、振幅估计、Deutsch-Jozsa、纠缠态、Dicke 态、热态、态层析）

## Test plan

- [x] `cd docs && make html` 构建成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)