### PR TITLE
docs: optimize homepage and README with workflow examples and CLI links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,39 +8,56 @@
 
 **QPanda**: **Q**uantum **P**rogramming **A**rchitecture for **N**ISQ **D**evice **A**pplication
 
-QPanda-lite is a simple, easy-to-use, and transparent Python-native version of QPanda.
+QPanda-lite is a simple, easy-to-use, and transparent Python-native quantum computing framework.
 
 ---
 
-## Table of Contents
+## 核心工作流
 
-- [Quick Example](#quick-example)
-- [Features](#features)
-- [Installation](#installation)
-- [Project Structure](#project-structure)
-- [Quick Start](#quick-start)
-- [Documentation](#documentation)
+QPanda-lite 围绕一个简洁的工作流设计：**任意方式构建线路 → CLI 统一执行**。
 
----
+### 1. 安装
 
-## Quick Example
+```bash
+pip install qpandalite
+```
+
+### 2. 构建线路（支持 QPanda-lite 原生或任意第三方工具）
 
 ```python
 from qpandalite.circuit_builder import Circuit
-from qpandalite.simulator import OriginIR_Simulator
 
-# Build a Bell state circuit
-circuit = Circuit()
-circuit.h(0)           # Hadamard on qubit 0
-circuit.cnot(0, 1)     # CNOT from qubit 0 to qubit 1
-circuit.measure(0, 1)   # Measure both qubits
+c = Circuit()
+c.h(0)
+c.cnot(0, 1)
+c.measure(0, 1)
 
-# Simulate with 1000 shots
-sim = OriginIR_Simulator()
-result = sim.simulate_shots(circuit.originir, shots=1000)
-print(result)
-# Possible output: {0: 497, 3: 503}
+# 输出 OriginIR 格式，可供 CLI 使用
+open('circuit.ir', 'w').write(c.originir)
 ```
+
+> 你也可以使用 Qiskit、Cirq 等工具构建线路，只需最终输出 OriginIR 或 OpenQASM 2.0 格式。
+
+### 3. CLI 统一执行
+
+```bash
+# 本地模拟
+qpandalite simulate circuit.ir --shots 1000
+
+# 提交到云端
+qpandalite submit circuit.ir --platform originq --shots 1000
+
+# 查询任务结果
+qpandalite result <task_id>
+```
+
+---
+
+## 设计理念
+
+| 线路构建 | 原生 API 或任意工具，输出 OriginIR / QASM2 |
+| CLI 执行 | 统一接口：模拟、云端、任务管理 |
+| 结果分析 | 原生 Python 结构，易于集成 |
 
 ---
 
@@ -120,85 +137,27 @@ pip install .
 
 ---
 
-## Project Structure
+## CLI Quick Reference
 
-```
-QPanda-lite/
-├── qpandalite/
-│   ├── circuit_builder/          # Circuit class and gate definitions
-│   ├── simulator/                # Local simulators (OriginIR, QASM, etc.)
-│   ├── originir/                 # OriginIR parser
-│   ├── qasm/                    # OpenQASM 2.0 parser
-│   ├── task/                    # Cloud task submission (OriginQ / Quafu / IBM)
-│   ├── transpiler/              # Circuit conversion (Qiskit ↔ OriginIR)
-│   └── analyzer/                # Result analysis (expectation values, etc.)
-├── QPandaLiteCpp/               # C++ backend (pybind11)
-├── docs/                        # Sphinx documentation
-└── test/                       # Unit tests
-```
+```bash
+# 查看帮助
+qpandalite --help
 
----
+# 本地模拟
+qpandalite simulate circuit.ir --shots 1000
 
-## Quick Start
+# 提交到云端（支持 originq / quafu / ibm / dummy）
+qpandalite submit circuit.ir --platform originq --shots 1000
 
-### 1. Build a Circuit
+# 查询任务结果
+qpandalite result <task_id>
 
-```python
-from qpandalite.circuit_builder import Circuit
+# 配置云平台 Token
+qpandalite config init
+qpandalite config set originq.token YOUR_TOKEN
 
-c = Circuit()
-c.rx(1, 0.1)         # RX rotation on qubit 1
-c.cnot(1, 0)         # CNOT with control=1, target=0
-c.measure(0, 1)      # Measure qubits 0 and 1
-
-
-print(c.circuit)
-# QINIT 2
-# CREG 2
-# RX q[1], (0.1)
-# CNOT q[1], q[0]
-# MEASURE q[0], c[0]
-# MEASURE q[1], c[1]
-```
-
-> 注意：`measure` 只记录被测量的 qubit，电路中实际使用的 qubit 由门操作决定。
-
-### 2. Circuit Simulation
-
-```python
-import qpandalite.simulator as qsim
-
-sim = qsim.OriginIR_Simulator(reverse_key=False)
-
-originir = '''
-QINIT 72
-CREG 3
-RY q[45],(0.9424777960769379)
-RY q[46],(0.9424777960769379)
-CZ q[45],q[46]
-RY q[45],(-0.25521154)
-RY q[46],(0.26327053)
-X q[46]
-MEASURE q[45],c[0]
-MEASURE q[46],c[2]
-MEASURE q[52],c[1]
-'''
-
-res = sim.simulate_statevector(originir)
-print(res)
-print(sim.state)
-```
-
-### 3. Submit to Cloud Hardware
-
-```python
-from qpandalite import submit_task, wait_for_result
-
-# Configure via environment variables:
-# export QUAFU_API_TOKEN="your-token"
-
-task_id = submit_task(circuit, backend='quafu', shots=1000, chip_id='ScQ-P10')
-result = wait_for_result(task_id, backend='quafu')
+# 也可以用 python -m 调用
+python -m qpandalite simulate circuit.ir
 ```
 
 ---

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,56 @@ QPanda-lite 是一个 Python 原生、轻量且强调透明性的量子计算框
 .. |Build| image:: https://github.com/Agony5757/QPanda-lite/actions/workflows/build_and_test.yml/badge.svg?branch=main
     :target: https://github.com/Agony5757/QPanda-lite/actions/workflows/build_and_test.yml
 
+核心工作流
+----------
+
+QPanda-lite 的设计围绕一个简洁的工作流：**任意方式构建线路 → CLI 统一执行**。
+
+.. code-block:: bash
+   :caption: 1. 安装
+
+   pip install qpandalite
+
+.. code-block:: python
+   :caption: 2. 构建线路（支持 QPanda-lite 原生或任意第三方工具）
+
+   from qpandalite.circuit_builder import Circuit
+
+   c = Circuit()
+   c.h(0)
+   c.cnot(0, 1)
+   c.measure(0, 1)
+
+   # 输出 OriginIR 格式，可供 CLI 使用
+   open('circuit.ir', 'w').write(c.originir)
+
+.. code-block:: bash
+   :caption: 3. CLI 统一执行
+
+   # 本地模拟
+   qpandalite simulate circuit.ir --shots 1000
+
+   # 提交到云端
+   qpandalite submit circuit.ir --platform originq --shots 1000
+
+   # 查询任务结果
+   qpandalite result <task_id>
+
+设计理念
+--------
+
+**线路构建，工具自由**
+
+QPanda-lite 提供原生的 Circuit API，但你也可以使用 Qiskit、Cirq 等任何工具构建线路。最终只需输出 OriginIR 或 OpenQASM 2.0 格式即可。
+
+**CLI 执行，接口统一**
+
+无论是本地模拟还是云端真机，CLI 提供一致的命令接口：``simulate``、``submit``、``result``、``config``。
+
+**结果数据，原生结构**
+
+测量结果以 Python 原生 ``dict`` / ``list`` / ``ndarray`` 返回，无需额外解析，便于集成到数据分析流程。
+
 快速入口
 --------
 
@@ -32,7 +82,7 @@ QPanda-lite 是一个 Python 原生、轻量且强调透明性的量子计算框
 
 **命令行工具**
 
-:doc:`CLI 概览 <source/cli/index>` | :doc:`电路转换 <source/cli/index#电路格式转换-qpandalite-circuit>` | :doc:`本地模拟 <source/cli/index#本地模拟-qpandalite-simulate>` | :doc:`云端任务 <source/cli/index#云端任务提交-qpandalite-submit>` | :doc:`配置管理 <source/cli/index#配置管理-qpandalite-config>`
+:doc:`CLI 安装 <source/cli/installation>` | :doc:`本地模拟 <source/cli/simulate>` | :doc:`云端提交 <source/cli/submit>` | :doc:`结果查询 <source/cli/result>` | :doc:`配置管理 <source/cli/config>`
 
 **算法示例**
 


### PR DESCRIPTION
## Summary

- Fix broken CLI links in documentation homepage (`docs/index.rst`)
- Add core workflow examples (install → build circuit → CLI execute) to both homepage and README
- Add design philosophy section establishing the user mental model: circuit building with any tool, CLI for unified execution
- Add CLI Quick Reference section in README with common commands

## Changes

| File | Change |
|------|--------|
| `docs/index.rst` | Fixed CLI links, added workflow code blocks and design philosophy |
| `README.md` | Added workflow examples, design philosophy table, CLI quick reference; removed redundant sections |

## Test plan

- [x] Verify RST syntax in `docs/index.rst` is correct
- [ ] Build docs locally and verify links work
- [ ] Review README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)